### PR TITLE
feat: add database, auth layer, and admin CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ htmlcov/
 .venv/
 venv/
 
+# Runtime data
+data/
+
 # Environment
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # ds01-jobs
+
+Job submission service for the DS01 compute cluster.
+
+## Admin CLI
+
+Manage researcher API keys with `ds01-job-admin`.
+
+### Prerequisites
+
+- **GitHub CLI (`gh`)** - used to verify org membership. Install: https://cli.github.com/
+- Authenticate with `gh auth login` before using key commands.
+- Alternatively, set the `GITHUB_TOKEN` environment variable.
+
+### Commands
+
+```bash
+# Create a key (username = GitHub username, must be an org member)
+uv run ds01-job-admin key-create <github-username>
+
+# List all keys
+uv run ds01-job-admin key-list
+
+# Revoke a key
+uv run ds01-job-admin key-revoke <github-username>
+
+# Rotate a key (revoke + create)
+uv run ds01-job-admin key-rotate <github-username>
+```
+
+The `<github-username>` argument is the researcher's GitHub username, not an
+arbitrary identifier. Org membership is checked against `hertie-data-science-lab`
+via the GitHub API.

--- a/src/ds01_jobs/app.py
+++ b/src/ds01_jobs/app.py
@@ -1,0 +1,60 @@
+"""FastAPI application factory for ds01-jobs.
+
+Wires together the health endpoint, rate limiter, auth dependency,
+and database initialisation into a single application instance.
+"""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+
+from ds01_jobs import __version__
+from ds01_jobs.database import init_db
+from ds01_jobs.health import router as health_router
+from ds01_jobs.middleware import limiter, rate_limit_handler
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Application lifespan: initialise database on startup."""
+    await init_db()
+    yield
+
+
+async def _validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Return structured 422 for validation errors."""
+    return JSONResponse(
+        status_code=422,
+        content={
+            "detail": exc.errors(),
+        },
+    )
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(
+        title="DS01 Job Submission API",
+        version=__version__,
+        docs_url="/docs",
+        lifespan=_lifespan,
+    )
+
+    # Rate limiter
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit_handler)  # type: ignore[arg-type]
+
+    # Validation error handler
+    app.add_exception_handler(RequestValidationError, _validation_error_handler)  # type: ignore[arg-type]
+
+    # Routers
+    app.include_router(health_router)
+
+    return app
+
+
+app = create_app()

