### PR TITLE
feat: add rate limiter and POST /api/v1/jobs endpoint

### DIFF
--- a/src/ds01_jobs/app.py
+++ b/src/ds01_jobs/app.py
@@ -26,11 +26,26 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 async def _validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
-    """Return structured 422 for validation errors."""
+    """Return Stripe-like structured 422 for validation errors."""
+    errors = []
+    for err in exc.errors():
+        # Build field path, skipping the "body" prefix that Pydantic adds
+        field = ".".join(str(loc) for loc in err.get("loc", []) if loc != "body")
+        errors.append(
+            {
+                "field": field or "unknown",
+                "code": err.get("type", "validation_error"),
+                "message": err.get("msg", "Validation failed"),
+            }
+        )
     return JSONResponse(
         status_code=422,
         content={
-            "detail": exc.errors(),
+            "error": {
+                "type": "validation_error",
+                "message": "Request validation failed",
+                "errors": errors,
+            }
         },
     )
 

--- a/src/ds01_jobs/app.py
+++ b/src/ds01_jobs/app.py
@@ -15,6 +15,7 @@ from slowapi.errors import RateLimitExceeded
 from ds01_jobs import __version__
 from ds01_jobs.database import init_db
 from ds01_jobs.health import router as health_router
+from ds01_jobs.jobs import router as jobs_router
 from ds01_jobs.middleware import limiter, rate_limit_handler
 
 
@@ -68,6 +69,7 @@ def create_app() -> FastAPI:
 
     # Routers
     app.include_router(health_router)
+    app.include_router(jobs_router)
 
     return app
 

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -25,3 +25,23 @@ class Settings(BaseSettings):
     # Authentication
     github_org: str = "hertie-data-science-lab"
     key_expiry_days: int = 90
+
+    # Dockerfile scanning
+    allowed_base_registries: list[str] = [
+        "docker.io/library/",
+        "nvcr.io/nvidia/",
+        "ghcr.io/astral-sh/",
+        "docker.io/pytorch/",
+        "docker.io/tensorflow/",
+        "docker.io/huggingface/",
+    ]
+    blocked_env_keys: list[str] = ["LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT"]
+    warning_env_keys: list[str] = ["LD_DEBUG", "PYTHONPATH"]
+
+    # Rate limiting defaults
+    default_concurrent_limit: int = 3
+    default_daily_limit: int = 10
+
+    # URL validation
+    allowed_github_orgs: list[str] = []
+    preflight_timeout_seconds: float = 5.0

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -26,6 +26,23 @@ CREATE TABLE IF NOT EXISTS api_keys (
     last_used_at TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_api_keys_key_id ON api_keys(key_id);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    username TEXT NOT NULL,
+    repo_url TEXT NOT NULL,
+    branch TEXT NOT NULL DEFAULT 'main',
+    gpu_count INTEGER NOT NULL DEFAULT 1,
+    job_name TEXT NOT NULL,
+    timeout_seconds INTEGER,
+    dockerfile_content TEXT,
+    status TEXT NOT NULL DEFAULT 'queued',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (username) REFERENCES api_keys(username)
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_username_status ON jobs(username, status);
+CREATE INDEX IF NOT EXISTS idx_jobs_username_created ON jobs(username, created_at);
 """
 
 

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -1,0 +1,181 @@
+"""Job submission endpoint for ds01-jobs.
+
+POST /api/v1/jobs orchestrates the full validation pipeline and returns
+202 Accepted with a queued job.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from functools import lru_cache
+
+import aiosqlite
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+
+from ds01_jobs.auth import get_current_user
+from ds01_jobs.config import Settings
+from ds01_jobs.database import get_db
+from ds01_jobs.models import JobResponse, JobSubmitRequest
+from ds01_jobs.rate_limit import check_rate_limits
+from ds01_jobs.scanner import scan_dockerfile
+from ds01_jobs.url_validation import check_ssrf, validate_repo_url_format, verify_repo_accessible
+
+router = APIRouter(prefix="/api/v1")
+
+MAX_TIMEOUT_SECONDS = 86400  # 24 hours
+
+
+@lru_cache(maxsize=1)
+def _get_settings() -> Settings:
+    """Return cached Settings instance."""
+    return Settings()
+
+
+@router.post("/jobs", status_code=202, response_model=JobResponse)
+async def submit_job(
+    request: Request,
+    response: Response,
+    body: JobSubmitRequest,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> JobResponse:
+    """Submit a new GPU job for execution."""
+    settings = _get_settings()
+    username = user["username"]
+
+    # 1. URL format validation (cheap, no I/O)
+    try:
+        owner, repo = validate_repo_url_format(body.repo_url, settings.allowed_github_orgs)
+    except ValueError as e:
+        return JSONResponse(  # type: ignore[return-value]
+            status_code=422,
+            content={
+                "error": {
+                    "type": "validation_error",
+                    "message": str(e),
+                    "errors": [
+                        {
+                            "field": "repo_url",
+                            "code": "invalid_url",
+                            "message": str(e),
+                        }
+                    ],
+                }
+            },
+        )
+
+    # 2. Rate limit check (raises 429 on failure)
+    concurrent_count, concurrent_limit, daily_count, daily_limit = await check_rate_limits(
+        db, username, settings
+    )
+
+    # 3. SSRF check
+    try:
+        await check_ssrf("github.com")
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    # 4. Pre-flight HEAD request
+    try:
+        await verify_repo_accessible(body.repo_url, settings.preflight_timeout_seconds)
+    except ValueError as e:
+        return JSONResponse(  # type: ignore[return-value]
+            status_code=422,
+            content={
+                "error": {
+                    "type": "validation_error",
+                    "message": str(e),
+                    "errors": [
+                        {
+                            "field": "repo_url",
+                            "code": "repo_not_found",
+                            "message": str(e),
+                        }
+                    ],
+                }
+            },
+        )
+
+    # 5. Dockerfile scan (if provided)
+    if body.dockerfile_content:
+        violations = scan_dockerfile(
+            body.dockerfile_content,
+            settings.allowed_base_registries,
+            settings.blocked_env_keys,
+            settings.warning_env_keys,
+        )
+        errors = [v for v in violations if v.severity == "error"]
+        if errors:
+            return JSONResponse(  # type: ignore[return-value]
+                status_code=422,
+                content={
+                    "error": {
+                        "type": "dockerfile_scan_error",
+                        "message": "Dockerfile scan found errors",
+                        "errors": [
+                            {
+                                "field": f"dockerfile_content:{v.line}",
+                                "code": v.rule,
+                                "message": v.message,
+                            }
+                            for v in errors
+                        ],
+                    }
+                },
+            )
+
+    # 6. Generate job_id
+    job_id = str(uuid.uuid4())
+
+    # 7. Generate job_name
+    job_name = body.job_name
+    if not job_name:
+        job_name = f"{repo}-{job_id[:8]}"
+
+    # 8. Clamp timeout
+    timeout_seconds = body.timeout_seconds
+    if timeout_seconds is not None:
+        timeout_seconds = min(timeout_seconds, MAX_TIMEOUT_SECONDS)
+
+    # 9. Insert job
+    now_iso = datetime.now(UTC).isoformat()
+    await db.execute(
+        "INSERT INTO jobs "
+        "(id, username, repo_url, branch, gpu_count, job_name, "
+        "timeout_seconds, dockerfile_content, status, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            job_id,
+            username,
+            body.repo_url,
+            body.branch,
+            body.gpu_count,
+            job_name,
+            timeout_seconds,
+            body.dockerfile_content,
+            "queued",
+            now_iso,
+            now_iso,
+        ),
+    )
+    await db.commit()
+
+    # 10. Set rate limit headers
+    midnight_tomorrow = datetime.now(UTC).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ) + timedelta(days=1)
+    response.headers["X-RateLimit-Limit-Concurrent"] = str(concurrent_limit)
+    response.headers["X-RateLimit-Remaining-Concurrent"] = str(
+        concurrent_limit - concurrent_count - 1
+    )
+    response.headers["X-RateLimit-Limit-Daily"] = str(daily_limit)
+    response.headers["X-RateLimit-Remaining-Daily"] = str(daily_limit - daily_count - 1)
+    response.headers["X-RateLimit-Reset-Daily"] = midnight_tomorrow.isoformat()
+
+    # 11. Return 202
+    return JobResponse(
+        job_id=job_id,
+        status="queued",
+        status_url=f"/api/v1/jobs/{job_id}",
+        created_at=now_iso,
+    )

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class HealthResponse(BaseModel):
@@ -27,3 +27,68 @@ class AuthErrorResponse(BaseModel):
     """Response schema for 401 authentication errors."""
 
     detail: str = "Authentication failed"
