### PR TITLE
feat: add runner poll loop, cancel endpoint, and CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.scripts]
 ds01-job-admin = "ds01_jobs.cli:app"
+ds01-job-runner = "ds01_jobs.runner:cli_main"
 
 [build-system]
 requires = ["uv_build>=0.10.8,<0.11.0"]

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -45,3 +45,12 @@ class Settings(BaseSettings):
     # URL validation
     allowed_github_orgs: list[str] = []
     preflight_timeout_seconds: float = 5.0
+
+    # Runner
+    runner_poll_interval: float = 5.0
+    build_timeout_seconds: float = 900.0  # 15 minutes
+    clone_timeout_seconds: float = 120.0  # 2 minutes
+    default_job_timeout_seconds: float = 14400.0  # 4 hours
+    max_job_timeout_seconds: float = 86400.0  # 24 hours hard ceiling
+    workspace_root: Path = Path("/var/lib/ds01-jobs/workspaces")
+    docker_bin: Path = Path("/usr/local/bin/docker")

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -39,11 +39,19 @@ CREATE TABLE IF NOT EXISTS jobs (
     status TEXT NOT NULL DEFAULT 'queued',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
+    failed_phase TEXT,
+    exit_code INTEGER,
+    error_summary TEXT,
+    started_at TEXT,
+    completed_at TEXT,
     FOREIGN KEY (username) REFERENCES api_keys(username)
 );
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
 CREATE INDEX IF NOT EXISTS idx_jobs_username_status ON jobs(username, status);
 CREATE INDEX IF NOT EXISTS idx_jobs_username_created ON jobs(username, created_at);
 """
+# Note: Schema uses CREATE TABLE IF NOT EXISTS. For pre-v1 development,
+# drop and recreate the DB if columns are missing after schema changes.
 
 
 @lru_cache(maxsize=1)

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -1,0 +1,392 @@
+"""Job executor - runs a single job through clone, build, run, collect, cleanup."""
+
+import asyncio
+import logging
+import os
+import signal
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+
+from ds01_jobs.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class PhaseError(Exception):
+    """A job phase (clone/build/run) failed with a non-zero exit code."""
+
+    def __init__(self, phase: str, exit_code: int, summary: str) -> None:
+        self.phase = phase
+        self.exit_code = exit_code
+        self.summary = summary
+        super().__init__(summary)
+
+
+class PhaseTimeoutError(PhaseError):
+    """A job phase exceeded its timeout and was killed."""
+
+    def __init__(self, phase: str, timeout: float) -> None:
+        super().__init__(phase, -1, f"{phase} timed out after {timeout:.0f}s")
+        self.timeout = timeout
+
+
+class JobExecutor:
+    """Executes a single job through the clone -> build -> run pipeline."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._current_process: asyncio.subprocess.Process | None = None
+
+    async def execute(
+        self,
+        job_id: str,
+        repo_url: str,
+        branch: str,
+        gpu_count: int,
+        timeout_seconds: int | None,
+        db_path: Path,
+    ) -> None:
+        """Run a job through the full execution pipeline.
+
+        Args:
+            job_id: Unique job identifier.
+            repo_url: Git repository URL to clone.
+            branch: Git branch to check out.
+            gpu_count: Number of GPUs requested.
+            timeout_seconds: Job run timeout (None = use default).
+            db_path: Path to the SQLite database.
+        """
+        workspace = self.settings.workspace_root / job_id
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # Set started_at
+            async with aiosqlite.connect(db_path) as db:
+                now = datetime.now(UTC).isoformat()
+                await db.execute(
+                    "UPDATE jobs SET started_at=?, updated_at=? WHERE id=?",
+                    (now, now, job_id),
+                )
+                await db.commit()
+
+            await self._clone(job_id, repo_url, branch, workspace, db_path)
+            await self._build(job_id, workspace, db_path)
+            await self._run_container(job_id, workspace, gpu_count, timeout_seconds, db_path)
+            await self._collect_results(job_id, workspace)
+
+            # Success
+            await self._update_status(db_path, job_id, "succeeded")
+            logger.info("Job %s succeeded", job_id)
+
+        except PhaseError as exc:
+            logger.error("Job %s failed in %s: %s", job_id, exc.phase, exc.summary)
+            await self._update_status(
+                db_path,
+                job_id,
+                "failed",
+                failed_phase=exc.phase,
+                exit_code=exc.exit_code,
+                error_summary=exc.summary,
+            )
+        except Exception:
+            logger.exception("Job %s failed with unexpected error", job_id)
+            await self._update_status(
+                db_path,
+                job_id,
+                "failed",
+                error_summary="Unexpected executor error",
+            )
+        finally:
+            await self._cleanup(job_id)
+
+    async def _update_status(
+        self,
+        db_path: Path,
+        job_id: str,
+        status: str,
+        *,
+        failed_phase: str | None = None,
+        exit_code: int | None = None,
+        error_summary: str | None = None,
+    ) -> None:
+        """Atomically update job status in SQLite."""
+        now = datetime.now(UTC).isoformat()
+        async with aiosqlite.connect(db_path) as db:
+            if status in ("succeeded", "failed"):
+                await db.execute(
+                    "UPDATE jobs SET status=?, updated_at=?, completed_at=?, "
+                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
+                    (status, now, now, failed_phase, exit_code, error_summary, job_id),
+                )
+            elif status == "cloning":
+                await db.execute(
+                    "UPDATE jobs SET status=?, updated_at=?, started_at=?, "
+                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
+                    (status, now, now, failed_phase, exit_code, error_summary, job_id),
+                )
+            else:
+                await db.execute(
+                    "UPDATE jobs SET status=?, updated_at=?, "
+                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
+                    (status, now, failed_phase, exit_code, error_summary, job_id),
+                )
+            await db.commit()
+
+    async def _check_cancelled(self, db_path: Path, job_id: str) -> bool:
+        """Check if the job has been cancelled (status set to failed externally)."""
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("SELECT status FROM jobs WHERE id=?", (job_id,))
+            row = await cursor.fetchone()
+            if row and row[0] == "failed":
+                return True
+        return False
+
+    async def _run_phase(
+        self,
+        job_id: str,
+        cmd: list[str],
+        log_path: Path,
+        timeout: float,
+    ) -> int:
+        """Execute a subprocess phase with process group isolation and timeout.
+
+        Args:
+            job_id: Job identifier (for logging).
+            cmd: Command and arguments to execute.
+            log_path: Path to write stdout/stderr.
+            timeout: Maximum seconds before killing the process group.
+
+        Returns:
+            The subprocess return code.
+
+        Raises:
+            PhaseTimeoutError: If the process exceeds the timeout.
+        """
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("w") as log_file:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=log_file,
+                stderr=asyncio.subprocess.STDOUT,
+                process_group=0,
+            )
+            self._current_process = proc
+            try:
+                returncode = await asyncio.wait_for(proc.wait(), timeout=timeout)
+                return returncode
+            except asyncio.TimeoutError:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                await proc.wait()
+                raise
+            finally:
+                self._current_process = None
+
+    async def _clone(
+        self,
+        job_id: str,
+        repo_url: str,
+        branch: str,
+        workspace: Path,
+        db_path: Path,
+    ) -> None:
+        """Clone repository with shallow depth, retrying once on failure."""
+        await self._update_status(db_path, job_id, "cloning")
+
+        cmd = [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            repo_url,
+            str(workspace / "repo"),
+        ]
+        log_path = workspace / "clone.log"
+
+        exit_code = await self._run_phase(
+            job_id, cmd, log_path, self.settings.clone_timeout_seconds
+        )
+
+        if exit_code != 0:
+            logger.warning("Job %s clone failed (exit %d), retrying in 10s", job_id, exit_code)
+            await asyncio.sleep(10)
+            exit_code = await self._run_phase(
+                job_id, cmd, log_path, self.settings.clone_timeout_seconds
+            )
+            if exit_code != 0:
+                raise PhaseError("clone", exit_code, "Clone failed after retry")
+
+    async def _build(self, job_id: str, workspace: Path, db_path: Path) -> None:
+        """Build Docker image from the repo Dockerfile."""
+        if await self._check_cancelled(db_path, job_id):
+            raise PhaseError("build", -1, "Job cancelled before build")
+
+        await self._update_status(db_path, job_id, "building")
+
+        image_tag = f"ds01-job-{job_id}"
+        cmd = [
+            str(self.settings.docker_bin),
+            "build",
+            "-t",
+            image_tag,
+            "-f",
+            str(workspace / "repo" / "Dockerfile"),
+            str(workspace / "repo"),
+        ]
+        log_path = workspace / "build.log"
+
+        try:
+            exit_code = await self._run_phase(
+                job_id, cmd, log_path, self.settings.build_timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            raise PhaseTimeoutError("build", self.settings.build_timeout_seconds)
+
+        if exit_code != 0:
+            raise PhaseError("build", exit_code, "Docker build failed")
+
+    async def _run_container(
+        self,
+        job_id: str,
+        workspace: Path,
+        gpu_count: int,
+        timeout_seconds: int | None,
+        db_path: Path,
+    ) -> None:
+        """Run the Docker container with GPU access."""
+        if await self._check_cancelled(db_path, job_id):
+            raise PhaseError("run", -1, "Job cancelled before run")
+
+        await self._update_status(db_path, job_id, "running")
+
+        image_tag = f"ds01-job-{job_id}"
+        container_name = f"ds01-job-{job_id}"
+
+        # Resolve timeout
+        resolved_timeout = float(
+            timeout_seconds
+            if timeout_seconds is not None
+            else self.settings.default_job_timeout_seconds
+        )
+        resolved_timeout = min(resolved_timeout, self.settings.max_job_timeout_seconds)
+
+        cmd = [
+            str(self.settings.docker_bin),
+            "run",
+            "--name",
+            container_name,
+            "--gpus",
+            "all",
+            image_tag,
+        ]
+        log_path = workspace / "run.log"
+
+        try:
+            exit_code = await self._run_phase(job_id, cmd, log_path, resolved_timeout)
+        except asyncio.TimeoutError:
+            raise PhaseTimeoutError("run", resolved_timeout)
+
+        if exit_code != 0:
+            raise PhaseError("run", exit_code, "Container exited with error")
+
+    async def _collect_results(self, job_id: str, workspace: Path) -> None:
+        """Copy results from container /output/ to workspace/results/."""
+        container_name = f"ds01-job-{job_id}"
+        results_dir = workspace / "results"
+        results_dir.mkdir(exist_ok=True)
+
+        proc = await asyncio.create_subprocess_exec(
+            str(self.settings.docker_bin),
+            "cp",
+            f"{container_name}:/output/.",
+            str(results_dir),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            logger.warning("Failed to collect results for %s: %s", job_id, stderr.decode().strip())
+
+    async def _cleanup(self, job_id: str) -> None:
+        """Remove container, image, and prune build cache."""
+        docker = str(self.settings.docker_bin)
+
+        # Remove container
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                docker,
+                "rm",
+                "-f",
+                f"ds01-job-{job_id}",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+        except Exception:
+            logger.debug("Failed to remove container for job %s", job_id, exc_info=True)
+
+        # Remove image
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                docker,
+                "image",
+                "rm",
+                "-f",
+                f"ds01-job-{job_id}",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+        except Exception:
+            logger.debug("Failed to remove image for job %s", job_id, exc_info=True)
+
+        # Prune build cache
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                docker,
+                "builder",
+                "prune",
+                "--force",
+                "--filter",
+                "until=1h",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+        except Exception:
+            logger.debug("Failed to prune build cache for job %s", job_id, exc_info=True)
+
+    async def kill_current_process(self, job_id: str) -> None:
+        """Kill the currently running subprocess and its Docker container.
+
+        Used by the runner for cancel and shutdown.
+        """
+        proc = self._current_process
+        if proc is not None and proc.returncode is None:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+
+        # Also force-remove any Docker container (survives process group kill)
+        docker = str(self.settings.docker_bin)
+        try:
+            rm_proc = await asyncio.create_subprocess_exec(
+                docker,
+                "rm",
+                "-f",
+                f"ds01-job-{job_id}",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await rm_proc.wait()
+        except Exception:
+            pass

--- a/src/ds01_jobs/gpu.py
+++ b/src/ds01_jobs/gpu.py
@@ -1,0 +1,67 @@
+"""GPU availability checking via nvidia-smi.
+
+Queries nvidia-smi to determine how many GPUs are currently idle
+(less than 100 MiB memory used). Returns 0 gracefully when
+nvidia-smi is unavailable (e.g. in CI or on non-GPU machines).
+"""
+
+import asyncio
+
+IDLE_MEMORY_THRESHOLD_MIB = 100
+
+
+async def get_available_gpu_count() -> int:
+    """Return the number of idle GPUs based on nvidia-smi memory usage.
+
+    A GPU is considered idle if its memory usage is below
+    IDLE_MEMORY_THRESHOLD_MIB. Returns 0 if nvidia-smi is not
+    available or exits with a non-zero code.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "nvidia-smi",
+            "--query-gpu=index,memory.used",
+            "--format=csv,noheader,nounits",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+    except FileNotFoundError:
+        return 0
+
+    if proc.returncode != 0:
+        return 0
+
+    idle = 0
+    for line in stdout.decode().strip().splitlines():
+        parts = line.split(",")
+        if len(parts) == 2:
+            memory_used = float(parts[1].strip())
+            if memory_used < IDLE_MEMORY_THRESHOLD_MIB:
+                idle += 1
+    return idle
+
+
+async def get_gpu_count() -> int:
+    """Return total GPU count (not just available).
+
+    Used for validation (e.g. rejecting gpu_count > total).
+    Returns 0 if nvidia-smi is unavailable.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "nvidia-smi",
+            "--query-gpu=index,memory.used",
+            "--format=csv,noheader,nounits",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+    except FileNotFoundError:
+        return 0
+
+    if proc.returncode != 0:
+        return 0
+
+    lines = [line for line in stdout.decode().strip().splitlines() if line.strip()]
+    return len(lines)

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -1,7 +1,9 @@
-"""Job submission endpoint for ds01-jobs.
+"""Job endpoints for ds01-jobs.
 
 POST /api/v1/jobs orchestrates the full validation pipeline and returns
 202 Accepted with a queued job.
+
+POST /api/v1/jobs/{job_id}/cancel marks a job as cancelled (failed).
 """
 
 import uuid
@@ -179,3 +181,42 @@ async def submit_job(
         status_url=f"/api/v1/jobs/{job_id}",
         created_at=now_iso,
     )
+
+
+ACTIVE_STATUSES = ("queued", "cloning", "building", "running")
+
+
+@router.post("/jobs/{job_id}/cancel", status_code=200)
+async def cancel_job(
+    job_id: str,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> dict[str, str]:
+    """Cancel a job by setting its status to failed."""
+    # 1. Look up job
+    cursor = await db.execute("SELECT username, status FROM jobs WHERE id = ?", (job_id,))
+    row = await cursor.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # 2. Ownership check
+    if row["username"] != user["username"]:
+        raise HTTPException(status_code=403, detail="Not your job")
+
+    # 3. Status check
+    if row["status"] not in ACTIVE_STATUSES:
+        raise HTTPException(status_code=409, detail=f"Job is already {row['status']}")
+
+    # 4. Atomic update with optimistic concurrency
+    now_iso = datetime.now(UTC).isoformat()
+    update_cursor = await db.execute(
+        "UPDATE jobs SET status='failed', updated_at=?, error_summary='Cancelled by user' "
+        "WHERE id=? AND status IN ('queued','cloning','building','running')",
+        (now_iso, job_id),
+    )
+    if update_cursor.rowcount == 0:
+        raise HTTPException(status_code=409, detail="Job status changed during cancel")
+
+    await db.commit()
+
+    return {"job_id": job_id, "status": "failed", "message": "Job cancelled"}

--- a/src/ds01_jobs/runner.py
+++ b/src/ds01_jobs/runner.py
@@ -1,0 +1,148 @@
+"""DS01 job runner - polls SQLite and executes Docker jobs.
+
+Long-running service that polls for queued jobs, checks GPU availability,
+dispatches jobs via JobExecutor, and handles graceful shutdown.
+"""
+
+import asyncio
+import logging
+import signal
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from ds01_jobs.config import Settings
+from ds01_jobs.executor import JobExecutor
+from ds01_jobs.gpu import get_available_gpu_count
+
+logger = logging.getLogger(__name__)
+
+
+class JobRunner:
+    """Async poll-dispatch loop for queued GPU jobs."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.shutdown_event = asyncio.Event()
+        self.active_jobs: dict[str, asyncio.Task[None]] = {}
+        self.active_executors: dict[str, JobExecutor] = {}
+
+    async def run(self) -> None:
+        """Main entry point - poll loop with signal handling and shutdown drain."""
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, self._handle_sigterm)
+        loop.add_signal_handler(signal.SIGINT, self._handle_sigterm)
+
+        await self._recover_orphaned_jobs()
+
+        while not self.shutdown_event.is_set():
+            await self._poll_and_dispatch()
+            self._cleanup_completed_tasks()
+            try:
+                await asyncio.wait_for(
+                    self.shutdown_event.wait(),
+                    timeout=self.settings.runner_poll_interval,
+                )
+            except asyncio.TimeoutError:
+                pass  # Normal - poll interval elapsed
+
+        active_count = len(self.active_jobs)
+        if active_count > 0:
+            logger.info("Shutting down, waiting for %d active jobs to drain...", active_count)
+            await asyncio.gather(*self.active_jobs.values(), return_exceptions=True)
+
+        logger.info("Runner stopped.")
+
+    def _handle_sigterm(self) -> None:
+        """Signal handler for SIGTERM and SIGINT."""
+        self.shutdown_event.set()
+        logger.info("SIGTERM received, draining active jobs...")
+
+    async def _recover_orphaned_jobs(self) -> None:
+        """Mark in-progress jobs as failed on startup (orphan recovery)."""
+        async with aiosqlite.connect(self.settings.db_path) as db:
+            now = datetime.now(UTC).isoformat()
+            cursor = await db.execute(
+                "UPDATE jobs SET status='failed', updated_at=?, "
+                "error_summary='Runner restarted - job interrupted' "
+                "WHERE status IN ('cloning', 'building', 'running')",
+                (now,),
+            )
+            if cursor.rowcount > 0:
+                logger.info("Recovered %d orphaned jobs on startup", cursor.rowcount)
+            await db.commit()
+
+    def _cleanup_completed_tasks(self) -> None:
+        """Remove finished tasks from active_jobs and log any exceptions."""
+        done_ids = [jid for jid, task in self.active_jobs.items() if task.done()]
+        for jid in done_ids:
+            task = self.active_jobs.pop(jid)
+            self.active_executors.pop(jid, None)
+            exc = task.exception() if not task.cancelled() else None
+            if exc is not None:
+                logger.error("Job %s task raised exception: %s", jid, exc)
+
+    async def _poll_and_dispatch(self) -> None:
+        """Query queued jobs and dispatch those that fit available GPUs."""
+        available = await get_available_gpu_count()
+        if available <= 0:
+            return
+
+        async with aiosqlite.connect(self.settings.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT id, username, repo_url, branch, gpu_count, timeout_seconds "
+                "FROM jobs WHERE status='queued' ORDER BY created_at ASC"
+            )
+            rows = await cursor.fetchall()
+
+        for row in rows:
+            job_id: str = row["id"]
+            gpu_count: int = row["gpu_count"]
+
+            if gpu_count > available:
+                continue
+
+            if job_id in self.active_jobs:
+                continue
+
+            executor = JobExecutor(self.settings)
+            task = asyncio.create_task(
+                executor.execute(
+                    job_id,
+                    row["repo_url"],
+                    row["branch"],
+                    gpu_count,
+                    row["timeout_seconds"],
+                    self.settings.db_path,
+                )
+            )
+            self.active_jobs[job_id] = task
+            self.active_executors[job_id] = executor
+            available -= gpu_count
+
+            if available <= 0:
+                break
+
+    async def cancel_job(self, job_id: str) -> bool:
+        """Kill a running job's executor process.
+
+        Returns True if the job was found and killed, False otherwise.
+        """
+        executor = self.active_executors.get(job_id)
+        if executor is not None:
+            await executor.kill_current_process(job_id)
+            self.active_executors.pop(job_id, None)
+            return True
+        return False
+
+
+def cli_main() -> None:
+    """CLI entry point for ds01-job-runner."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    settings = Settings()
+    runner = JobRunner(settings)
+    asyncio.run(runner.run())

--- a/tests/unit/test_cancel.py
+++ b/tests/unit/test_cancel.py
@@ -1,0 +1,275 @@
+"""Tests for POST /api/v1/jobs/{job_id}/cancel endpoint."""
+
+import hashlib
+import hmac
+import secrets
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import get_db, init_db
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash."""
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request."""
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+) -> None:
+    """Insert a test API key into the database."""
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+        )
+        await db.commit()
+
+
+async def _insert_job(
+    db_path: Path,
+    job_id: str | None = None,
+    username: str = "testuser",
+    status: str = "running",
+) -> str:
+    """Insert a test job and return its ID."""
+    jid = job_id or str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                jid,
+                username,
+                "https://github.com/test/repo",
+                "main",
+                1,
+                "test-job",
+                status,
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+    return jid
+
+
+def _make_app(db_path: Path):
+    """Create a test app with cancel endpoint."""
+    from ds01_jobs.app import create_app
+
+    app = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return app
+
+
+def _build_cancel_headers(raw_key: str, job_id: str) -> dict[str, str]:
+    """Build auth + signing headers for a POST cancel request."""
+    path = f"/api/v1/jobs/{job_id}/cancel"
+    headers = _sign_request(raw_key, "POST", path, body=b"")
+    headers["Authorization"] = f"Bearer {raw_key}"
+    return headers
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_job(tmp_path: Path) -> None:
+    """Cancel a running job returns 200 with status=failed."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="running")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert data["message"] == "Job cancelled"
+
+    # Verify DB state
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT status, error_summary FROM jobs WHERE id=?", (job_id,))
+        row = await cursor.fetchone()
+    assert row["status"] == "failed"
+    assert row["error_summary"] == "Cancelled by user"
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_job(tmp_path: Path) -> None:
+    """Cancel a queued job returns 200."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="queued")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cancel_completed_job(tmp_path: Path) -> None:
+    """Cancel a succeeded job returns 409."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 409
+    assert "already succeeded" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_failed_job(tmp_path: Path) -> None:
+    """Cancel an already-failed job returns 409."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="failed")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 409
+    assert "already failed" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_not_found(tmp_path: Path) -> None:
+    """Cancel a non-existent job returns 404."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    fake_id = str(uuid.uuid4())
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, fake_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{fake_id}/cancel", headers=headers)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_other_users_job(tmp_path: Path) -> None:
+    """Cancel another user's job returns 403."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    # Alice's key
+    alice_key, alice_kid, alice_hash = _create_test_key()
+    await _seed_key(db_path, alice_kid, alice_hash, username="alice")
+
+    # Bob's key
+    bob_key, bob_kid, bob_hash = _create_test_key()
+    await _seed_key(db_path, bob_kid, bob_hash, username="bob")
+
+    # Alice's job
+    job_id = await _insert_job(db_path, username="alice", status="running")
+
+    # Bob tries to cancel Alice's job
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(bob_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cancel_unauthenticated(tmp_path: Path) -> None:
+    """Cancel without auth returns 401 or 403."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    job_id = await _insert_job(db_path, status="running")
+
+    app = _make_app(db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel")
+
+    assert resp.status_code in (401, 403)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,0 +1,440 @@
+"""Unit tests for the job executor module."""
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+from ds01_jobs.config import Settings
+from ds01_jobs.database import SCHEMA_SQL
+from ds01_jobs.executor import JobExecutor
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+JOB_ID = "test-job-001"
+REPO_URL = "https://github.com/example/repo.git"
+BRANCH = "main"
+
+
+@pytest.fixture
+def executor_settings(tmp_path: Path) -> Settings:
+    """Settings configured for test use."""
+    return Settings(
+        _env_file=None,
+        workspace_root=tmp_path / "workspaces",
+        docker_bin=Path("/usr/local/bin/docker"),
+        build_timeout_seconds=60.0,
+        clone_timeout_seconds=30.0,
+        default_job_timeout_seconds=120.0,
+        max_job_timeout_seconds=300.0,
+        db_path=tmp_path / "test.db",
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Initialise a test database with a queued job row (sync)."""
+    path = tmp_path / "test.db"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            JOB_ID,
+            "testuser",
+            REPO_URL,
+            BRANCH,
+            1,
+            "test-job",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _mock_process(returncode: int = 0) -> AsyncMock:
+    """Create a mock subprocess with the given return code."""
+    proc = AsyncMock()
+    proc.pid = 12345
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    proc.communicate.return_value = (b"", b"")
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_success(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Successful execution completes with status=succeeded."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status, completed_at FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "succeeded"
+    assert row[1] is not None  # completed_at set
+
+    # Workspace was created
+    workspace = executor_settings.workspace_root / JOB_ID
+    assert workspace.exists()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.sleep", new_callable=AsyncMock)
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_clone_failure_retries(
+    mock_exec: AsyncMock,
+    mock_sleep: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Clone retries once on failure and succeeds on second attempt."""
+    # First clone call fails, second succeeds, rest succeed
+    fail_proc = _mock_process(128)
+    ok_proc = _mock_process(0)
+    mock_exec.side_effect = [fail_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "succeeded"
+
+    # Verify sleep was called for the retry delay
+    mock_sleep.assert_awaited_with(10)
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.sleep", new_callable=AsyncMock)
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_clone_failure_after_retry(
+    mock_exec: AsyncMock,
+    mock_sleep: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Clone fails both attempts, job transitions to failed with clone phase."""
+    fail_proc = _mock_process(128)
+    ok_proc = _mock_process(0)
+    # Both clone attempts fail; cleanup procs succeed
+    mock_exec.side_effect = [fail_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status, failed_phase FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "clone"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_build_failure(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Build failure sets status=failed with failed_phase=build."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    # clone ok, build fails, cleanup procs
+    mock_exec.side_effect = [ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            "SELECT status, failed_phase, exit_code FROM jobs WHERE id=?", (JOB_ID,)
+        )
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "build"
+    assert row[2] == 1
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_run_failure(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Run failure sets status=failed with failed_phase=run."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    # clone ok, build ok, run fails, cleanup procs
+    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status, failed_phase FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "run"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.os.killpg")
+@patch("ds01_jobs.executor.asyncio.wait_for")
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_build_timeout(
+    mock_exec: AsyncMock,
+    mock_wait_for: AsyncMock,
+    mock_killpg: MagicMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Build timeout kills process group and transitions to failed."""
+    ok_proc = _mock_process(0)
+
+    # Build proc - will be "timed out" by mocking wait_for
+    timeout_proc = AsyncMock()
+    timeout_proc.pid = 99999
+    timeout_proc.returncode = None
+    timeout_proc.wait.return_value = -9
+
+    cleanup_proc = _mock_process(0)
+    # clone ok, build times out, cleanup procs
+    mock_exec.side_effect = [ok_proc, timeout_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    # First wait_for call (clone) succeeds, second (build) times out
+    call_count = 0
+
+    async def selective_wait_for(coro: object, *, timeout: float) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Clone phase - return success
+            return await coro  # type: ignore[misc]
+        # Build phase - raise TimeoutError
+        raise asyncio.TimeoutError
+
+    mock_wait_for.side_effect = selective_wait_for
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            "SELECT status, failed_phase, error_summary FROM jobs WHERE id=?", (JOB_ID,)
+        )
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "build"
+    assert "timed out" in row[2]
+
+    # Verify process group kill was called
+    mock_killpg.assert_called()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_status_transitions_order(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Status transitions happen in the correct order for a successful job."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    # Spy on _update_status to track call order
+    statuses: list[str] = []
+    original_update = executor._update_status
+
+    async def tracking_update(db_path_: Path, job_id: str, status: str, **kwargs: object) -> None:
+        statuses.append(status)
+        await original_update(db_path_, job_id, status, **kwargs)
+
+    executor._update_status = tracking_update  # type: ignore[assignment]
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    assert statuses == ["cloning", "building", "running", "succeeded"]
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_cleanup_called_on_failure(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Cleanup subprocess calls are made even when build fails."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    cleanup_proc = _mock_process(0)
+    # clone ok, build fails, then 3 cleanup calls (rm, image rm, builder prune)
+    mock_exec.side_effect = [ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    # Check cleanup calls were made (the last 3 create_subprocess_exec calls)
+    calls = mock_exec.call_args_list
+    docker = str(executor_settings.docker_bin)
+
+    # Find cleanup calls - they use docker rm, docker image rm, docker builder prune
+    cleanup_cmds = []
+    for c in calls:
+        args = c[0] if c[0] else ()
+        if args and args[0] == docker:
+            if len(args) > 1 and args[1] in ("rm", "image", "builder"):
+                cleanup_cmds.append(args[1])
+
+    assert "rm" in cleanup_cmds
+    assert "image" in cleanup_cmds
+    assert "builder" in cleanup_cmds
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_docker_bin_path_used(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """All docker subprocess calls use settings.docker_bin, not a hardcoded path."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    docker = str(executor_settings.docker_bin)
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        # Skip the git clone call
+        if args and args[0] == "git":
+            continue
+        # All other calls should use the docker wrapper path
+        if args:
+            assert args[0] == docker, f"Expected {docker} but got {args[0]} in call {args}"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_log_files_created(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Log files are created at expected paths for each phase."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    workspace = executor_settings.workspace_root / JOB_ID
+    assert (workspace / "clone.log").exists()
+    assert (workspace / "build.log").exists()
+    assert (workspace / "run.log").exists()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_cancel_check_stops_execution(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """If job is cancelled between phases, executor stops before the next phase."""
+    ok_proc = _mock_process(0)
+    cleanup_proc = _mock_process(0)
+    mock_exec.side_effect = [ok_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    executor = JobExecutor(executor_settings)
+
+    # After clone succeeds, set the job status to failed (simulating cancel)
+    original_check = executor._check_cancelled
+
+    call_count = 0
+
+    async def cancel_after_clone(db_path_: Path, job_id: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First check (before build) - simulate cancel
+            async with aiosqlite.connect(db_path_) as db:
+                await db.execute(
+                    "UPDATE jobs SET status='failed', error_summary='Cancelled by user' WHERE id=?",
+                    (job_id,),
+                )
+                await db.commit()
+            return True
+        return await original_check(db_path_, job_id)
+
+    executor._check_cancelled = cancel_after_clone  # type: ignore[assignment]
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    # Verify build was never started - no docker build call should exist
+    calls = mock_exec.call_args_list
+    docker_cmds = [c[0] for c in calls if c[0] and c[0][0] == str(executor_settings.docker_bin)]
+    build_calls = [c for c in docker_cmds if len(c) > 1 and c[1] == "build"]
+    assert len(build_calls) == 0, "Build should not have been called after cancel"

--- a/tests/unit/test_gpu.py
+++ b/tests/unit/test_gpu.py
@@ -1,0 +1,81 @@
+"""Unit tests for GPU availability module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ds01_jobs.gpu import get_available_gpu_count, get_gpu_count
+
+
+def _make_process_mock(stdout: bytes, returncode: int = 0) -> AsyncMock:
+    """Create a mock subprocess with given stdout and return code."""
+    proc = AsyncMock()
+    proc.communicate.return_value = (stdout, b"")
+    proc.returncode = returncode
+    return proc
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_all_idle(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 0\n1, 0\n2, 0\n3, 0\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_available_gpu_count()
+
+    assert count == 4
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_some_busy(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 0\n1, 5000\n2, 0\n3, 5000\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_available_gpu_count()
+
+    assert count == 2
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_all_busy(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 8000\n1, 5000\n2, 12000\n3, 9000\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_available_gpu_count()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_nvidia_smi_fails(mock_exec: AsyncMock) -> None:
+    mock_exec.return_value = _make_process_mock(b"", returncode=1)
+
+    count = await get_available_gpu_count()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_available_gpu_count_nvidia_smi_not_found(
+    mock_exec: AsyncMock,
+) -> None:
+    mock_exec.side_effect = FileNotFoundError("nvidia-smi not found")
+
+    count = await get_available_gpu_count()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec")
+async def test_get_gpu_count_returns_total(mock_exec: AsyncMock) -> None:
+    stdout = b"0, 0\n1, 5000\n2, 0\n3, 8000\n"
+    mock_exec.return_value = _make_process_mock(stdout)
+
+    count = await get_gpu_count()
+
+    assert count == 4

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,283 @@
+"""Unit tests for the job runner module."""
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import aiosqlite
+import pytest
+
+from ds01_jobs.config import Settings
+from ds01_jobs.database import SCHEMA_SQL
+from ds01_jobs.runner import JobRunner
+
+
+@pytest.fixture
+def runner_settings(tmp_path: Path) -> Settings:
+    """Settings configured for test use."""
+    return Settings(
+        _env_file=None,
+        db_path=tmp_path / "test.db",
+        runner_poll_interval=0.1,
+        workspace_root=tmp_path / "workspaces",
+        docker_bin=Path("/usr/local/bin/docker"),
+    )
+
+
+@pytest.fixture
+def populated_db(tmp_path: Path) -> Path:
+    """Initialise DB with 2 queued jobs and return db_path."""
+    db_path = tmp_path / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+    for i in range(2):
+        conn.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"job-{i}",
+                "testuser",
+                "https://github.com/test/repo.git",
+                "main",
+                1,
+                f"test-job-{i}",
+                "queued",
+                f"2026-01-01T00:00:0{i}",
+                f"2026-01-01T00:00:0{i}",
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _init_db_sync(db_path: Path) -> None:
+    """Initialise schema synchronously for tests."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_recover_orphaned_jobs(runner_settings: Settings) -> None:
+    """Startup recovery marks in-progress jobs as failed."""
+    db_path = runner_settings.db_path
+    _init_db_sync(db_path)
+
+    conn = sqlite3.connect(db_path)
+    for status in ("running", "building", "cloning"):
+        conn.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"orphan-{status}",
+                "testuser",
+                "https://github.com/test/repo.git",
+                "main",
+                1,
+                f"orphan-{status}",
+                status,
+                "2026-01-01T00:00:00",
+                "2026-01-01T00:00:00",
+            ),
+        )
+    # Also add a queued job that should NOT be affected
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "queued-job",
+            "testuser",
+            "https://github.com/test/repo.git",
+            "main",
+            1,
+            "queued-job",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    runner = JobRunner(runner_settings)
+    await runner._recover_orphaned_jobs()
+
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT id, status, error_summary FROM jobs ORDER BY id")
+        rows = await cursor.fetchall()
+
+    results = {row["id"]: (row["status"], row["error_summary"]) for row in rows}
+    assert results["orphan-running"] == ("failed", "Runner restarted - job interrupted")
+    assert results["orphan-building"] == ("failed", "Runner restarted - job interrupted")
+    assert results["orphan-cloning"] == ("failed", "Runner restarted - job interrupted")
+    assert results["queued-job"][0] == "queued"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+@patch("ds01_jobs.runner.JobExecutor")
+async def test_poll_dispatches_queued_jobs(
+    mock_executor_cls: AsyncMock,
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    populated_db: Path,
+) -> None:
+    """Poll dispatches queued jobs when GPUs are available."""
+    runner_settings.db_path = populated_db
+    mock_gpu.return_value = 4
+
+    mock_executor = AsyncMock()
+    mock_executor.execute = AsyncMock()
+    mock_executor_cls.return_value = mock_executor
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    assert len(runner.active_jobs) == 2
+    assert mock_executor_cls.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+async def test_poll_skips_when_no_gpus(
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    populated_db: Path,
+) -> None:
+    """No GPUs available means no jobs dispatched."""
+    runner_settings.db_path = populated_db
+    mock_gpu.return_value = 0
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    assert len(runner.active_jobs) == 0
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+@patch("ds01_jobs.runner.JobExecutor")
+async def test_poll_skips_oversized_jobs(
+    mock_executor_cls: AsyncMock,
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Jobs requiring more GPUs than available are skipped; smaller ones run."""
+    db_path = tmp_path / "test.db"
+    runner_settings.db_path = db_path
+    _init_db_sync(db_path)
+
+    conn = sqlite3.connect(db_path)
+    # Job needing 2 GPUs
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "big-job",
+            "testuser",
+            "https://github.com/test/repo.git",
+            "main",
+            2,
+            "big-job",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    # Job needing 1 GPU
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "small-job",
+            "testuser",
+            "https://github.com/test/repo.git",
+            "main",
+            1,
+            "small-job",
+            "queued",
+            "2026-01-01T00:00:01",
+            "2026-01-01T00:00:01",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    mock_gpu.return_value = 1
+    mock_executor = AsyncMock()
+    mock_executor.execute = AsyncMock()
+    mock_executor_cls.return_value = mock_executor
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    assert "small-job" in runner.active_jobs
+    assert "big-job" not in runner.active_jobs
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+async def test_shutdown_event_stops_loop(
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+) -> None:
+    """Setting shutdown_event before run() causes immediate exit."""
+    _init_db_sync(runner_settings.db_path)
+    mock_gpu.return_value = 0
+
+    runner = JobRunner(runner_settings)
+    runner.shutdown_event.set()
+
+    # run() should exit without blocking
+    await asyncio.wait_for(runner.run(), timeout=5.0)
+
+    # No jobs dispatched
+    assert len(runner.active_jobs) == 0
+
+
+@pytest.mark.asyncio
+async def test_sigterm_sets_shutdown_event(runner_settings: Settings) -> None:
+    """_handle_sigterm sets the shutdown event."""
+    runner = JobRunner(runner_settings)
+    assert not runner.shutdown_event.is_set()
+    runner._handle_sigterm()
+    assert runner.shutdown_event.is_set()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+async def test_completed_tasks_cleaned_up(
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+) -> None:
+    """Completed asyncio tasks are removed from active_jobs."""
+    _init_db_sync(runner_settings.db_path)
+    mock_gpu.return_value = 0
+
+    runner = JobRunner(runner_settings)
+
+    # Create a done task
+    async def noop() -> None:
+        pass
+
+    done_task = asyncio.create_task(noop())
+    await done_task  # Let it finish
+
+    runner.active_jobs["done-job"] = done_task
+    runner.active_executors["done-job"] = AsyncMock()
+
+    # Run one poll cycle (no jobs to dispatch since GPU=0)
+    await runner._poll_and_dispatch()
+    runner._cleanup_completed_tasks()
+
+    assert "done-job" not in runner.active_jobs
+    assert "done-job" not in runner.active_executors


### PR DESCRIPTION
## Summary

- Create `JobRunner` — async poll-dispatch loop that queries SQLite for queued jobs every 5s
- GPU availability checked before dispatch; jobs needing more GPUs than available are skipped
- SIGTERM/SIGINT handler stops polling and drains active jobs before exit
- Startup recovery marks orphaned in-progress jobs (`cloning`/`building`/`running`) as `failed`
- Add `POST /api/v1/jobs/{id}/cancel` — sets status to `failed` with ownership (403), status validation (409), and optimistic concurrency
- Register `ds01-job-runner` CLI entry point in pyproject.toml

## Test plan

- [x] 7 runner tests: poll dispatch, GPU skip, oversized job skip, orphan recovery, shutdown event, SIGTERM handler, task cleanup
- [x] 7 cancel tests: running job, queued job, completed (409), failed (409), not found (404), other user (403), unauthenticated
- [x] Full suite (133 unit tests) passes with no regressions
- [x] `ruff check` and `mypy` pass

**PR 3 of 3** for Phase 4 (Job Runner). Depends on #20.