--- a/src/ds01_jobs/auth.py
+++ b/src/ds01_jobs/auth.py
@@ -1,0 +1,164 @@
+"""HMAC-SHA256 authentication dependency for FastAPI.
+
+Validates API key format, bcrypt hash, timestamp freshness, nonce
+uniqueness, and HMAC signature. All auth failures return a generic 401.
+"""
+
+import asyncio
+import hashlib
+import hmac
+import logging
+import sqlite3
+import time
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import bcrypt
+from fastapi import Depends, HTTPException, Request, Response
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from ds01_jobs.database import get_db
+
+logger = logging.getLogger(__name__)
+
+HMAC_TOLERANCE_SECONDS = 300
+NONCE_EXPIRY_SECONDS = 300
+KEY_EXPIRY_WARNING_DAYS = 14
+
+security = HTTPBearer()
+
+# In-memory nonce cache: nonce string -> monotonic expiry timestamp
+_used_nonces: dict[str, float] = {}
+
+
+def _cleanup_nonces() -> None:
+    """Remove expired nonces from the cache."""
+    now = time.monotonic()
+    expired = [n for n, exp in _used_nonces.items() if exp <= now]
+    for n in expired:
+        del _used_nonces[n]
+
+
+def _check_and_store_nonce(nonce: str) -> bool:
+    """Check if a nonce is fresh and store it.
+
+    Returns True if the nonce is fresh (not seen before), False if replay.
+    """
+    _cleanup_nonces()
+    if nonce in _used_nonces:
+        return False
+    _used_nonces[nonce] = time.monotonic() + NONCE_EXPIRY_SECONDS
+    return True
+
+
+async def _get_key_record(db: aiosqlite.Connection, key_id: str) -> sqlite3.Row | None:
+    """Look up an active (non-revoked) API key by key_id."""
+    cursor = await db.execute(
+        "SELECT * FROM api_keys WHERE key_id = ? AND revoked = 0",
+        (key_id,),
+    )
+    return await cursor.fetchone()
+
+
+def _build_canonical(method: str, path: str, timestamp: str, nonce: str, body: bytes) -> str:
+    """Build the canonical string for HMAC signing.
+
+    Format: METHOD\\nPATH\\nTIMESTAMP\\nNONCE\\nBODY_SHA256_HEX
+    """
+    body_hash = hashlib.sha256(body).hexdigest()
+    return f"{method}\n{path}\n{timestamp}\n{nonce}\n{body_hash}"
+
+
+def _verify_signature(raw_key: str, canonical: str, provided_signature: str) -> bool:
+    """Verify the HMAC-SHA256 signature using the raw API key."""
+    expected = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, provided_signature)
+
+
+def _auth_failed(request: Request, reason: str, username: str | None = None) -> HTTPException:
+    """Log the specific failure reason and return a generic 401."""
+    ip = request.client.host if request.client else "unknown"
+    user_info = f" for {username}" if username else ""
+    logger.warning("Auth failed%s: %s", user_info, reason, extra={"ip": ip})
+    return HTTPException(status_code=401, detail="Authentication failed")
+
+
+async def get_current_user(
+    request: Request,
+    response: Response,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> dict[str, str]:
+    """FastAPI dependency that authenticates requests via HMAC-SHA256.
+
+    Returns a dict with the authenticated username on success.
+    Raises HTTP 401 on any authentication failure.
+    """
+    raw_key = credentials.credentials
+
+    # 1. Validate prefix
+    if not raw_key.startswith("ds01_"):
+        raise _auth_failed(request, "invalid key prefix")
+
+    # 2. Extract key_id (first 8 chars of base64url portion)
+    key_id = raw_key[5:13]
+
+    # 3. Look up key record
+    row = await _get_key_record(db, key_id)
+    if row is None:
+        raise _auth_failed(request, "key_id not found", username=None)
+
+    username: str = row["username"]
+
+    # 4. Check expiry
+    expires_at = datetime.fromisoformat(row["expires_at"])
+    now = datetime.now(UTC)
+    if now >= expires_at:
+        raise _auth_failed(request, "key expired", username=username)
+
+    # 5. bcrypt verify (run in thread pool to avoid blocking)
+    key_hash: str = row["key_hash"]
+    valid = await asyncio.to_thread(bcrypt.checkpw, raw_key.encode(), key_hash.encode())
+    if not valid:
+        raise _auth_failed(request, "bcrypt mismatch", username=username)
+
+    # 6. Extract signing headers
+    timestamp_str = request.headers.get("X-Timestamp")
+    nonce = request.headers.get("X-Nonce")
+    signature = request.headers.get("X-Signature")
+
+    if not timestamp_str or not nonce or not signature:
+        raise _auth_failed(request, "missing signing headers", username=username)
+
+    # 7. Timestamp freshness
+    try:
+        req_time = float(timestamp_str)
+    except ValueError:
+        raise _auth_failed(request, "invalid timestamp format", username=username) from None
+
+    if abs(time.time() - req_time) > HMAC_TOLERANCE_SECONDS:
+        raise _auth_failed(request, "stale timestamp", username=username)
+
+    # 8. Nonce replay check
+    if not _check_and_store_nonce(nonce):
+        raise _auth_failed(request, "nonce replay", username=username)
+
+    # 9. Build canonical string and verify HMAC signature
+    body = await request.body()
+    canonical = _build_canonical(request.method, request.url.path, timestamp_str, nonce, body)
+    if not _verify_signature(raw_key, canonical, signature):
+        raise _auth_failed(request, "invalid signature", username=username)
+
+    # 10. Update last_used_at
+    now_iso = now.isoformat()
+    await db.execute(
+        "UPDATE api_keys SET last_used_at = ? WHERE key_id = ?",
+        (now_iso, key_id),
+    )
+    await db.commit()
+
+    # 11. Set expiry warning header if within 14 days
+    if expires_at - now <= timedelta(days=KEY_EXPIRY_WARNING_DAYS):
+        response.headers["X-DS01-Key-Expiry-Warning"] = expires_at.date().isoformat()
+
+    return {"username": username}

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -1,0 +1,348 @@
+"""Admin CLI for ds01-jobs API key management.
+
+Provides key-create, key-list, key-revoke, and key-rotate commands
+for managing researcher API keys.
+"""
+
+import base64
+import json
+import re
+import secrets
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from typing import Annotated
+
+import bcrypt
+import httpx
+import typer
+
+from ds01_jobs.config import Settings
+from ds01_jobs.database import SCHEMA_SQL, get_db_sync
+
+app = typer.Typer(
+    name="ds01-job-admin",
+    help="DS01 Job Submission Service - Admin CLI",
+)
+
+
+def _hash_key(raw_key: str) -> str:
+    """Hash an API key with bcrypt (rounds=12)."""
+    return bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt(rounds=12)).decode()
+
+
+def _print_key_result(
+    username: str,
+    raw_key: str,
+    key_id: str,
+    expires_date: str,
+    action: str,
+    json_output: bool,
+) -> None:
+    """Display a key creation/rotation result."""
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "username": username,
+                    "key": raw_key,
+                    "key_id": key_id,
+                    "expires_at": expires_date,
+                },
+                indent=2,
+            )
+        )
+    else:
+        typer.echo(f"API Key {action} successfully")
+        typer.echo("")
+        typer.echo(f"Key:     {raw_key}")
+        typer.echo("")
+        typer.echo(f"User:    {username}")
+        typer.echo(f"Expires: {expires_date}")
+        typer.echo("")
+        typer.echo("Setup instructions (send to researcher):")
+        typer.echo("\u2500" * 41)
+        typer.echo("mkdir -p ~/.config/ds01")
+        typer.echo(f'echo "DS01_API_KEY={raw_key}" > ~/.config/ds01/credentials')
+        typer.echo("\u2500" * 41)
+
+
+def generate_api_key() -> tuple[str, str]:
+    """Generate an API key with ds01_ prefix.
+
+    Returns:
+        Tuple of (raw_key, key_id) where key_id is first 8 chars of the
+        base64url portion.
+    """
+    raw_bytes = secrets.token_bytes(32)
+    encoded = base64.urlsafe_b64encode(raw_bytes).rstrip(b"=").decode()
+    raw_key = f"ds01_{encoded}"
+    key_id = encoded[:8]
+    return raw_key, key_id
+
+
+def parse_duration(duration: str) -> int:
+    """Parse a duration string like '90d' into days.
+
+    Args:
+        duration: Duration string in Nd format (e.g. '90d', '30d', '180d').
+
+    Returns:
+        Number of days.
+
+    Raises:
+        typer.BadParameter: If the format is invalid.
+    """
+    match = re.match(r"^(\d+)d$", duration)
+    if not match:
+        raise typer.BadParameter(f"Invalid duration format: {duration!r}. Use Nd format (e.g. 90d)")
+    return int(match.group(1))
+
+
+def check_org_membership(username: str, org: str) -> bool:
+    """Check GitHub organisation membership.
+
+    Uses authenticated endpoint if GITHUB_TOKEN is set, otherwise falls back
+    to public members endpoint.
+
+    Args:
+        username: GitHub username to check.
+        org: GitHub organisation name.
+
+    Returns:
+        True if user is a member, False otherwise.
+    """
+    import os
+
+    token = os.environ.get("GITHUB_TOKEN")
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+
+    if token:
+        url = f"https://api.github.com/orgs/{org}/members/{username}"
+        headers["Authorization"] = f"Bearer {token}"
+    else:
+        url = f"https://api.github.com/orgs/{org}/public_members/{username}"
+
+    try:
+        response = httpx.get(url, headers=headers, timeout=10.0)
+    except httpx.HTTPError as exc:
+        typer.echo(f"Error checking GitHub org membership: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if response.status_code == 204:
+        return True
+    if response.status_code == 404:
+        return False
+
+    typer.echo(
+        f"Unexpected response from GitHub API: {response.status_code}",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    """Ensure the api_keys table exists."""
+    conn.executescript(SCHEMA_SQL)
+
+
+def _get_active_key(conn: sqlite3.Connection, username: str) -> sqlite3.Row | None:
+    """Look up an active (non-revoked, non-expired) key for a user."""
+    now = datetime.now(UTC).isoformat()
+    cursor = conn.execute(
+        "SELECT * FROM api_keys WHERE username = ? AND revoked = 0 AND expires_at > ?",
+        (username, now),
+    )
+    return cursor.fetchone()  # type: ignore[no-any-return]
+
+
+@app.command("key-create")
+def key_create(
+    username: str,
+    expires: Annotated[
+        str, typer.Option(help="Key validity duration (e.g. 90d, 30d, 180d)")
+    ] = "90d",
+    json_output: Annotated[bool, typer.Option("--json", help="JSON output")] = False,
+) -> None:
+    """Create a new API key for a researcher."""
+    settings = Settings(_env_file=None)
+
+    # Check GitHub org membership
+    if not check_org_membership(username, settings.github_org):
+        typer.echo(f"Error: {username} is not a member of {settings.github_org}", err=True)
+        raise typer.Exit(code=1)
+
+    days = parse_duration(expires)
+
+    with get_db_sync() as conn:
+        _ensure_schema(conn)
+
+        # Check for existing active key
+        if _get_active_key(conn, username):
+            typer.echo(
+                f"Error: User {username} already has an active key. "
+                "Use key-revoke or key-rotate first.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        # Generate and hash key
+        raw_key, key_id = generate_api_key()
+        key_hash = _hash_key(raw_key)
+
+        now = datetime.now(UTC)
+        expires_dt = now + timedelta(days=days)
+
+        conn.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, now.isoformat(), expires_dt.isoformat()),
+        )
+        conn.commit()
+
+    _print_key_result(
+        username, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "created", json_output
+    )
+
+
+@app.command("key-list")
+def key_list(
+    json_output: Annotated[bool, typer.Option("--json", help="JSON output")] = False,
+) -> None:
+    """List all API keys."""
+    with get_db_sync() as conn:
+        _ensure_schema(conn)
+        cursor = conn.execute(
+            "SELECT username, key_id, created_at, expires_at, revoked, last_used_at "
+            "FROM api_keys ORDER BY created_at DESC"
+        )
+        rows = cursor.fetchall()
+
+    now = datetime.now(UTC)
+    keys = []
+    for row in rows:
+        if row["revoked"]:
+            status = "revoked"
+        elif datetime.fromisoformat(row["expires_at"]) <= now:
+            status = "expired"
+        else:
+            status = "active"
+
+        keys.append(
+            {
+                "username": row["username"],
+                "status": status,
+                "created": row["created_at"][:10],
+                "expires": row["expires_at"][:10],
+                "last_used": row["last_used_at"][:10] if row["last_used_at"] else "never",
+            }
+        )
+
+    if json_output:
+        typer.echo(json.dumps(keys, indent=2))
+    else:
+        if not keys:
+            typer.echo("No API keys found.")
+            return
+
+        # Aligned columnar output
+        headers = ["USERNAME", "STATUS", "CREATED", "EXPIRES", "LAST USED"]
+        col_widths = [
+            max(len(headers[0]), *(len(k["username"]) for k in keys)),
+            max(len(headers[1]), *(len(k["status"]) for k in keys)),
+            max(len(headers[2]), *(len(k["created"]) for k in keys)),
+            max(len(headers[3]), *(len(k["expires"]) for k in keys)),
+            max(len(headers[4]), *(len(k["last_used"]) for k in keys)),
+        ]
+
+        header_line = "  ".join(h.ljust(w) for h, w in zip(headers, col_widths, strict=True))
+        typer.echo(header_line)
+
+        for key in keys:
+            vals = [
+                key["username"],
+                key["status"],
+                key["created"],
+                key["expires"],
+                key["last_used"],
+            ]
+            line = "  ".join(v.ljust(w) for v, w in zip(vals, col_widths, strict=True))
+            typer.echo(line)
+
+
+@app.command("key-revoke")
+def key_revoke(
+    username: str,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="JSON output")] = False,
+) -> None:
+    """Revoke an API key for a user."""
+    with get_db_sync() as conn:
+        _ensure_schema(conn)
+
+        cursor = conn.execute(
+            "SELECT * FROM api_keys WHERE username = ? AND revoked = 0",
+            (username,),
+        )
+        row = cursor.fetchone()
+
+        if not row:
+            typer.echo(f"Error: No active key found for {username}", err=True)
+            raise typer.Exit(code=1)
+
+        if not yes:
+            typer.confirm(f"Revoke key for {username}?", abort=True)
+
+        conn.execute(
+            "UPDATE api_keys SET revoked = 1 WHERE username = ?",
+            (username,),
+        )
+        conn.commit()
+
+    if json_output:
+        typer.echo(json.dumps({"username": username, "status": "revoked"}, indent=2))
+    else:
+        typer.echo(f"Key revoked for {username}")
+
+
+@app.command("key-rotate")
+def key_rotate(
+    username: str,
+    expires: Annotated[
+        str, typer.Option(help="Key validity duration (e.g. 90d, 30d, 180d)")
+    ] = "90d",
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="JSON output")] = False,
+) -> None:
+    """Rotate an API key (revoke old, create new)."""
+    days = parse_duration(expires)
+
+    with get_db_sync() as conn:
+        _ensure_schema(conn)
+
+        # Check for existing active key
+        active = _get_active_key(conn, username)
+        if not active:
+            typer.echo(f"Error: No active key found for {username}", err=True)
+            raise typer.Exit(code=1)
+
+        if not yes:
+            typer.confirm(f"Rotate key for {username}?", abort=True)
+
+        # Generate new key
+        raw_key, key_id = generate_api_key()
+        key_hash = _hash_key(raw_key)
+
+        now = datetime.now(UTC)
+        expires_dt = now + timedelta(days=days)
+
+        # Atomic rotation: update the existing row with new key data
+        conn.execute(
+            "UPDATE api_keys SET key_id = ?, key_hash = ?, created_at = ?, "
+            "expires_at = ?, revoked = 0, last_used_at = NULL WHERE username = ?",
+            (key_id, key_hash, now.isoformat(), expires_dt.isoformat(), username),
+        )
+        conn.commit()
+
+    _print_key_result(
+        username, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "rotated", json_output
+    )

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -6,9 +6,11 @@ for managing researcher API keys.
 
 import base64
 import json