+
+
+# --- Job submission models ---
+
+
+class JobSubmitRequest(BaseModel):
+    """Request body for POST /api/v1/jobs."""
+
+    repo_url: str
+    gpu_count: int = Field(default=1, ge=1, le=8)
+    branch: str = "main"
+    job_name: str | None = None
+    timeout_seconds: int | None = Field(default=None, ge=60, le=86400)
+    dockerfile_content: str | None = None
+
+
+class JobResponse(BaseModel):
+    """Response body for successful job submission (202)."""
+
+    job_id: str
+    status: str
+    status_url: str
+    created_at: str
+
+
+class ErrorDetail(BaseModel):
+    """Single field-level error in a Stripe-like error response."""
+
+    field: str
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """Stripe-like error body with type, message, and field-level errors."""
+
+    type: str
+    message: str
+    errors: list[ErrorDetail] = []
+
+
+class APIError(BaseModel):
+    """Top-level error wrapper: {"error": {...}}."""
+
+    error: ErrorResponse
+
+
+class RateLimitErrorResponse(BaseModel):
+    """Structured 429 response body for per-user rate limits."""
+
+    type: Literal["rate_limit_error"] = "rate_limit_error"
+    limit_type: str
+    message: str
+    limit: int
+    current: int
+    retry_after: int | None
+
+
+class ScanViolationModel(BaseModel):
+    """Pydantic model for a single Dockerfile scan violation."""
+
+    line: int
+    severity: str
+    rule: str
+    message: str

