### PR TITLE
feat: CI pipelines and quality gates

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -1,0 +1,18 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: [self-hosted, gpu]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: uv sync --locked --all-groups
+
+      - name: Integration tests
+        run: uv run pytest -m integration --tb=short

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -15,4 +15,4 @@ jobs:
         run: uv sync --locked --all-groups
 
       - name: Integration tests
-        run: uv run pytest -m integration --tb=short
+        run: uv run pytest -m integration --tb=short || [ $? -eq 5 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --locked --all-groups
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Format check
+        run: uv run ruff format --check .
+
+      - name: Type check
+        run: uv run mypy src/
+
+      - name: Unit tests
+        run: uv run pytest -m 'not integration' --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: uv run ruff format --check .
 
       - name: Type check
-        run: uv run mypy src/
+        run: uv run mypy src/ds01_jobs/
 
       - name: Unit tests
         run: uv run pytest -m 'not integration' --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,17 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+exclude = [
+    "src/auth.py",
+    "src/database.py",
+    "src/limiter.py",
+    "src/main.py",
+    "src/models.py",
+    "src/rate_limit.py",
+    "src/scanner.py",
+    "src/routers/",
+    "src/__init__.py",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP"]


### PR DESCRIPTION
## Summary

- **Tier 1 CI** (`ci.yml`): ruff check, ruff format, mypy, unit tests — runs on PRs to main
- **Tier 2 CI** (`ci-integration.yml`): integration tests on `[self-hosted, gpu]` — runs on push to main + workflow_dispatch
- Ruff exclude for brownfield `src/` files, mypy scoped to `src/ds01_jobs/`
- Handles pytest exit code 5 (no tests collected) in integration workflow

## Verify

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ds01_jobs/ && uv run pytest -m 'not integration' --tb=short
```

## Stack

**3/3** — depends on #2 (`feature/settings-tests`).