### PR TITLE
feat: add Dockerfile scanner, URL validation, and job submission models

### DIFF
--- a/src/ds01_jobs/app.py
+++ b/src/ds01_jobs/app.py
@@ -26,11 +26,26 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 async def _validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
-    """Return structured 422 for validation errors."""
+    """Return Stripe-like structured 422 for validation errors."""
+    errors = []
+    for err in exc.errors():
+        # Build field path, skipping the "body" prefix that Pydantic adds
+        field = ".".join(str(loc) for loc in err.get("loc", []) if loc != "body")
+        errors.append(
+            {
+                "field": field or "unknown",
+                "code": err.get("type", "validation_error"),
+                "message": err.get("msg", "Validation failed"),
+            }
+        )
     return JSONResponse(
         status_code=422,
         content={
-            "detail": exc.errors(),
+            "error": {
+                "type": "validation_error",
+                "message": "Request validation failed",
+                "errors": errors,
+            }
         },
     )
 

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -25,3 +25,23 @@ class Settings(BaseSettings):
     # Authentication
     github_org: str = "hertie-data-science-lab"
     key_expiry_days: int = 90
+
+    # Dockerfile scanning
+    allowed_base_registries: list[str] = [
+        "docker.io/library/",
+        "nvcr.io/nvidia/",
+        "ghcr.io/astral-sh/",
+        "docker.io/pytorch/",
+        "docker.io/tensorflow/",
+        "docker.io/huggingface/",
+    ]
+    blocked_env_keys: list[str] = ["LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT"]
+    warning_env_keys: list[str] = ["LD_DEBUG", "PYTHONPATH"]
+
+    # Rate limiting defaults
+    default_concurrent_limit: int = 3
+    default_daily_limit: int = 10
+
+    # URL validation
+    allowed_github_orgs: list[str] = []
+    preflight_timeout_seconds: float = 5.0

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -26,6 +26,23 @@ CREATE TABLE IF NOT EXISTS api_keys (
     last_used_at TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_api_keys_key_id ON api_keys(key_id);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    username TEXT NOT NULL,
+    repo_url TEXT NOT NULL,
+    branch TEXT NOT NULL DEFAULT 'main',
+    gpu_count INTEGER NOT NULL DEFAULT 1,
+    job_name TEXT NOT NULL,
+    timeout_seconds INTEGER,
+    dockerfile_content TEXT,
+    status TEXT NOT NULL DEFAULT 'queued',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (username) REFERENCES api_keys(username)
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_username_status ON jobs(username, status);
+CREATE INDEX IF NOT EXISTS idx_jobs_username_created ON jobs(username, created_at);
 """
 
 

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class HealthResponse(BaseModel):
@@ -27,3 +27,68 @@ class AuthErrorResponse(BaseModel):
     """Response schema for 401 authentication errors."""
 
     detail: str = "Authentication failed"
+
+
+# --- Job submission models ---
+
+
+class JobSubmitRequest(BaseModel):
+    """Request body for POST /api/v1/jobs."""
+
+    repo_url: str
+    gpu_count: int = Field(default=1, ge=1, le=8)
+    branch: str = "main"
+    job_name: str | None = None
+    timeout_seconds: int | None = Field(default=None, ge=60, le=86400)
+    dockerfile_content: str | None = None
+
+
+class JobResponse(BaseModel):
+    """Response body for successful job submission (202)."""
+
+    job_id: str
+    status: str
+    status_url: str
+    created_at: str
+
+
+class ErrorDetail(BaseModel):
+    """Single field-level error in a Stripe-like error response."""
+
+    field: str
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """Stripe-like error body with type, message, and field-level errors."""
+
+    type: str
+    message: str
+    errors: list[ErrorDetail] = []
+
+
+class APIError(BaseModel):
+    """Top-level error wrapper: {"error": {...}}."""
+
+    error: ErrorResponse
+
+
+class RateLimitErrorResponse(BaseModel):
+    """Structured 429 response body for per-user rate limits."""
+
+    type: Literal["rate_limit_error"] = "rate_limit_error"
+    limit_type: str
+    message: str
+    limit: int
+    current: int
+    retry_after: int | None
+
+
+class ScanViolationModel(BaseModel):
+    """Pydantic model for a single Dockerfile scan violation."""
+
+    line: int
+    severity: str
+    rule: str
+    message: str

--- a/src/ds01_jobs/scanner.py
+++ b/src/ds01_jobs/scanner.py
@@ -1,0 +1,153 @@
+"""Dockerfile static analysis for ds01-jobs.
+
+Scans Dockerfile content for disallowed base images, dangerous ENV directives,
+and insecure USER directives. Returns structured violations with line numbers.
+"""
+
+import re
+from dataclasses import dataclass
+
+_FROM_RE = re.compile(
+    r"^\s*FROM\s+"
+    r"(?:--platform=\S+\s+)?"  # optional --platform flag
+    r"(\S+)"  # image reference (group 1)
+    r"(?:\s+AS\s+\S+)?",  # optional AS name
+    re.IGNORECASE,
+)
+_ENV_RE = re.compile(
+    r"^\s*ENV\s+(\w+)",  # ENV KEY (group 1 = key name)
+    re.IGNORECASE,
+)
+_USER_RE = re.compile(
+    r"^\s*USER\s+(\S+)",  # USER name (group 1)
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class ScanViolation:
+    """A single violation found during Dockerfile scanning."""
+
+    line: int  # 1-based line number
+    severity: str  # "error", "warning", "info"
+    rule: str  # machine-readable rule ID
+    message: str  # human-readable explanation
+
+
+def _normalise_image_ref(image: str) -> str:
+    """Normalise a Docker image reference to fully qualified form.
+
+    Strips tags and digests, then prepends registry prefix:
+    - bare name (no /) -> docker.io/library/
+    - user name (no . in first segment) -> docker.io/
+    - otherwise use as-is
+    """
+    # Strip tag (:...) and digest (@...) for prefix matching
+    name = image.split(":")[0].split("@")[0]
+    if name == "scratch":
+        return "scratch"
+    if "/" not in name:
+        return f"docker.io/library/{name}"
+    if "." not in name.split("/")[0]:
+        return f"docker.io/{name}"
+    return name
+
+
+def scan_dockerfile(
+    content: str,
+    allowed_registries: list[str],
+    blocked_env_keys: list[str],
+    warning_env_keys: list[str],
+) -> list[ScanViolation]:
+    """Scan Dockerfile content and return a list of violations.
+
+    Args:
+        content: Raw Dockerfile text.
+        allowed_registries: Registry prefixes that are permitted (e.g. "docker.io/library/").
+        blocked_env_keys: ENV key names that produce errors in the final stage.
+        warning_env_keys: ENV key names that produce warnings in the final stage.
+
+    Returns:
+        List of ScanViolation instances, possibly empty.
+    """
+    violations: list[ScanViolation] = []
+    lines = content.splitlines()
+
+    # First pass: find all FROM line indices to identify the final stage
+    from_indices: list[int] = []
+    for i, line in enumerate(lines):
+        if _FROM_RE.match(line):
+            from_indices.append(i)
+
+    last_from = from_indices[-1] if from_indices else 0
+
+    for i, line in enumerate(lines):
+        lineno = i + 1  # 1-based
+
+        # Check FROM directives (all stages)
+        m = _FROM_RE.match(line)
+        if m:
+            image = m.group(1)
+            # Unresolved build args - can't statically verify
+            if "${" in image:
+                violations.append(
+                    ScanViolation(
+                        line=lineno,
+                        severity="info",
+                        rule="UNRESOLVED_BUILD_ARG",
+                        message=f"Base image '{image}' contains unresolved build arg"
+                        " - cannot statically verify",
+                    )
+                )
+                continue
+
+            normalised = _normalise_image_ref(image)
+            if normalised != "scratch":
+                if not any(normalised.startswith(reg) for reg in allowed_registries):
+                    violations.append(
+                        ScanViolation(
+                            line=lineno,
+                            severity="error",
+                            rule="BLOCKED_BASE_IMAGE",
+                            message=f"Base image '{image}' not in allowed registries",
+                        )
+                    )
+            continue
+
+        # ENV and USER checks only in final stage
+        if i >= last_from:
+            m = _ENV_RE.match(line)
+            if m:
+                key = m.group(1)
+                if key in blocked_env_keys:
+                    violations.append(
+                        ScanViolation(
+                            line=lineno,
+                            severity="error",
+                            rule="BLOCKED_ENV",
+                            message=f"ENV {key} is not allowed (security risk)",
+                        )
+                    )
+                elif key in warning_env_keys:
+                    violations.append(
+                        ScanViolation(
+                            line=lineno,
+                            severity="warning",
+                            rule="SUSPICIOUS_ENV",
+                            message=f"ENV {key} may pose a security risk",
+                        )
+                    )
+                continue
+
+            m = _USER_RE.match(line)
+            if m and m.group(1) == "root":
+                violations.append(
+                    ScanViolation(
+                        line=lineno,
+                        severity="warning",
+                        rule="USER_ROOT",
+                        message="Running as root - cgroup constraints apply regardless",
+                    )
+                )
+
+    return violations

--- a/src/ds01_jobs/url_validation.py
+++ b/src/ds01_jobs/url_validation.py
@@ -1,0 +1,86 @@
+"""GitHub URL validation and SSRF prevention for ds01-jobs.
+
+Validates that repository URLs point to GitHub, checks for SSRF via DNS resolution,
+and verifies repository accessibility with a pre-flight HEAD request.
+"""
+
+import asyncio
+import ipaddress
+import re
+import socket
+
+import httpx
+
+GITHUB_URL_RE = re.compile(
+    r"^https://github\.com/"
+    r"(?P<owner>[a-zA-Z0-9\-_.]+)/"
+    r"(?P<repo>[a-zA-Z0-9\-_.]+?)"
+    r"(?:\.git)?/?$"
+)
+
+
+def validate_repo_url_format(url: str, allowed_orgs: list[str]) -> tuple[str, str]:
+    """Validate URL format and return (owner, repo).
+
+    Args:
+        url: The repository URL to validate.
+        allowed_orgs: List of permitted GitHub organisations. Empty means any org allowed.
+
+    Returns:
+        Tuple of (owner, repo) extracted from the URL.
+
+    Raises:
+        ValueError: If the URL is not a valid GitHub repository URL or org is not allowed.
+    """
+    m = GITHUB_URL_RE.match(url.strip())
+    if not m:
+        raise ValueError("Must be a valid GitHub repository URL (https://github.com/owner/repo)")
+
+    owner, repo = m.group("owner"), m.group("repo")
+
+    if allowed_orgs and owner not in allowed_orgs:
+        raise ValueError("Only GitHub repository URLs are supported")
+
+    return owner, repo
+
+
+async def check_ssrf(hostname: str) -> None:
+    """Resolve hostname and verify all IPs are public.
+
+    Args:
+        hostname: The hostname to resolve and check.
+
+    Raises:
+        ValueError: If any resolved IP is private, loopback, reserved, or link-local.
+    """
+    try:
+        addrs = await asyncio.to_thread(socket.getaddrinfo, hostname, 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise ValueError("Only GitHub repository URLs are supported")
+
+    for _family, _type, _proto, _canonname, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
+            raise ValueError("Only GitHub repository URLs are supported")
+
+
+async def verify_repo_accessible(url: str, timeout: float = 5.0) -> None:
+    """Send a HEAD request to verify the repository exists.
+
+    Args:
+        url: The GitHub repository URL.
+        timeout: Request timeout in seconds.
+
+    Raises:
+        ValueError: If the repository is not found or request fails.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.head(url, timeout=timeout, follow_redirects=False)
+    except (httpx.TimeoutException, httpx.ConnectError):
+        raise ValueError("Only GitHub repository URLs are supported")
+
+    if resp.status_code == 404:
+        raise ValueError("Repository not found")
+    if resp.status_code >= 400:
+        raise ValueError("Only GitHub repository URLs are supported")

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -1,0 +1,157 @@
+"""Tests for ds01_jobs.scanner - Dockerfile static analysis."""
+
+from ds01_jobs.scanner import ScanViolation, scan_dockerfile
+
+# Default registries matching config defaults
+ALLOWED = [
+    "docker.io/library/",
+    "nvcr.io/nvidia/",
+    "ghcr.io/astral-sh/",
+    "docker.io/pytorch/",
+    "docker.io/tensorflow/",
+    "docker.io/huggingface/",
+]
+BLOCKED = ["LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT"]
+WARNING = ["LD_DEBUG", "PYTHONPATH"]
+
+
+def _scan(content: str) -> list[ScanViolation]:
+    return scan_dockerfile(content, ALLOWED, BLOCKED, WARNING)
+
+
+def test_approved_base_image_passes():
+    """Docker Hub official shorthand image (python:3.12-slim) produces no violations."""
+    violations = _scan("FROM python:3.12-slim\nRUN pip install torch\n")
+    assert violations == []
+
+
+def test_blocked_base_image_error():
+    """Disallowed registry produces error with correct line number."""
+    violations = _scan("FROM evil.registry.io/malware:latest\n")
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "error"
+    assert v.rule == "BLOCKED_BASE_IMAGE"
+    assert v.line == 1
+
+
+def test_nvcr_nvidia_allowed():
+    """NVIDIA Container Registry images pass validation."""
+    violations = _scan("FROM nvcr.io/nvidia/pytorch:24.01-py3\n")
+    assert violations == []
+
+
+def test_ghcr_astral_allowed():
+    """GitHub Container Registry astral-sh images pass validation."""
+    violations = _scan("FROM ghcr.io/astral-sh/uv:0.10\n")
+    assert violations == []
+
+
+def test_scratch_always_allowed():
+    """FROM scratch is always allowed (Docker built-in)."""
+    violations = _scan("FROM scratch\nCOPY --from=builder /app /app\n")
+    assert violations == []
+
+
+def test_multistage_all_from_scanned():
+    """All FROM directives are scanned for base image compliance (SCAN-01)."""
+    dockerfile = (
+        "FROM python:3.12-slim AS builder\n"
+        "RUN pip install torch\n"
+        "FROM evil.registry.io/backdoor:latest\n"
+        "COPY --from=builder /app /app\n"
+    )
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    assert violations[0].rule == "BLOCKED_BASE_IMAGE"
+    assert violations[0].line == 3
+
+
+def test_multistage_env_final_stage_only():
+    """ENV rules apply to final stage only - builder stage LD_LIBRARY_PATH is OK."""
+    dockerfile = (
+        "FROM python:3.12-slim AS builder\n"
+        "ENV LD_LIBRARY_PATH=/usr/local/lib\n"
+        "RUN make\n"
+        "FROM python:3.12-slim\n"
+        "COPY --from=builder /app /app\n"
+    )
+    violations = _scan(dockerfile)
+    # Builder stage LD_LIBRARY_PATH should NOT produce a violation
+    assert violations == []
+
+
+def test_blocked_env_ld_preload():
+    """ENV LD_PRELOAD in final stage produces error (SCAN-03)."""
+    dockerfile = "FROM python:3.12-slim\nENV LD_PRELOAD /evil.so\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "error"
+    assert v.rule == "BLOCKED_ENV"
+    assert "LD_PRELOAD" in v.message
+
+
+def test_blocked_env_ld_audit():
+    """ENV LD_AUDIT in final stage produces error."""
+    dockerfile = "FROM python:3.12-slim\nENV LD_AUDIT /evil.so\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    assert violations[0].severity == "error"
+    assert violations[0].rule == "BLOCKED_ENV"
+
+
+def test_warning_env_pythonpath():
+    """ENV PYTHONPATH in final stage produces warning, not error."""
+    dockerfile = "FROM python:3.12-slim\nENV PYTHONPATH /custom\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "warning"
+    assert v.rule == "SUSPICIOUS_ENV"
+
+
+def test_user_root_warning():
+    """USER root in final stage produces warning (SCAN-04)."""
+    dockerfile = "FROM python:3.12-slim\nUSER root\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "warning"
+    assert v.rule == "USER_ROOT"
+
+
+def test_violation_has_line_number():
+    """Violations include correct 1-based line numbers (SCAN-05)."""
+    dockerfile = "FROM python:3.12-slim\nRUN echo hello\nENV LD_PRELOAD /evil.so\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    assert violations[0].line == 3
+
+
+def test_docker_hub_user_image_normalised():
+    """User image pytorch/pytorch normalised to docker.io/pytorch/pytorch."""
+    violations = _scan("FROM pytorch/pytorch:latest\n")
+    assert violations == []
+
+
+def test_unresolved_build_arg_info():
+    """FROM with unresolved build arg produces info, not error."""
+    dockerfile = "ARG BASE_IMAGE\nFROM ${BASE_IMAGE}\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "info"
+    assert v.rule == "UNRESOLVED_BUILD_ARG"
+
+
+def test_from_with_platform_flag():
+    """FROM --platform=linux/amd64 is parsed correctly."""
+    violations = _scan("FROM --platform=linux/amd64 python:3.12\n")
+    assert violations == []
+
+
+def test_empty_dockerfile():
+    """Empty Dockerfile produces no violations."""
+    violations = _scan("")
+    assert violations == []

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -1,0 +1,130 @@
+"""Tests for ds01_jobs.url_validation - GitHub URL validation and SSRF prevention."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ds01_jobs.url_validation import check_ssrf, validate_repo_url_format, verify_repo_accessible
+
+# --- validate_repo_url_format ---
+
+
+def test_valid_github_url():
+    """Standard GitHub URL returns (owner, repo)."""
+    owner, repo = validate_repo_url_format("https://github.com/owner/repo", [])
+    assert owner == "owner"
+    assert repo == "repo"
+
+
+def test_valid_github_url_with_git_suffix():
+    """URL with .git suffix passes."""
+    owner, repo = validate_repo_url_format("https://github.com/owner/repo.git", [])
+    assert owner == "owner"
+    assert repo == "repo"
+
+
+def test_valid_github_url_with_trailing_slash():
+    """URL with trailing slash passes."""
+    owner, repo = validate_repo_url_format("https://github.com/owner/repo/", [])
+    assert owner == "owner"
+    assert repo == "repo"
+
+
+def test_rejects_non_github_url():
+    """Non-GitHub URL raises ValueError."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("https://gitlab.com/owner/repo", [])
+
+
+def test_rejects_http_url():
+    """HTTP (non-HTTPS) URL raises ValueError."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("http://github.com/owner/repo", [])
+
+
+def test_rejects_browser_url_with_extra_path():
+    """Browser URLs with extra path segments are rejected."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("https://github.com/owner/repo/tree/main", [])
+
+
+def test_rejects_private_ip_url():
+    """URL with private IP instead of github.com is rejected."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("https://192.168.1.1/owner/repo", [])
+
+
+def test_org_restriction_allowed():
+    """With allowed_orgs set, matching org passes."""
+    owner, repo = validate_repo_url_format("https://github.com/myorg/repo", ["myorg"])
+    assert owner == "myorg"
+    assert repo == "repo"
+
+
+def test_org_restriction_blocked():
+    """With allowed_orgs set, non-matching org raises generic error."""
+    with pytest.raises(ValueError, match="Only GitHub repository URLs are supported"):
+        validate_repo_url_format("https://github.com/other/repo", ["myorg"])
+
+
+def test_org_restriction_empty_allows_all():
+    """With empty allowed_orgs, any org passes."""
+    owner, repo = validate_repo_url_format("https://github.com/anyorg/repo", [])
+    assert owner == "anyorg"
+    assert repo == "repo"
+
+
+# --- check_ssrf ---
+
+
+@pytest.mark.asyncio
+async def test_check_ssrf_private_ip():
+    """Private IP resolution raises ValueError."""
+    fake_addrs = [(2, 1, 6, "", ("127.0.0.1", 443))]
+    with patch("ds01_jobs.url_validation.socket.getaddrinfo", return_value=fake_addrs):
+        with pytest.raises(ValueError, match="Only GitHub repository URLs are supported"):
+            await check_ssrf("evil.example.com")
+
+
+@pytest.mark.asyncio
+async def test_check_ssrf_public_ip():
+    """Public IP resolution does not raise."""
+    fake_addrs = [(2, 1, 6, "", ("140.82.121.4", 443))]
+    with patch("ds01_jobs.url_validation.socket.getaddrinfo", return_value=fake_addrs):
+        await check_ssrf("github.com")  # Should not raise
+
+
+# --- verify_repo_accessible ---
+
+
+@pytest.mark.asyncio
+async def test_verify_repo_accessible_success():
+    """200 response means repository exists."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+
+    with patch("ds01_jobs.url_validation.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.head = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await verify_repo_accessible("https://github.com/owner/repo")
+
+
+@pytest.mark.asyncio
+async def test_verify_repo_accessible_not_found():
+    """404 response raises ValueError('Repository not found')."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 404
+
+    with patch("ds01_jobs.url_validation.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.head = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(ValueError, match="Repository not found"):
+            await verify_repo_accessible("https://github.com/owner/nonexistent")


### PR DESCRIPTION
## Summary

- Extend config with scanner allowlists, rate limit defaults, URL validation settings
- Add job submission request/response models and Stripe-like error format (ErrorDetail/ErrorResponse/APIError)
- Add jobs table to database schema with username+status and username+created_at indexes
- Create Dockerfile scanner — base image allowlist with Docker Hub normalisation, ENV blocking in final stage, USER root warnings, multi-stage support
- Create URL validator — GitHub URL format validation, org restriction, SSRF prevention via DNS+IP check, pre-flight HEAD request
- Update validation error handler to return structured error format

## Test plan

- [x] 82 unit tests pass (`uv run pytest tests/unit/ -v`)
- [ ] CI passes (ruff, mypy, pytest)
- [ ] Review scanner regex patterns and normalisation logic
- [ ] Review SSRF prevention (DNS resolution + private IP check)