--- a/src/ds01_jobs/rate_limit.py
+++ b/src/ds01_jobs/rate_limit.py
@@ -1,0 +1,129 @@
+"""Per-user rate limiting for ds01-jobs.
+
+Enforces concurrent and daily job submission limits per user,
+with configurable per-group overrides from resource-limits.yaml.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import yaml
+from fastapi import HTTPException
+
+from ds01_jobs.config import Settings
+
+logger = logging.getLogger(__name__)
+
+ACTIVE_STATUSES = ("queued", "cloning", "building", "running")
+
+
+def load_resource_limits(path: Path) -> dict:  # type: ignore[type-arg]
+    """Load resource-limits.yaml, returning empty dict if file missing."""
+    if not path.is_file():
+        return {}
+    with path.open() as f:
+        data = yaml.safe_load(f)
+    return data if isinstance(data, dict) else {}
+
+
+def get_user_limits(username: str, settings: Settings) -> tuple[int, int]:
+    """Return (concurrent_limit, daily_limit) for a user.
+
+    Precedence (lowest to highest):
+    1. Settings defaults
+    2. resource-limits.yaml group limits
+    """
+    concurrent = settings.default_concurrent_limit
+    daily = settings.default_daily_limit
+
+    data = load_resource_limits(settings.resource_limits_path)
+    groups = data.get("groups", {})
+    users = data.get("users", {})
+
+    group_name = users.get(username)
+    if group_name and group_name in groups:
+        group_cfg = groups[group_name]
+        concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
+        daily = group_cfg.get("max_daily_submissions", daily)
+
+    return concurrent, daily
+
+
+async def get_user_job_counts(db: aiosqlite.Connection, username: str) -> tuple[int, int]:
+    """Return (concurrent_active_count, daily_submission_count) for a user."""
+    # Concurrent: jobs in active statuses
+    placeholders = ",".join("?" for _ in ACTIVE_STATUSES)
+    cursor = await db.execute(
+        f"SELECT COUNT(*) FROM jobs WHERE username = ? AND status IN ({placeholders})",
+        (username, *ACTIVE_STATUSES),
+    )
+    row = await cursor.fetchone()
+    concurrent = row[0] if row else 0
+
+    # Daily: jobs created since midnight UTC today
+    midnight = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM jobs WHERE username = ? AND created_at >= ?",
+        (username, midnight),
+    )
+    row = await cursor.fetchone()
+    daily = row[0] if row else 0
+
+    return concurrent, daily
+
+
+async def check_rate_limits(
+    db: aiosqlite.Connection, username: str, settings: Settings
+) -> tuple[int, int, int, int]:
+    """Check both rate limits and raise HTTPException(429) if exceeded.
+
+    Returns (concurrent_count, concurrent_limit, daily_count, daily_limit) on success.
+    """
+    concurrent_limit, daily_limit = get_user_limits(username, settings)
+    concurrent_count, daily_count = await get_user_job_counts(db, username)
+
+    # Check concurrent limit first
+    if concurrent_count >= concurrent_limit:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "error": {
+                    "type": "rate_limit_error",
+                    "limit_type": "concurrent",
+                    "message": (
+                        f"Concurrent job limit reached ({concurrent_count}/{concurrent_limit})"
+                    ),
+                    "limit": concurrent_limit,
+                    "current": concurrent_count,
+                    "retry_after": None,
+                }
+            },
+        )
+
+    # Check daily limit
+    if daily_count >= daily_limit:
+        # Calculate seconds until midnight UTC
+        now = datetime.now(UTC)
+        midnight_tomorrow = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
+            days=1
+        )
+        retry_after = int((midnight_tomorrow - now).total_seconds())
+
+        raise HTTPException(
+            status_code=429,
+            headers={"Retry-After": str(retry_after)},
+            detail={
+                "error": {
+                    "type": "rate_limit_error",
+                    "limit_type": "daily",
+                    "message": f"Daily submission limit reached ({daily_count}/{daily_limit})",
+                    "limit": daily_limit,
+                    "current": daily_count,
+                    "retry_after": retry_after,
+                }
+            },
+        )
+
+    return concurrent_count, concurrent_limit, daily_count, daily_limit

--- a/src/ds01_jobs/scanner.py
+++ b/src/ds01_jobs/scanner.py
@@ -1,0 +1,153 @@
+"""Dockerfile static analysis for ds01-jobs.
+
+Scans Dockerfile content for disallowed base images, dangerous ENV directives,
+and insecure USER directives. Returns structured violations with line numbers.
+"""
+
+import re
+from dataclasses import dataclass
+
+_FROM_RE = re.compile(
+    r"^\s*FROM\s+"
+    r"(?:--platform=\S+\s+)?"  # optional --platform flag
+    r"(\S+)"  # image reference (group 1)
+    r"(?:\s+AS\s+\S+)?",  # optional AS name
+    re.IGNORECASE,
+)
+_ENV_RE = re.compile(
+    r"^\s*ENV\s+(\w+)",  # ENV KEY (group 1 = key name)
+    re.IGNORECASE,
+)
+_USER_RE = re.compile(
+    r"^\s*USER\s+(\S+)",  # USER name (group 1)
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class ScanViolation:
+    """A single violation found during Dockerfile scanning."""
+
+    line: int  # 1-based line number
+    severity: str  # "error", "warning", "info"
+    rule: str  # machine-readable rule ID
+    message: str  # human-readable explanation
+
+
+def _normalise_image_ref(image: str) -> str:
+    """Normalise a Docker image reference to fully qualified form.
+
+    Strips tags and digests, then prepends registry prefix:
+    - bare name (no /) -> docker.io/library/
+    - user name (no . in first segment) -> docker.io/
+    - otherwise use as-is
+    """
+    # Strip tag (:...) and digest (@...) for prefix matching
+    name = image.split(":")[0].split("@")[0]
+    if name == "scratch":
+        return "scratch"
+    if "/" not in name:
+        return f"docker.io/library/{name}"
+    if "." not in name.split("/")[0]:
+        return f"docker.io/{name}"
+    return name
+
+
+def scan_dockerfile(
+    content: str,
+    allowed_registries: list[str],
+    blocked_env_keys: list[str],
+    warning_env_keys: list[str],
+) -> list[ScanViolation]:
+    """Scan Dockerfile content and return a list of violations.
+
+    Args:
+        content: Raw Dockerfile text.
+        allowed_registries: Registry prefixes that are permitted (e.g. "docker.io/library/").
+        blocked_env_keys: ENV key names that produce errors in the final stage.
+        warning_env_keys: ENV key names that produce warnings in the final stage.
+
+    Returns:
+        List of ScanViolation instances, possibly empty.
+    """
+    violations: list[ScanViolation] = []
+    lines = content.splitlines()
+
+    # First pass: find all FROM line indices to identify the final stage
+    from_indices: list[int] = []
+    for i, line in enumerate(lines):
+        if _FROM_RE.match(line):
+            from_indices.append(i)
+
+    last_from = from_indices[-1] if from_indices else 0
+
+    for i, line in enumerate(lines):
+        lineno = i + 1  # 1-based
+
+        # Check FROM directives (all stages)
+        m = _FROM_RE.match(line)
+        if m:
+            image = m.group(1)
+            # Unresolved build args - can't statically verify
+            if "${" in image:
+                violations.append(
+                    ScanViolation(
+                        line=lineno,
+                        severity="info",
+                        rule="UNRESOLVED_BUILD_ARG",
+                        message=f"Base image '{image}' contains unresolved build arg"
+                        " - cannot statically verify",
+                    )
+                )
+                continue
+
+            normalised = _normalise_image_ref(image)
+            if normalised != "scratch":
+                if not any(normalised.startswith(reg) for reg in allowed_registries):
+                    violations.append(
+                        ScanViolation(
+                            line=lineno,
+                            severity="error",
+                            rule="BLOCKED_BASE_IMAGE",
+                            message=f"Base image '{image}' not in allowed registries",
+                        )
+                    )
+            continue
+
+        # ENV and USER checks only in final stage
+        if i >= last_from:
+            m = _ENV_RE.match(line)
+            if m:
+                key = m.group(1)
+                if key in blocked_env_keys:
+                    violations.append(
+                        ScanViolation(
+                            line=lineno,
+                            severity="error",
+                            rule="BLOCKED_ENV",
+                            message=f"ENV {key} is not allowed (security risk)",
+                        )
+                    )
+                elif key in warning_env_keys:
+                    violations.append(
+                        ScanViolation(
+                            line=lineno,
+                            severity="warning",
+                            rule="SUSPICIOUS_ENV",
+                            message=f"ENV {key} may pose a security risk",
+                        )
+                    )
+                continue
+
+            m = _USER_RE.match(line)
+            if m and m.group(1) == "root":
+                violations.append(
+                    ScanViolation(
+                        line=lineno,
+                        severity="warning",
+                        rule="USER_ROOT",
+                        message="Running as root - cgroup constraints apply regardless",
+                    )
+                )
+
+    return violations

--- a/src/ds01_jobs/url_validation.py
+++ b/src/ds01_jobs/url_validation.py
@@ -1,0 +1,86 @@
+"""GitHub URL validation and SSRF prevention for ds01-jobs.
+
+Validates that repository URLs point to GitHub, checks for SSRF via DNS resolution,
+and verifies repository accessibility with a pre-flight HEAD request.
+"""
+
+import asyncio
+import ipaddress
+import re
+import socket
+
+import httpx
+
+GITHUB_URL_RE = re.compile(
+    r"^https://github\.com/"
+    r"(?P<owner>[a-zA-Z0-9\-_.]+)/"
+    r"(?P<repo>[a-zA-Z0-9\-_.]+?)"
+    r"(?:\.git)?/?$"
+)
+
+
+def validate_repo_url_format(url: str, allowed_orgs: list[str]) -> tuple[str, str]:
+    """Validate URL format and return (owner, repo).
+
+    Args:
+        url: The repository URL to validate.
+        allowed_orgs: List of permitted GitHub organisations. Empty means any org allowed.
+
+    Returns:
+        Tuple of (owner, repo) extracted from the URL.
+
+    Raises:
+        ValueError: If the URL is not a valid GitHub repository URL or org is not allowed.
+    """
+    m = GITHUB_URL_RE.match(url.strip())
+    if not m:
+        raise ValueError("Must be a valid GitHub repository URL (https://github.com/owner/repo)")
+
+    owner, repo = m.group("owner"), m.group("repo")
+
+    if allowed_orgs and owner not in allowed_orgs:
+        raise ValueError("Only GitHub repository URLs are supported")
+
+    return owner, repo
+
+
+async def check_ssrf(hostname: str) -> None:
+    """Resolve hostname and verify all IPs are public.
+
+    Args:
+        hostname: The hostname to resolve and check.
+
+    Raises:
+        ValueError: If any resolved IP is private, loopback, reserved, or link-local.
+    """
+    try:
+        addrs = await asyncio.to_thread(socket.getaddrinfo, hostname, 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise ValueError("Only GitHub repository URLs are supported")
+
+    for _family, _type, _proto, _canonname, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
+            raise ValueError("Only GitHub repository URLs are supported")
+
+
+async def verify_repo_accessible(url: str, timeout: float = 5.0) -> None:
+    """Send a HEAD request to verify the repository exists.
+
+    Args:
+        url: The GitHub repository URL.
+        timeout: Request timeout in seconds.
+
+    Raises:
+        ValueError: If the repository is not found or request fails.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.head(url, timeout=timeout, follow_redirects=False)
+    except (httpx.TimeoutException, httpx.ConnectError):
+        raise ValueError("Only GitHub repository URLs are supported")
+
+    if resp.status_code == 404:
+        raise ValueError("Repository not found")
+    if resp.status_code >= 400:
+        raise ValueError("Only GitHub repository URLs are supported")

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,0 +1,417 @@
+"""Tests for ds01_jobs.jobs module - POST /api/v1/jobs endpoint."""
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import aiosqlite
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import get_db, init_db
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash."""
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request."""
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+) -> None:
+    """Insert a test API key into the database."""
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+        )
+        await db.commit()
+
+
+async def _insert_job(
+    db_path: Path,
+    username: str = "testuser",
+    status: str = "queued",
+    created_at: str | None = None,
+) -> None:
+    """Insert a test job row directly into the database."""
+    now = created_at or datetime.now(UTC).isoformat()
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()),
+                username,
+                "https://github.com/test/repo",
+                "main",
+                1,
+                "test-job",
+                status,
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+
+
+def _make_app(db_path: Path):
+    """Create a test app with jobs router and mocked external calls."""
+    from ds01_jobs.app import create_app
+    from ds01_jobs.jobs import _get_settings
+
+    app = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    def _override_settings():
+        from ds01_jobs.config import Settings
+
+        return Settings(_env_file=None)
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[_get_settings] = _override_settings
+
+    return app
+
+
+def _build_headers(raw_key: str, body_dict: dict) -> dict[str, str]:  # type: ignore[type-arg]
+    """Build auth + signing headers for a POST /api/v1/jobs request."""
+    body_bytes = json.dumps(body_dict).encode()
+    headers = _sign_request(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    headers["Authorization"] = f"Bearer {raw_key}"
+    headers["Content-Type"] = "application/json"
+    return headers
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_success(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """Valid auth + valid repo_url returns 202 with job record in DB."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert "job_id" in data
+    assert data["status"] == "queued"
+    assert data["status_url"].startswith("/api/v1/jobs/")
+    assert "created_at" in data
+
+    # Verify job in DB
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT * FROM jobs WHERE id = ?", (data["job_id"],))
+        row = await cursor.fetchone()
+        assert row is not None
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_invalid_url(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """Bad URL returns 422 with Stripe-like error body."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://evil.com/hacked"}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data["error"]["type"] == "validation_error"
+    assert data["error"]["errors"][0]["field"] == "repo_url"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_with_dockerfile_scan_error(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """Dockerfile with blocked base image returns 422 with dockerfile_scan_error."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {
+        "repo_url": "https://github.com/testorg/myrepo",
+        "dockerfile_content": "FROM evil.registry.io/hacker/image:latest\nRUN echo hi",
+    }
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data["error"]["type"] == "dockerfile_scan_error"
+    assert len(data["error"]["errors"]) > 0
+    assert data["error"]["errors"][0]["code"] == "BLOCKED_BASE_IMAGE"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_with_clean_dockerfile(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """Valid Dockerfile returns 202 (scan passes)."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {
+        "repo_url": "https://github.com/testorg/myrepo",
+        "dockerfile_content": "FROM python:3.13-slim\nRUN pip install torch",
+    }
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_concurrent_limit_exceeded(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """User at concurrent limit gets 429 with limit_type='concurrent'."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    # Insert 3 active jobs (default concurrent limit)
+    for _ in range(3):
+        await _insert_job(db_path, status="queued")
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 429
+    data = resp.json()
+    assert data["detail"]["error"]["limit_type"] == "concurrent"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_daily_limit_exceeded(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """User at daily limit gets 429 with limit_type='daily'."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    # Insert 10 completed jobs today (default daily limit)
+    for _ in range(10):
+        await _insert_job(db_path, status="succeeded")
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 429
+    data = resp.json()
+    assert data["detail"]["error"]["limit_type"] == "daily"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_rate_limit_headers_on_success(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """Successful 202 includes X-RateLimit-* headers."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 202
+    assert "x-ratelimit-limit-concurrent" in resp.headers
+    assert "x-ratelimit-remaining-concurrent" in resp.headers
+    assert "x-ratelimit-limit-daily" in resp.headers
+    assert "x-ratelimit-remaining-daily" in resp.headers
+    assert "x-ratelimit-reset-daily" in resp.headers
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_auto_generated_job_name(
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+) -> None:
+    """Omitting job_name auto-generates from repo name + short ID."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 202
+    data = resp.json()
+    job_id = data["job_id"]
+
+    # Verify auto-generated name in DB
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT job_name FROM jobs WHERE id = ?", (job_id,))
+        row = await cursor.fetchone()
+        assert row is not None
+        name = row[0]
+        assert name.startswith("myrepo-")
+        assert job_id[:8] in name
+
+
+@pytest.mark.asyncio
+async def test_submit_job_unauthenticated(tmp_path: Path) -> None:
+    """No auth headers returns 401 or 403."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    app = _make_app(db_path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/jobs",
+            json={"repo_url": "https://github.com/testorg/myrepo"},
+        )
+
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_job_repo_not_found(mock_ssrf: AsyncMock, tmp_path: Path) -> None:
+    """verify_repo_accessible raising ValueError returns 422 with repo_not_found."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    headers = _build_headers(raw_key, body)
+
+    with patch(
+        "ds01_jobs.jobs.verify_repo_accessible",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Repository not found"),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data["error"]["errors"][0]["code"] == "repo_not_found"

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,258 @@
+"""Tests for ds01_jobs.rate_limit module - per-user rate limiting."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from ds01_jobs.config import Settings
+from ds01_jobs.database import init_db
+from ds01_jobs.rate_limit import check_rate_limits, get_user_job_counts, get_user_limits
+
+
+def _test_settings(**overrides: object) -> Settings:
+    """Create a Settings instance isolated from .env files."""
+    return Settings(_env_file=None, **overrides)  # type: ignore[call-arg]
+
+
+async def _insert_job(
+    db: aiosqlite.Connection,
+    username: str = "testuser",
+    status: str = "queued",
+    created_at: str | None = None,
+) -> None:
+    """Insert a test job row."""
+    import uuid
+
+    now = created_at or datetime.now(UTC).isoformat()
+    await db.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+        "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            str(uuid.uuid4()),
+            username,
+            "https://github.com/test/repo",
+            "main",
+            1,
+            "test-job",
+            status,
+            now,
+            now,
+        ),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_user_limits_defaults() -> None:
+    """No resource-limits.yaml returns settings defaults (3, 10)."""
+    settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
+    concurrent, daily = get_user_limits("someuser", settings)
+    assert concurrent == 3
+    assert daily == 10
+
+
+@pytest.mark.asyncio
+async def test_get_user_limits_from_yaml(tmp_path: Path) -> None:
+    """User mapped to student group gets group limits (2, 5)."""
+    yaml_path = tmp_path / "resource-limits.yaml"
+    yaml_path.write_text(
+        "groups:\n"
+        "  student:\n"
+        "    max_concurrent_jobs: 2\n"
+        "    max_daily_submissions: 5\n"
+        "  researcher:\n"
+        "    max_concurrent_jobs: 5\n"
+        "    max_daily_submissions: 20\n"
+        "users:\n"
+        "  alice: researcher\n"
+        "  bob: student\n"
+    )
+    settings = _test_settings(resource_limits_path=yaml_path)
+    concurrent, daily = get_user_limits("bob", settings)
+    assert concurrent == 2
+    assert daily == 5
+
+    concurrent, daily = get_user_limits("alice", settings)
+    assert concurrent == 5
+    assert daily == 20
+
+
+@pytest.mark.asyncio
+async def test_get_user_limits_user_not_in_yaml(tmp_path: Path) -> None:
+    """User not listed in YAML users section falls back to defaults."""
+    yaml_path = tmp_path / "resource-limits.yaml"
+    yaml_path.write_text(
+        "groups:\n"
+        "  student:\n"
+        "    max_concurrent_jobs: 2\n"
+        "    max_daily_submissions: 5\n"
+        "users:\n"
+        "  bob: student\n"
+    )
+    settings = _test_settings(resource_limits_path=yaml_path)
+    concurrent, daily = get_user_limits("unknown_user", settings)
+    assert concurrent == 3
+    assert daily == 10
+
+
+@pytest.mark.asyncio
+async def test_get_user_job_counts_no_jobs(tmp_path: Path) -> None:
+    """Empty jobs table returns (0, 0)."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    async with aiosqlite.connect(db_path) as db:
+        concurrent, daily = await get_user_job_counts(db, "testuser")
+
+    assert concurrent == 0
+    assert daily == 0
+
+
+@pytest.mark.asyncio
+async def test_get_user_job_counts_with_active_jobs(tmp_path: Path) -> None:
+    """2 active jobs + 1 succeeded -> concurrent = 2."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    async with aiosqlite.connect(db_path) as db:
+        await _insert_job(db, status="queued")
+        await _insert_job(db, status="running")
+        await _insert_job(db, status="succeeded")
+
+        concurrent, _daily = await get_user_job_counts(db, "testuser")
+
+    assert concurrent == 2
+
+
+@pytest.mark.asyncio
+async def test_get_user_job_counts_daily_count(tmp_path: Path) -> None:
+    """3 jobs today, 2 yesterday -> daily = 3."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    now = datetime.now(UTC)
+    yesterday = (now - timedelta(days=1)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        # 3 jobs today
+        await _insert_job(db, status="queued")
+        await _insert_job(db, status="running")
+        await _insert_job(db, status="succeeded")
+        # 2 jobs yesterday
+        await _insert_job(db, status="succeeded", created_at=yesterday)
+        await _insert_job(db, status="succeeded", created_at=yesterday)
+
+        _concurrent, daily = await get_user_job_counts(db, "testuser")
+
+    assert daily == 3
+
+
+@pytest.mark.asyncio
+async def test_check_rate_limits_passes(tmp_path: Path) -> None:
+    """Under both limits returns counts without raising."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+    settings = _test_settings(
+        resource_limits_path=Path("/nonexistent"),
+        default_concurrent_limit=3,
+        default_daily_limit=10,
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        await _insert_job(db, status="queued")
+        result = await check_rate_limits(db, "testuser", settings)
+
+    concurrent_count, concurrent_limit, daily_count, daily_limit = result
+    assert concurrent_count == 1
+    assert concurrent_limit == 3
+    assert daily_count == 1
+    assert daily_limit == 10
+
+
+@pytest.mark.asyncio
+async def test_check_rate_limits_concurrent_exceeded(tmp_path: Path) -> None:
+    """At concurrent limit raises 429 with limit_type='concurrent'."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+    settings = _test_settings(
+        resource_limits_path=Path("/nonexistent"),
+        default_concurrent_limit=2,
+        default_daily_limit=10,
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        await _insert_job(db, status="queued")
+        await _insert_job(db, status="running")
+
+        with pytest.raises(Exception) as exc_info:
+            await check_rate_limits(db, "testuser", settings)
+
+    exc = exc_info.value
+    assert exc.status_code == 429  # type: ignore[union-attr]
+    body = exc.detail  # type: ignore[union-attr]
+    assert body["error"]["limit_type"] == "concurrent"
+    assert body["error"]["current"] == 2
+    assert body["error"]["limit"] == 2
+    assert body["error"]["retry_after"] is None
+
+
+@pytest.mark.asyncio
+async def test_check_rate_limits_daily_exceeded(tmp_path: Path) -> None:
+    """At daily limit raises 429 with limit_type='daily'."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+    settings = _test_settings(
+        resource_limits_path=Path("/nonexistent"),
+        default_concurrent_limit=10,
+        default_daily_limit=2,
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        # Insert 2 succeeded jobs (count toward daily but not concurrent)
+        await _insert_job(db, status="succeeded")
+        await _insert_job(db, status="succeeded")
+
+        with pytest.raises(Exception) as exc_info:
+            await check_rate_limits(db, "testuser", settings)
+
+    exc = exc_info.value
+    assert exc.status_code == 429  # type: ignore[union-attr]
+    body = exc.detail  # type: ignore[union-attr]
+    assert body["error"]["limit_type"] == "daily"
+    assert body["error"]["current"] == 2
+    assert body["error"]["limit"] == 2
+    assert body["error"]["retry_after"] is not None
+    assert body["error"]["retry_after"] > 0
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_429_body_structure(tmp_path: Path) -> None:
+    """Verify 429 response body matches the exact CONTEXT.md structure."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+    settings = _test_settings(
+        resource_limits_path=Path("/nonexistent"),
+        default_concurrent_limit=1,
+        default_daily_limit=10,
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        await _insert_job(db, status="queued")
+
+        with pytest.raises(Exception) as exc_info:
+            await check_rate_limits(db, "testuser", settings)
+
+    exc = exc_info.value
+    body = exc.detail  # type: ignore[union-attr]
+
+    # Verify structure: {error: {type, limit_type, message, limit, current, retry_after}}
+    assert "error" in body
+    error = body["error"]
+    assert error["type"] == "rate_limit_error"
+    assert "limit_type" in error
+    assert "message" in error
+    assert "limit" in error
+    assert "current" in error
+    assert "retry_after" in error

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -1,0 +1,157 @@
+"""Tests for ds01_jobs.scanner - Dockerfile static analysis."""
+
+from ds01_jobs.scanner import ScanViolation, scan_dockerfile
+
+# Default registries matching config defaults
+ALLOWED = [
+    "docker.io/library/",
+    "nvcr.io/nvidia/",
+    "ghcr.io/astral-sh/",
+    "docker.io/pytorch/",
+    "docker.io/tensorflow/",
+    "docker.io/huggingface/",
+]
+BLOCKED = ["LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT"]
+WARNING = ["LD_DEBUG", "PYTHONPATH"]
+
+
+def _scan(content: str) -> list[ScanViolation]:
+    return scan_dockerfile(content, ALLOWED, BLOCKED, WARNING)
+
+
+def test_approved_base_image_passes():
+    """Docker Hub official shorthand image (python:3.12-slim) produces no violations."""
+    violations = _scan("FROM python:3.12-slim\nRUN pip install torch\n")
+    assert violations == []
+
+
+def test_blocked_base_image_error():
+    """Disallowed registry produces error with correct line number."""
+    violations = _scan("FROM evil.registry.io/malware:latest\n")
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "error"
+    assert v.rule == "BLOCKED_BASE_IMAGE"
+    assert v.line == 1
+
+
+def test_nvcr_nvidia_allowed():
+    """NVIDIA Container Registry images pass validation."""
+    violations = _scan("FROM nvcr.io/nvidia/pytorch:24.01-py3\n")
+    assert violations == []
+
+
+def test_ghcr_astral_allowed():
+    """GitHub Container Registry astral-sh images pass validation."""
+    violations = _scan("FROM ghcr.io/astral-sh/uv:0.10\n")
+    assert violations == []
+
+
+def test_scratch_always_allowed():
+    """FROM scratch is always allowed (Docker built-in)."""
+    violations = _scan("FROM scratch\nCOPY --from=builder /app /app\n")
+    assert violations == []
+
+
+def test_multistage_all_from_scanned():
+    """All FROM directives are scanned for base image compliance (SCAN-01)."""
+    dockerfile = (
+        "FROM python:3.12-slim AS builder\n"
+        "RUN pip install torch\n"
+        "FROM evil.registry.io/backdoor:latest\n"
+        "COPY --from=builder /app /app\n"
+    )
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    assert violations[0].rule == "BLOCKED_BASE_IMAGE"
+    assert violations[0].line == 3
+
+
+def test_multistage_env_final_stage_only():
+    """ENV rules apply to final stage only - builder stage LD_LIBRARY_PATH is OK."""
+    dockerfile = (
+        "FROM python:3.12-slim AS builder\n"
+        "ENV LD_LIBRARY_PATH=/usr/local/lib\n"
+        "RUN make\n"
+        "FROM python:3.12-slim\n"
+        "COPY --from=builder /app /app\n"
+    )
+    violations = _scan(dockerfile)
+    # Builder stage LD_LIBRARY_PATH should NOT produce a violation
+    assert violations == []
+
+
+def test_blocked_env_ld_preload():
+    """ENV LD_PRELOAD in final stage produces error (SCAN-03)."""
+    dockerfile = "FROM python:3.12-slim\nENV LD_PRELOAD /evil.so\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "error"
+    assert v.rule == "BLOCKED_ENV"
+    assert "LD_PRELOAD" in v.message
+
+
+def test_blocked_env_ld_audit():
+    """ENV LD_AUDIT in final stage produces error."""
+    dockerfile = "FROM python:3.12-slim\nENV LD_AUDIT /evil.so\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    assert violations[0].severity == "error"
+    assert violations[0].rule == "BLOCKED_ENV"
+
+
+def test_warning_env_pythonpath():
+    """ENV PYTHONPATH in final stage produces warning, not error."""
+    dockerfile = "FROM python:3.12-slim\nENV PYTHONPATH /custom\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "warning"
+    assert v.rule == "SUSPICIOUS_ENV"
+
+
+def test_user_root_warning():
+    """USER root in final stage produces warning (SCAN-04)."""
+    dockerfile = "FROM python:3.12-slim\nUSER root\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "warning"
+    assert v.rule == "USER_ROOT"
+
+
+def test_violation_has_line_number():
+    """Violations include correct 1-based line numbers (SCAN-05)."""
+    dockerfile = "FROM python:3.12-slim\nRUN echo hello\nENV LD_PRELOAD /evil.so\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    assert violations[0].line == 3
+
+
+def test_docker_hub_user_image_normalised():
+    """User image pytorch/pytorch normalised to docker.io/pytorch/pytorch."""
+    violations = _scan("FROM pytorch/pytorch:latest\n")
+    assert violations == []
+
+
+def test_unresolved_build_arg_info():
+    """FROM with unresolved build arg produces info, not error."""
+    dockerfile = "ARG BASE_IMAGE\nFROM ${BASE_IMAGE}\n"
+    violations = _scan(dockerfile)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.severity == "info"
+    assert v.rule == "UNRESOLVED_BUILD_ARG"
+
+
+def test_from_with_platform_flag():
+    """FROM --platform=linux/amd64 is parsed correctly."""
+    violations = _scan("FROM --platform=linux/amd64 python:3.12\n")
+    assert violations == []
+
+
+def test_empty_dockerfile():
+    """Empty Dockerfile produces no violations."""
+    violations = _scan("")
+    assert violations == []

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -1,0 +1,130 @@
+"""Tests for ds01_jobs.url_validation - GitHub URL validation and SSRF prevention."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ds01_jobs.url_validation import check_ssrf, validate_repo_url_format, verify_repo_accessible
+
+# --- validate_repo_url_format ---
+
+
+def test_valid_github_url():
+    """Standard GitHub URL returns (owner, repo)."""
+    owner, repo = validate_repo_url_format("https://github.com/owner/repo", [])
+    assert owner == "owner"
+    assert repo == "repo"
+
+
+def test_valid_github_url_with_git_suffix():
+    """URL with .git suffix passes."""
+    owner, repo = validate_repo_url_format("https://github.com/owner/repo.git", [])
+    assert owner == "owner"
+    assert repo == "repo"
+
+
+def test_valid_github_url_with_trailing_slash():
+    """URL with trailing slash passes."""
+    owner, repo = validate_repo_url_format("https://github.com/owner/repo/", [])
+    assert owner == "owner"
+    assert repo == "repo"
+
+
+def test_rejects_non_github_url():
+    """Non-GitHub URL raises ValueError."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("https://gitlab.com/owner/repo", [])
+
+
+def test_rejects_http_url():
+    """HTTP (non-HTTPS) URL raises ValueError."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("http://github.com/owner/repo", [])
+
+
+def test_rejects_browser_url_with_extra_path():
+    """Browser URLs with extra path segments are rejected."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("https://github.com/owner/repo/tree/main", [])
+
+
+def test_rejects_private_ip_url():
+    """URL with private IP instead of github.com is rejected."""
+    with pytest.raises(ValueError, match="Must be a valid GitHub repository URL"):
+        validate_repo_url_format("https://192.168.1.1/owner/repo", [])
+
+
+def test_org_restriction_allowed():
+    """With allowed_orgs set, matching org passes."""
+    owner, repo = validate_repo_url_format("https://github.com/myorg/repo", ["myorg"])
+    assert owner == "myorg"
+    assert repo == "repo"
+
+
+def test_org_restriction_blocked():
+    """With allowed_orgs set, non-matching org raises generic error."""
+    with pytest.raises(ValueError, match="Only GitHub repository URLs are supported"):
+        validate_repo_url_format("https://github.com/other/repo", ["myorg"])
+
+
+def test_org_restriction_empty_allows_all():
+    """With empty allowed_orgs, any org passes."""
+    owner, repo = validate_repo_url_format("https://github.com/anyorg/repo", [])
+    assert owner == "anyorg"
+    assert repo == "repo"
+
+
+# --- check_ssrf ---
+
+
+@pytest.mark.asyncio
+async def test_check_ssrf_private_ip():
+    """Private IP resolution raises ValueError."""
+    fake_addrs = [(2, 1, 6, "", ("127.0.0.1", 443))]
+    with patch("ds01_jobs.url_validation.socket.getaddrinfo", return_value=fake_addrs):
+        with pytest.raises(ValueError, match="Only GitHub repository URLs are supported"):
+            await check_ssrf("evil.example.com")
+
+
+@pytest.mark.asyncio
+async def test_check_ssrf_public_ip():
+    """Public IP resolution does not raise."""
+    fake_addrs = [(2, 1, 6, "", ("140.82.121.4", 443))]
+    with patch("ds01_jobs.url_validation.socket.getaddrinfo", return_value=fake_addrs):
+        await check_ssrf("github.com")  # Should not raise
+
+
+# --- verify_repo_accessible ---
+
+
+@pytest.mark.asyncio
+async def test_verify_repo_accessible_success():
+    """200 response means repository exists."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+
+    with patch("ds01_jobs.url_validation.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.head = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await verify_repo_accessible("https://github.com/owner/repo")
+
+
+@pytest.mark.asyncio
+async def test_verify_repo_accessible_not_found():
+    """404 response raises ValueError('Repository not found')."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 404
+
+    with patch("ds01_jobs.url_validation.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.head = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(ValueError, match="Repository not found"):
+            await verify_repo_accessible("https://github.com/owner/nonexistent")


### PR DESCRIPTION
## Summary

- Create per-user rate limiter with concurrent and daily limits, configurable via resource-limits.yaml groups
- Create POST /api/v1/jobs endpoint orchestrating validation pipeline: URL format → rate limits → SSRF → pre-flight → Dockerfile scan → insert → 202 Accepted
- Rate limit headers (X-RateLimit-Limit/Remaining-Concurrent/Daily, X-RateLimit-Reset-Daily) on all 202 responses
- Auto-generated job names from repo name + short UUID when not provided
- 429 responses with structured body (limit_type, current, limit, retry_after)

**Depends on:** #16

## Test plan

- [x] 102 unit tests pass (`uv run pytest tests/unit/ -v`)
- [ ] CI passes (ruff, mypy, pytest)
- [ ] Review validation pipeline ordering (cheapest checks first)
- [ ] Review rate limit header calculation
- [ ] Confirm 429 response body matches API contract