### PR TITLE
feat: add runner schema extensions, config, and GPU module

### DIFF
--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -45,3 +45,12 @@ class Settings(BaseSettings):
     # URL validation
     allowed_github_orgs: list[str] = []
     preflight_timeout_seconds: float = 5.0
+
+    # Runner
+    runner_poll_interval: float = 5.0
+    build_timeout_seconds: float = 900.0  # 15 minutes
+    clone_timeout_seconds: float = 120.0  # 2 minutes
+    default_job_timeout_seconds: float = 14400.0  # 4 hours
+    max_job_timeout_seconds: float = 86400.0  # 24 hours hard ceiling
+    workspace_root: Path = Path("/var/lib/ds01-jobs/workspaces")
+    docker_bin: Path = Path("/usr/local/bin/docker")

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -39,11 +39,19 @@ CREATE TABLE IF NOT EXISTS jobs (
     status TEXT NOT NULL DEFAULT 'queued',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
+    failed_phase TEXT,
+    exit_code INTEGER,
+    error_summary TEXT,
+    started_at TEXT,
+    completed_at TEXT,
     FOREIGN KEY (username) REFERENCES api_keys(username)
 );
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
 CREATE INDEX IF NOT EXISTS idx_jobs_username_status ON jobs(username, status);
 CREATE INDEX IF NOT EXISTS idx_jobs_username_created ON jobs(username, created_at);
 """
+# Note: Schema uses CREATE TABLE IF NOT EXISTS. For pre-v1 development,
+# drop and recreate the DB if columns are missing after schema changes.
 
 
 @lru_cache(maxsize=1)

--- a/src/ds01_jobs/gpu.py
+++ b/src/ds01_jobs/gpu.py
@@ -1,0 +1,67 @@
+"""GPU availability checking via nvidia-smi.
+
+Queries nvidia-smi to determine how many GPUs are currently idle
+(less than 100 MiB memory used). Returns 0 gracefully when
+nvidia-smi is unavailable (e.g. in CI or on non-GPU machines).
+"""
+
+import asyncio
+
+IDLE_MEMORY_THRESHOLD_MIB = 100
+
+
+async def get_available_gpu_count() -> int:
+    """Return the number of idle GPUs based on nvidia-smi memory usage.
+
+    A GPU is considered idle if its memory usage is below
+    IDLE_MEMORY_THRESHOLD_MIB. Returns 0 if nvidia-smi is not
+    available or exits with a non-zero code.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "nvidia-smi",
+            "--query-gpu=index,memory.used",
+            "--format=csv,noheader,nounits",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+    except FileNotFoundError:
+        return 0
+
+    if proc.returncode != 0:
+        return 0
+
+    idle = 0
+    for line in stdout.decode().strip().splitlines():
+        parts = line.split(",")
+        if len(parts) == 2:
+            memory_used = float(parts[1].strip())
+            if memory_used < IDLE_MEMORY_THRESHOLD_MIB:
+                idle += 1
+    return idle
+
+
+async def get_gpu_count() -> int:
+    """Return total GPU count (not just available).
+
+    Used for validation (e.g. rejecting gpu_count > total).
+    Returns 0 if nvidia-smi is unavailable.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "nvidia-smi",
+            "--query-gpu=index,memory.used",
+            "--format=csv,noheader,nounits",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+    except FileNotFoundError:
+        return 0
+
+    if proc.returncode != 0:
+        return 0
+
+    lines = [line for line in stdout.decode().strip().splitlines() if line.strip()]
+    return len(lines)

--- a/tests/unit/test_gpu.py
+++ b/tests/unit/test_gpu.py
@@ -1,0 +1,81 @@
+"""Unit tests for GPU availability module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ds01_jobs.gpu import get_available_gpu_count, get_gpu_count
+
+
+def _make_process_mock(stdout: bytes, returncode: int = 0) -> AsyncMock:
+    """Create a mock subprocess with given stdout and return code."""
+    proc = AsyncMock()
+    proc.communicate.return_value = (stdout, b"")
+    proc.returncode = returncode
+    return proc
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_all_idle(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 0\n1, 0\n2, 0\n3, 0\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_available_gpu_count()
+
+    assert count == 4
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_some_busy(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 0\n1, 5000\n2, 0\n3, 5000\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_available_gpu_count()
+
+    assert count == 2
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_all_busy(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 8000\n1, 5000\n2, 12000\n3, 9000\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_available_gpu_count()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_nvidia_smi_fails(mock_exec: AsyncMock) -> None:
+    mock_exec.return_value = _make_process_mock(b"", returncode=1)
+
+    count = await get_available_gpu_count()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_nvidia_smi_not_found(
+    mock_exec: AsyncMock,
+) -> None:
+    mock_exec.side_effect = FileNotFoundError("nvidia-smi not found")
+
+    count = await get_available_gpu_count()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_gpu_count_returns_total(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 0\n1, 5000\n2, 0\n3, 8000\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_gpu_count()
+
+    assert count == 4


### PR DESCRIPTION
## Summary

- Extend jobs table with 5 runner-tracking columns (`failed_phase`, `exit_code`, `error_summary`, `started_at`, `completed_at`) and a status index for efficient polling
- Add 7 runner settings to `Settings` (poll interval, build/clone/job timeouts, workspace root, docker binary path)
- Create `gpu.py` module — async `get_available_gpu_count()` and `get_gpu_count()` via nvidia-smi, returning 0 gracefully when unavailable

## Test plan

- [x] 6 unit tests for GPU module (all-idle, some-busy, all-busy, nvidia-smi failure, not found, total count)
- [x] Config fields load with defaults and are overridable via `DS01_JOBS_*` env vars
- [x] Schema includes new columns and index
- [x] `ruff check` and `mypy` pass

**PR 1 of 3** for Phase 4 (Job Runner). Next: executor (PR 2), runner + cancel (PR 3).