+import os
 import re
 import secrets
 import sqlite3
+import subprocess
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
@@ -98,11 +100,33 @@ def parse_duration(duration: str) -> int:
     return int(match.group(1))
 
 
+def _resolve_github_token() -> str | None:
+    """Resolve a GitHub token from GITHUB_TOKEN env var or gh CLI."""
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return None
+
+
 def check_org_membership(username: str, org: str) -> bool:
     """Check GitHub organisation membership.
 
-    Uses authenticated endpoint if GITHUB_TOKEN is set, otherwise falls back
-    to public members endpoint.
+    Resolves a GitHub token from (in order): GITHUB_TOKEN env var, gh CLI.
+    With a token, uses the authenticated members endpoint (sees private
+    memberships). Without a token, falls back to the public members endpoint.
 
     Args:
         username: GitHub username to check.
@@ -111,9 +135,7 @@ def check_org_membership(username: str, org: str) -> bool:
     Returns:
         True if user is a member, False otherwise.
     """
-    import os
-
-    token = os.environ.get("GITHUB_TOKEN")
+    token = _resolve_github_token()
     headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
 
     if token:
@@ -157,13 +179,17 @@ def _get_active_key(conn: sqlite3.Connection, username: str) -> sqlite3.Row | No
 
 @app.command("key-create")
 def key_create(
-    username: str,
+    username: Annotated[str, typer.Argument(help="GitHub username (must be a member of the org)")],
     expires: Annotated[
         str, typer.Option(help="Key validity duration (e.g. 90d, 30d, 180d)")
     ] = "90d",
     json_output: Annotated[bool, typer.Option("--json", help="JSON output")] = False,
 ) -> None:
-    """Create a new API key for a researcher."""
+    """Create a new API key for a researcher.
+
+    USERNAME must be the researcher's GitHub username. Org membership is
+    verified via the GitHub API (requires gh CLI or GITHUB_TOKEN).
+    """
     settings = Settings(_env_file=None)
 
     # Check GitHub org membership

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -319,8 +319,8 @@ def key_revoke(
             typer.confirm(f"Revoke key for {username}?", abort=True)
 
         conn.execute(
-            "UPDATE api_keys SET revoked = 1 WHERE username = ?",
-            (username,),
+            "UPDATE api_keys SET revoked = 1 WHERE id = ?",
+            (row["id"],),
         )
         conn.commit()
 

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -17,7 +17,7 @@ from ds01_jobs.config import Settings
 SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS api_keys (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    username TEXT NOT NULL UNIQUE,
+    username TEXT NOT NULL,
     key_id TEXT NOT NULL UNIQUE,
     key_hash TEXT NOT NULL,
     created_at TEXT NOT NULL,

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -1,0 +1,79 @@
+"""Database layer for ds01-jobs.
+
+Provides SQLite initialisation, async connection dependency for FastAPI,
+and sync connection context manager for CLI usage.
+"""
+
+import sqlite3
+from collections.abc import AsyncGenerator, Generator
+from contextlib import contextmanager
+from functools import lru_cache
+from pathlib import Path
+
+import aiosqlite
+
+from ds01_jobs.config import Settings
+
+SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    key_id TEXT NOT NULL UNIQUE,
+    key_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    revoked INTEGER NOT NULL DEFAULT 0,
+    last_used_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_id ON api_keys(key_id);
+"""
+
+
+@lru_cache(maxsize=1)
+def _get_db_path() -> Path:
+    """Return the database path from settings (cached)."""
+    return Settings(_env_file=None).db_path
+
+
+async def init_db(db_path: Path | None = None) -> None:
+    """Initialise the database, creating parent dirs and schema.
+
+    Args:
+        db_path: Override for the database path. Defaults to Settings.db_path.
+    """
+    path = db_path or _get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    async with aiosqlite.connect(path) as db:
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.executescript(SCHEMA_SQL)
+        await db.commit()
+
+
+async def get_db(db_path: Path | None = None) -> AsyncGenerator[aiosqlite.Connection, None]:
+    """FastAPI dependency yielding an async database connection.
+
+    Args:
+        db_path: Override for the database path. Defaults to Settings.db_path.
+    """
+    path = db_path or _get_db_path()
+
+    async with aiosqlite.connect(path) as db:
+        db.row_factory = aiosqlite.Row
+        yield db
+
+
+@contextmanager
+def get_db_sync(db_path: Path | None = None) -> Generator[sqlite3.Connection, None, None]:
+    """Sync context manager for CLI database access.
+
+    Args:
+        db_path: Override for the database path. Defaults to Settings.db_path.
+    """
+    path = db_path or _get_db_path()
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/src/ds01_jobs/health.py
+++ b/src/ds01_jobs/health.py
@@ -1,0 +1,37 @@
+"""Health check endpoint for ds01-jobs API.
+
+Provides GET /health with database connectivity probe.
+Exempt from rate limiting and authentication.
+"""
+
+import aiosqlite
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from ds01_jobs import __version__
+from ds01_jobs.database import get_db
+from ds01_jobs.middleware import limiter
+from ds01_jobs.models import HealthResponse
+
+router = APIRouter()
+
+
+@router.get("/health", response_model=HealthResponse)
+@limiter.exempt  # type: ignore[untyped-decorator]
+async def health(
+    request: Request,
+    db: aiosqlite.Connection = Depends(get_db),
+) -> HealthResponse | JSONResponse:
+    """Health check with database connectivity probe.
+
+    Returns 200 with status "ok" when DB is reachable,
+    or 503 with status "degraded" when DB is unreachable.
+    """
+    try:
+        await db.execute("SELECT 1")
+        return HealthResponse(status="ok", version=__version__, db="ok")
+    except Exception:
+        return JSONResponse(
+            status_code=503,
+            content=HealthResponse(status="degraded", version=__version__, db="error").model_dump(),
+        )

--- a/src/ds01_jobs/middleware.py
+++ b/src/ds01_jobs/middleware.py
@@ -1,0 +1,41 @@
+"""Rate limiting middleware for ds01-jobs API.
+
+Configures slowapi global rate limiter keyed by API key_id,
+falling back to client IP for unauthenticated requests.
+"""
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+
+from ds01_jobs.models import RateLimitResponse
+
+
+def _get_api_key_identifier(request: Request) -> str:
+    """Extract rate limit key from the request.
+
+    Uses the key_id portion of the Bearer token (chars 12-20 of Authorization
+    header value, i.e. after "Bearer ds01_"). Falls back to client IP.
+    """
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer ds01_") and len(auth) >= 20:
+        return auth[12:20]
+    return request.client.host if request.client else "unknown"
+
+
+limiter = Limiter(key_func=_get_api_key_identifier, default_limits=["60/minute"])
+
+
+async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Custom 429 handler returning structured JSON body."""
+    return JSONResponse(
+        status_code=429,
+        content=RateLimitResponse(
+            retry_after_seconds=60,
+            limit_type="global",
+            current_count=60,
+            max_allowed=60,
+        ).model_dump(),
+        headers={"Retry-After": "60"},
+    )

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -1,0 +1,29 @@
+"""Pydantic response models for ds01-jobs API."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Response schema for GET /health."""
+
+    status: Literal["ok", "degraded"]
+    version: str
+    db: Literal["ok", "error"]
+
+
+class RateLimitResponse(BaseModel):
+    """Response schema for 429 rate limit errors."""
+
+    error: str = "rate_limit_exceeded"
+    retry_after_seconds: int
+    limit_type: str
+    current_count: int
+    max_allowed: int
+
+
+class AuthErrorResponse(BaseModel):
+    """Response schema for 401 authentication errors."""
+
+    detail: str = "Authentication failed"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,325 @@
+"""Tests for ds01_jobs.auth module - HMAC-SHA256 authentication."""
+
+import hashlib
+import hmac
+import secrets
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import init_db
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash.
+
+    Returns (raw_key, key_id, key_hash).
+    """
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request.
+
+    Returns dict of headers: X-Timestamp, X-Nonce, X-Signature.
+    """
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+    revoked: int = 0,
+) -> None:
+    """Insert a test API key into the database."""
+    import aiosqlite
+
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, revoked),
+        )
+        await db.commit()
+
+
+def _make_app(db_path: Path):
+    """Create a minimal FastAPI app with the auth dependency for testing."""
+    from fastapi import Depends, FastAPI
+
+    from ds01_jobs.auth import get_current_user
+    from ds01_jobs.database import get_db
+
+    app = FastAPI()
+
+    async def _override_get_db():
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    @app.get("/protected")
+    async def protected(user: dict = Depends(get_current_user)):
+        return {"user": user}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_valid_hmac_auth_passes(tmp_path: Path):
+    """A correctly signed request with a valid key authenticates successfully."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["user"]["username"] == "testuser"
+
+
+@pytest.mark.asyncio
+async def test_invalid_key_prefix_returns_401(tmp_path: Path):
+    """A key without the 'ds01_' prefix returns 401."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    app = _make_app(db_path)
+    headers = {"Authorization": "Bearer badprefix_abc12345"}
+    headers.update(_sign_request("badprefix_abc12345", "GET", "/protected"))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Authentication failed"
+
+
+@pytest.mark.asyncio
+async def test_expired_key_returns_401(tmp_path: Path):
+    """An expired key returns 401."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    expired = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    await _seed_key(db_path, key_id, key_hash, expires_at=expired)
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_revoked_key_returns_401(tmp_path: Path):
+    """A revoked key (revoked=1) returns 401."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, revoked=1)
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stale_timestamp_returns_401(tmp_path: Path):
+    """A timestamp outside the 5-minute tolerance returns 401."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    stale_ts = time.time() - 600  # 10 minutes ago
+    headers = _sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_nonce_replay_returns_401(tmp_path: Path):
+    """Replaying the same nonce within 5 minutes returns 401."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    fixed_nonce = "replay-nonce-123"
+
+    # First request should succeed
+    headers1 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers1["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp1 = await client.get("/protected", headers=headers1)
+    assert resp1.status_code == 200
+
+    # Second request with same nonce should fail
+    headers2 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers2["Authorization"] = f"Bearer {raw_key}"
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp2 = await client.get("/protected", headers=headers2)
+    assert resp2.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_hmac_signature_returns_401(tmp_path: Path):
+    """A tampered HMAC signature returns 401."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["X-Signature"] = "deadbeef" * 8  # tampered
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_expiry_warning_header_set_when_within_14_days(tmp_path: Path):
+    """Keys expiring within 14 days get X-DS01-Key-Expiry-Warning header with ISO date."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    expires = datetime.now(UTC) + timedelta(days=7)
+    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 200
+    warning = resp.headers.get("X-DS01-Key-Expiry-Warning")
+    assert warning is not None
+    assert warning == expires.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_expiry_warning_header_not_set_when_far_from_expiry(tmp_path: Path):
+    """Keys with more than 14 days remaining do NOT get the warning header."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    expires = datetime.now(UTC) + timedelta(days=60)
+    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 200
+    assert "X-DS01-Key-Expiry-Warning" not in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_last_used_at_updated_after_successful_auth(tmp_path: Path):
+    """last_used_at is updated in the database after successful authentication."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 200
+
+    # Verify last_used_at was set
+    import aiosqlite
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT last_used_at FROM api_keys WHERE key_id = ?", (key_id,))
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] is not None  # last_used_at should be set

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,332 @@
+"""Tests for ds01_jobs.cli module."""
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import bcrypt
+import pytest
+from typer.testing import CliRunner
+
+from ds01_jobs.cli import app, generate_api_key, parse_duration
+from ds01_jobs.database import SCHEMA_SQL
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Create a temporary SQLite database with api_keys schema."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_SQL)
+    conn.close()
+
+    # Monkeypatch Settings to use temp db path
+    monkeypatch.setattr(
+        "ds01_jobs.cli.Settings",
+        lambda _env_file=None, **kw: type(
+            "S",
+            (),
+            {"db_path": db_path, "github_org": "hertie-data-science-lab", "key_expiry_days": 90},
+        )(),
+    )
+    # Also patch get_db_sync to use temp path
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _patched_get_db_sync(db_path_arg=None):
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    monkeypatch.setattr("ds01_jobs.cli.get_db_sync", _patched_get_db_sync)
+
+    return db_path
+
+
+@pytest.fixture()
+def mock_github_member(monkeypatch: pytest.MonkeyPatch):
+    """Mock check_org_membership to return True."""
+    monkeypatch.setattr("ds01_jobs.cli.check_org_membership", lambda u, o: True)
+
+
+@pytest.fixture()
+def mock_github_non_member(monkeypatch: pytest.MonkeyPatch):
+    """Mock check_org_membership to return False."""
+    monkeypatch.setattr("ds01_jobs.cli.check_org_membership", lambda u, o: False)
+
+
+# --- Helper function tests ---
+
+
+def test_generate_api_key_format():
+    """Generated key has ds01_ prefix and key_id is 8 chars."""
+    raw_key, key_id = generate_api_key()
+    assert raw_key.startswith("ds01_")
+    assert len(key_id) == 8
+    # base64url portion should be substantial
+    assert len(raw_key) > 20
+
+
+def test_parse_duration_valid():
+    """parse_duration parses valid Nd format."""
+    assert parse_duration("90d") == 90
+    assert parse_duration("30d") == 30
+    assert parse_duration("180d") == 180
+    assert parse_duration("1d") == 1
+
+
+def test_parse_duration_invalid():
+    """parse_duration raises BadParameter for invalid format."""
+    import click
+
+    with pytest.raises(click.exceptions.BadParameter):
+        parse_duration("90")
+    with pytest.raises(click.exceptions.BadParameter):
+        parse_duration("abc")
+    with pytest.raises(click.exceptions.BadParameter):
+        parse_duration("90h")
+
+
+# --- key-create tests ---
+
+
+def test_key_create_success(tmp_db, mock_github_member):
+    """key-create produces output with ds01_ key, username, and expiry."""
+    result = runner.invoke(app, ["key-create", "researcher1"])
+    assert result.exit_code == 0
+    assert "ds01_" in result.output
+    assert "researcher1" in result.output
+    assert "Expires:" in result.output
+    assert "API Key created successfully" in result.output
+
+
+def test_key_create_json(tmp_db, mock_github_member):
+    """key-create --json produces valid JSON with key field."""
+    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["key"].startswith("ds01_")
+    assert data["username"] == "researcher1"
+    assert "key_id" in data
+    assert "expires_at" in data
+
+
+def test_key_create_non_member(tmp_db, mock_github_non_member):
+    """key-create for non-member exits with error."""
+    result = runner.invoke(app, ["key-create", "outsider"])
+    assert result.exit_code == 1
+
+
+def test_key_create_duplicate_active_key(tmp_db, mock_github_member):
+    """key-create for user with existing active key exits with error."""
+    # Create first key
+    result1 = runner.invoke(app, ["key-create", "researcher1"])
+    assert result1.exit_code == 0
+
+    # Try to create second key
+    result2 = runner.invoke(app, ["key-create", "researcher1"])
+    assert result2.exit_code == 1
+
+
+def test_key_create_custom_expires(tmp_db, mock_github_member):
+    """key-create with --expires 30d sets expiry ~30 days from now."""
+    result = runner.invoke(app, ["key-create", "researcher1", "--expires", "30d", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+
+    expected_date = (datetime.now(UTC) + timedelta(days=30)).strftime("%Y-%m-%d")
+    assert data["expires_at"] == expected_date
+
+
+def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member):
+    """Created key hash is valid bcrypt - bcrypt.checkpw returns True."""
+    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    raw_key = data["key"]
+
+    # Read hash from DB
+    conn = sqlite3.connect(tmp_db)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT key_hash FROM api_keys WHERE username = 'researcher1'")
+    row = cursor.fetchone()
+    conn.close()
+
+    assert row is not None
+    stored_hash = row["key_hash"]
+    assert bcrypt.checkpw(raw_key.encode(), stored_hash.encode())
+
+
+def test_key_create_setup_instructions(tmp_db, mock_github_member):
+    """key-create output includes setup instructions block."""
+    result = runner.invoke(app, ["key-create", "researcher1"])
+    assert result.exit_code == 0
+    assert "Setup instructions" in result.output
+    assert "mkdir -p ~/.config/ds01" in result.output
+    assert "DS01_API_KEY=" in result.output
+
+
+# --- key-list tests ---
+
+
+def test_key_list_empty(tmp_db):
+    """key-list with no keys shows empty message."""
+    result = runner.invoke(app, ["key-list"])
+    assert result.exit_code == 0
+    assert "No API keys found" in result.output
+
+
+def test_key_list_with_keys(tmp_db, mock_github_member):
+    """key-list shows correct columns."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-list"])
+    assert result.exit_code == 0
+    assert "USERNAME" in result.output
+    assert "STATUS" in result.output
+    assert "CREATED" in result.output
+    assert "EXPIRES" in result.output
+    assert "LAST USED" in result.output
+    assert "researcher1" in result.output
+    assert "active" in result.output
+
+
+def test_key_list_json(tmp_db, mock_github_member):
+    """key-list --json produces valid JSON array."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-list", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["username"] == "researcher1"
+    assert data[0]["status"] == "active"
+
+
+def test_key_list_shows_status(tmp_db, mock_github_member):
+    """key-list shows correct status for active, revoked, expired keys."""
+    # Create and revoke a key to test revoked status
+    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
+
+    result = runner.invoke(app, ["key-list", "--json"])
+    data = json.loads(result.output)
+    assert data[0]["status"] == "revoked"
+
+
+def test_key_list_shows_expired_status(tmp_db, mock_github_member):
+    """key-list shows 'expired' for keys past their expiry date."""
+    # Create key then manually backdate its expiry
+    runner.invoke(app, ["key-create", "researcher1"])
+    conn = sqlite3.connect(tmp_db)
+    past_date = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    conn.execute("UPDATE api_keys SET expires_at = ? WHERE username = 'researcher1'", (past_date,))
+    conn.commit()
+    conn.close()
+
+    result = runner.invoke(app, ["key-list", "--json"])
+    data = json.loads(result.output)
+    assert data[0]["status"] == "expired"
+
+
+# --- key-revoke tests ---
+
+
+def test_key_revoke_with_yes(tmp_db, mock_github_member):
+    """key-revoke --yes revokes without prompt."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
+    assert result.exit_code == 0
+    assert "Key revoked" in result.output
+
+
+def test_key_revoke_nonexistent_user(tmp_db):
+    """key-revoke for nonexistent user exits with error."""
+    result = runner.invoke(app, ["key-revoke", "nobody", "--yes"])
+    assert result.exit_code == 1
+
+
+def test_revoked_key_shows_in_list(tmp_db, mock_github_member):
+    """Revoked key shows as 'revoked' in key-list."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
+    result = runner.invoke(app, ["key-list", "--json"])
+    data = json.loads(result.output)
+    assert data[0]["status"] == "revoked"
+
+
+def test_key_revoke_json(tmp_db, mock_github_member):
+    """key-revoke --json produces valid JSON output."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-revoke", "researcher1", "--yes", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["username"] == "researcher1"
+    assert data["status"] == "revoked"
+
+
+# --- key-rotate tests ---
+
+
+def test_key_rotate_with_yes(tmp_db, mock_github_member):
+    """key-rotate --yes produces a new key."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-rotate", "researcher1", "--yes"])
+    assert result.exit_code == 0
+    assert "ds01_" in result.output
+    assert "API Key rotated successfully" in result.output
+
+
+def test_key_rotate_no_active_key(tmp_db):
+    """key-rotate for user with no active key exits with error."""
+    result = runner.invoke(app, ["key-rotate", "nobody", "--yes"])
+    assert result.exit_code == 1
+
+
+def test_key_rotate_produces_different_key(tmp_db, mock_github_member):
+    """Rotated key is different from the original."""
+    result1 = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    original_key = json.loads(result1.output)["key"]
+
+    result2 = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
+    assert result2.exit_code == 0
+    new_key = json.loads(result2.output)["key"]
+    assert new_key != original_key
+    assert new_key.startswith("ds01_")
+
+
+def test_key_rotate_json(tmp_db, mock_github_member):
+    """key-rotate --json produces valid JSON with new key."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["key"].startswith("ds01_")
+    assert data["username"] == "researcher1"
+
+
+def test_key_rotate_old_hash_changes(tmp_db, mock_github_member):
+    """After rotation, the stored hash corresponds to the new key."""
+    result1 = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    original_key = json.loads(result1.output)["key"]
+
+    result2 = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
+    new_key = json.loads(result2.output)["key"]
+
+    # Read hash from DB
+    conn = sqlite3.connect(tmp_db)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT key_hash FROM api_keys WHERE username = 'researcher1'")
+    row = cursor.fetchone()
+    conn.close()
+
+    stored_hash = row["key_hash"]
+    # New key should match
+    assert bcrypt.checkpw(new_key.encode(), stored_hash.encode())
+    # Old key should NOT match
+    assert not bcrypt.checkpw(original_key.encode(), stored_hash.encode())

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,7 +9,7 @@ import bcrypt
 import pytest
 from typer.testing import CliRunner
 
-from ds01_jobs.cli import app, generate_api_key, parse_duration
+from ds01_jobs.cli import _resolve_github_token, app, generate_api_key, parse_duration
 from ds01_jobs.database import SCHEMA_SQL
 
 runner = CliRunner()
@@ -59,6 +59,35 @@ def mock_github_member(monkeypatch: pytest.MonkeyPatch):
 def mock_github_non_member(monkeypatch: pytest.MonkeyPatch):
     """Mock check_org_membership to return False."""
     monkeypatch.setattr("ds01_jobs.cli.check_org_membership", lambda u, o: False)
+
+
+# --- Token resolution tests ---
+
+
+def test_resolve_github_token_from_env(monkeypatch: pytest.MonkeyPatch):
+    """GITHUB_TOKEN env var takes priority."""
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+    assert _resolve_github_token() == "ghp_test123"
+
+
+def test_resolve_github_token_from_gh_cli(monkeypatch: pytest.MonkeyPatch):
+    """Falls back to gh auth token when env var unset."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "ds01_jobs.cli.subprocess.run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "ghp_from_cli\n"})(),
+    )
+    assert _resolve_github_token() == "ghp_from_cli"
+
+
+def test_resolve_github_token_none_when_unavailable(monkeypatch: pytest.MonkeyPatch):
+    """Returns None when neither env var nor gh CLI available."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "ds01_jobs.cli.subprocess.run",
+        lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    assert _resolve_github_token() is None
 
 
 # --- Helper function tests ---

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -163,6 +163,17 @@ def test_key_create_duplicate_active_key(tmp_db, mock_github_member):
     assert result2.exit_code == 1
 
 
+def test_key_create_after_revoke(tmp_db, mock_github_member):
+    """key-create succeeds after the previous key is revoked."""
+    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
+
+    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["username"] == "researcher1"
+
+
 def test_key_create_custom_expires(tmp_db, mock_github_member):
     """key-create with --expires 30d sets expiry ~30 days from now."""
     result = runner.invoke(app, ["key-create", "researcher1", "--expires", "30d", "--json"])

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,123 @@
+"""Tests for ds01_jobs.database module."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ds01_jobs.database import get_db, get_db_sync, init_db
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_api_keys_table(tmp_path: Path):
+    """init_db creates the api_keys table with the correct columns."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+
+    # Verify table exists and has the right columns
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA table_info(api_keys)")
+    columns = {row[1] for row in cursor.fetchall()}
+    conn.close()
+
+    expected = {
+        "id",
+        "username",
+        "key_id",
+        "key_hash",
+        "created_at",
+        "expires_at",
+        "revoked",
+        "last_used_at",
+    }
+    assert columns == expected
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_key_id_index(tmp_path: Path):
+    """init_db creates an index on the key_id column."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_api_keys_key_id'"
+    )
+    indexes = cursor.fetchall()
+    conn.close()
+
+    assert len(indexes) == 1
+
+
+@pytest.mark.asyncio
+async def test_init_db_enables_wal_mode(tmp_path: Path):
+    """init_db enables WAL journal mode."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA journal_mode")
+    mode = cursor.fetchone()[0]
+    conn.close()
+
+    assert mode == "wal"
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_parent_directories(tmp_path: Path):
+    """init_db creates parent directories if they don't exist."""
+    db_path = tmp_path / "nested" / "dir" / "test.db"
+
+    await init_db(db_path=db_path)
+
+    assert db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_get_db_yields_connection_with_row_factory(tmp_path: Path):
+    """get_db yields a connection with row_factory set."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    async for db in get_db(db_path=db_path):
+        assert db.row_factory is not None
+        # Verify we can query
+        cursor = await db.execute("SELECT 1 AS value")
+        row = await cursor.fetchone()
+        assert row["value"] == 1
+
+
+def test_get_db_sync_yields_connection_with_row_factory(tmp_path: Path):
+    """get_db_sync yields a sync connection with row_factory set."""
+    db_path = tmp_path / "test.db"
+    # Create the DB first using sync sqlite3
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        "CREATE TABLE IF NOT EXISTS api_keys (id INTEGER PRIMARY KEY, username TEXT);"
+    )
+    conn.close()
+
+    with get_db_sync(db_path=db_path) as db:
+        assert db.row_factory is sqlite3.Row
+        cursor = db.execute("SELECT 1 AS value")
+        row = cursor.fetchone()
+        assert row["value"] == 1
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path: Path):
+    """Calling init_db multiple times does not raise errors."""
+    db_path = tmp_path / "test.db"
+
+    await init_db(db_path=db_path)
+    await init_db(db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA table_info(api_keys)")
+    columns = {row[1] for row in cursor.fetchall()}
+    conn.close()
+
+    assert "key_id" in columns

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,99 @@
+"""Tests for the GET /health endpoint."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import get_db, init_db
+
+
+def _make_app(db_path: Path):
+    """Create the app with DB overridden to use a test database."""
+    import aiosqlite
+    from fastapi import FastAPI
+
+    from ds01_jobs.health import router
+    from ds01_jobs.middleware import limiter
+
+    app = FastAPI()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.state.limiter = limiter
+    app.include_router(router)
+
+    return app
+
+
+def _make_broken_app():
+    """Create the app with DB dependency that raises an error."""
+    from fastapi import FastAPI
+
+    from ds01_jobs.health import router
+    from ds01_jobs.middleware import limiter
+
+    app = FastAPI()
+
+    async def _broken_get_db():
+        mock = AsyncMock()
+        mock.execute = AsyncMock(side_effect=Exception("DB unreachable"))
+        yield mock
+
+    app.dependency_overrides[get_db] = _broken_get_db
+    app.state.limiter = limiter
+    app.include_router(router)
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_health_returns_200_when_db_reachable(tmp_path: Path):
+    """GET /health returns 200 with status=ok when DB is reachable."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    app = _make_app(db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["version"] == "0.1.0"
+    assert data["db"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_health_returns_503_when_db_unreachable():
+    """GET /health returns 503 with status=degraded when DB is unreachable."""
+    app = _make_broken_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["db"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_health_requires_no_authentication(tmp_path: Path):
+    """GET /health works without any Authorization header."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    app = _make_app(db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # No Authorization header at all
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- SQLite database layer with async/sync access, WAL mode, and `api_keys` schema
- HMAC-SHA256 authentication (key prefix check, bcrypt verify, timestamp freshness, nonce replay protection)
- Health endpoint (`GET /health`) with DB connectivity check
- `ds01-job-admin` CLI with `key-create`, `key-list`, `key-revoke`, `key-rotate`
- GitHub org membership verification via authenticated API (auto-detects `gh` CLI token)
- Request ID middleware
- 51 unit tests

## Test plan

- [x] `uv run pytest tests/unit/` - 51 passed
- [x] Manual: `ds01-job-admin key-create henrycgbaker` - verified with `gh` token auto-detection
- [x] Manual: `key-list`, `key-revoke`, `key-rotate` all working
- [x] Manual: `GET /health` returns 200
- [ ] CI passes