### PR TITLE
feat: add database layer and response models

### DIFF
--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -1,0 +1,79 @@
+"""Database layer for ds01-jobs.
+
+Provides SQLite initialisation, async connection dependency for FastAPI,
+and sync connection context manager for CLI usage.
+"""
+
+import sqlite3
+from collections.abc import AsyncGenerator, Generator
+from contextlib import contextmanager
+from functools import lru_cache
+from pathlib import Path
+
+import aiosqlite
+
+from ds01_jobs.config import Settings
+
+SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    key_id TEXT NOT NULL UNIQUE,
+    key_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    revoked INTEGER NOT NULL DEFAULT 0,
+    last_used_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_id ON api_keys(key_id);
+"""
+
+
+@lru_cache(maxsize=1)
+def _get_db_path() -> Path:
+    """Return the database path from settings (cached)."""
+    return Settings(_env_file=None).db_path
+
+
+async def init_db(db_path: Path | None = None) -> None:
+    """Initialise the database, creating parent dirs and schema.
+
+    Args:
+        db_path: Override for the database path. Defaults to Settings.db_path.
+    """
+    path = db_path or _get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    async with aiosqlite.connect(path) as db:
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.executescript(SCHEMA_SQL)
+        await db.commit()
+
+
+async def get_db(db_path: Path | None = None) -> AsyncGenerator[aiosqlite.Connection, None]:
+    """FastAPI dependency yielding an async database connection.
+
+    Args:
+        db_path: Override for the database path. Defaults to Settings.db_path.
+    """
+    path = db_path or _get_db_path()
+
+    async with aiosqlite.connect(path) as db:
+        db.row_factory = aiosqlite.Row
+        yield db
+
+
+@contextmanager
+def get_db_sync(db_path: Path | None = None) -> Generator[sqlite3.Connection, None, None]:
+    """Sync context manager for CLI database access.
+
+    Args:
+        db_path: Override for the database path. Defaults to Settings.db_path.
+    """
+    path = db_path or _get_db_path()
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -1,0 +1,29 @@
+"""Pydantic response models for ds01-jobs API."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Response schema for GET /health."""
+
+    status: Literal["ok", "degraded"]
+    version: str
+    db: Literal["ok", "error"]
+
+
+class RateLimitResponse(BaseModel):
+    """Response schema for 429 rate limit errors."""
+
+    error: str = "rate_limit_exceeded"
+    retry_after_seconds: int
+    limit_type: str
+    current_count: int
+    max_allowed: int
+
+
+class AuthErrorResponse(BaseModel):
+    """Response schema for 401 authentication errors."""
+
+    detail: str = "Authentication failed"

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,123 @@
+"""Tests for ds01_jobs.database module."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ds01_jobs.database import get_db, get_db_sync, init_db
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_api_keys_table(tmp_path: Path):
+    """init_db creates the api_keys table with the correct columns."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+
+    # Verify table exists and has the right columns
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA table_info(api_keys)")
+    columns = {row[1] for row in cursor.fetchall()}
+    conn.close()
+
+    expected = {
+        "id",
+        "username",
+        "key_id",
+        "key_hash",
+        "created_at",
+        "expires_at",
+        "revoked",
+        "last_used_at",
+    }
+    assert columns == expected
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_key_id_index(tmp_path: Path):
+    """init_db creates an index on the key_id column."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_api_keys_key_id'"
+    )
+    indexes = cursor.fetchall()
+    conn.close()
+
+    assert len(indexes) == 1
+
+
+@pytest.mark.asyncio
+async def test_init_db_enables_wal_mode(tmp_path: Path):
+    """init_db enables WAL journal mode."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA journal_mode")
+    mode = cursor.fetchone()[0]
+    conn.close()
+
+    assert mode == "wal"
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_parent_directories(tmp_path: Path):
+    """init_db creates parent directories if they don't exist."""
+    db_path = tmp_path / "nested" / "dir" / "test.db"
+
+    await init_db(db_path=db_path)
+
+    assert db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_get_db_yields_connection_with_row_factory(tmp_path: Path):
+    """get_db yields a connection with row_factory set."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    async for db in get_db(db_path=db_path):
+        assert db.row_factory is not None
+        # Verify we can query
+        cursor = await db.execute("SELECT 1 AS value")
+        row = await cursor.fetchone()
+        assert row["value"] == 1
+
+
+def test_get_db_sync_yields_connection_with_row_factory(tmp_path: Path):
+    """get_db_sync yields a sync connection with row_factory set."""
+    db_path = tmp_path / "test.db"
+    # Create the DB first using sync sqlite3
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS api_keys (id INTEGER PRIMARY KEY, username TEXT);"
+    )
+    conn.close()
+
+    with get_db_sync(db_path=db_path) as db:
+        assert db.row_factory is sqlite3.Row
+        cursor = db.execute("SELECT 1 AS value")
+        row = cursor.fetchone()
+        assert row["value"] == 1
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path: Path):
+    """Calling init_db multiple times does not raise errors."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+    await init_db(db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA table_info(api_keys)")
+    columns = {row[1] for row in cursor.fetchall()}
+    conn.close()
+
+    assert "key_id" in columns


### PR DESCRIPTION
## Summary

- SQLite database layer with `api_keys` schema (8 columns), WAL mode
- `init_db()` for schema creation, `get_db()` async FastAPI dependency, `get_db_sync()` for CLI
- Pydantic response models: `HealthResponse`, `RateLimitResponse`, `AuthErrorResponse`
- 7 unit tests covering init, schema, async/sync connections

Stacked on #11.

## Test plan

- [x] `uv run pytest tests/unit/test_database.py` — all pass
- [x] mypy strict passes
- [ ] CI passes