### PR TITLE
feat: status, logs, listing, quota, and results endpoints

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,194 @@
+# Requirements: ds01-jobs
+
+**Defined:** 2026-03-04
+**Core Value:** Researchers can submit GPU jobs remotely and get results back without direct server access.
+
+## v1 Requirements
+
+Requirements for v0.1.0 milestone. Each maps to roadmap phases.
+
+### Project Foundation
+
+- [x] **FOUND-01**: Project uses src/ds01_jobs/ package layout with pyproject.toml and uv for dependency management
+- [x] **FOUND-02**: Pre-commit hooks installed (ruff format + lint via existing dotconfigs pattern)
+- [x] **FOUND-03**: Tier 1 CI runs on every PR: ruff lint, ruff format check, mypy type check, pytest unit tests (GitHub-hosted runner)
+- [x] **FOUND-04**: Tier 2 CI runs on push to main: integration tests on self-hosted GPU runner
+- [x] **FOUND-05**: Deploy script (deploy.sh) installs venv, deps, systemd units, admin CLI symlink
+- [x] **FOUND-06**: Pydantic Settings for configuration (DB path, API host/port, resource-limits.yaml path) with env var overrides
+
+### Authentication
+
+- [x] **AUTH-01**: User can authenticate via HMAC-SHA256 signed API key (Bearer token + X-Timestamp + X-Nonce + X-Signature headers)
+- [x] **AUTH-02**: API keys stored as bcrypt hashes with 90-day expiry and single-key-per-user rotation
+- [x] **AUTH-03**: Expiry warning header (X-DS01-Key-Expiry-Warning) set when key is within 14 days of expiry
+- [x] **AUTH-04**: Nonce replay protection via in-memory cache with 5-minute TTL
+- [x] **AUTH-05**: Admin can create API keys via `ds01-job-admin key-create <username>` — verifies GitHub org membership (hertie-data-science-lab) before creation; key printed once, never stored in plaintext
+- [x] **AUTH-06**: Admin can list all API keys with status via `ds01-job-admin key-list`
+- [x] **AUTH-07**: Admin can revoke API keys via `ds01-job-admin key-revoke <username>`
+
+### Job Submission
+
+- [ ] **JOB-01**: User can submit a GPU job via POST /api/v1/jobs with repo_url, branch, script_path, gpu_count
+- [ ] **JOB-02**: Immediate response with {job_id, status: "queued", status_url} on successful submission
+- [x] **JOB-03**: Structured 422 response with machine-parseable field-level errors on validation failure
+- [x] **JOB-04**: GitHub URL validation (only https://github.com/owner/repo accepted — SSRF prevention)
+- [x] **JOB-05**: Optional inline dockerfile_content field for pre-scan at submission time
+
+### Dockerfile Scanning
+
+- [x] **SCAN-01**: All FROM directives scanned across all stages (multi-stage bypass prevention)
+- [x] **SCAN-02**: Only approved base registries allowed: nvcr.io/nvidia/* and Docker Hub official images
+- [x] **SCAN-03**: ENV LD_PRELOAD and LD_LIBRARY_PATH blocked outright (CVE-2025-23266 mitigation)
+- [x] **SCAN-04**: USER root produces warning (non-blocking) — cgroup constraints apply regardless
+- [x] **SCAN-05**: Scan violations return structured error with line number, directive, and reason
+
+### Rate Limiting
+
+- [ ] **RATE-01**: Per-user concurrent job limit enforced before any job is queued
+- [ ] **RATE-02**: Per-user daily job limit enforced before any job is queued
+- [ ] **RATE-03**: Limits configurable per group via ds01-infra's resource-limits.yaml (read directly, no import hack)
+- [ ] **RATE-04**: 429 response includes retry_after_seconds, limit_type, current_count, max_allowed
+- [x] **RATE-05**: Global API rate limit (60 req/min per API key) via slowapi for brute-force protection
+
+### Job Runner
+
+- [x] **RUN-01**: Runner polls SQLite for queued jobs and executes them (separate systemd service)
+- [x] **RUN-02**: Job lifecycle: clone repo → docker build (no --gpus) → docker run (via wrapper) → capture output
+- [x] **RUN-03**: Status transitions committed to SQLite before each subprocess starts (queued → cloning → building → running → succeeded/failed)
+- [x] **RUN-04**: stdout/stderr written to log files per phase (clone.log, build.log, run.log), not PIPE
+- [x] **RUN-05**: GPU slot management: check real GPU availability (nvidia-smi / allocator state) before dispatch, not internal SUM query — respects GPUs used by interactive containers
+- [x] **RUN-06**: Build timeout (15 min) and configurable job timeout enforced via process group kill
+- [x] **RUN-07**: Startup recovery: detect orphaned running/building/cloning jobs on restart, mark as failed
+- [x] **RUN-08**: Graceful shutdown: SIGTERM handler drains running jobs before stopping
+- [x] **RUN-09**: Job cancellation via POST /api/v1/jobs/{id}/cancel — kills process group
+- [x] **RUN-10**: Docker build cache cleanup after each job to prevent disk exhaustion
+- [x] **RUN-11**: All docker commands go through /usr/local/bin/docker (wrapper) for cgroup/GPU enforcement
+
+### Status & Results
+
+- [x] **STAT-01**: User can poll job status via GET /api/v1/jobs/{id} (status, phase timestamps, error message)
+- [ ] **STAT-02**: User can retrieve stdout/stderr logs via GET /api/v1/jobs/{id}/logs
+- [ ] **STAT-03**: User can download result files via GET /api/v1/jobs/{id}/results
+- [x] **STAT-04**: User can check remaining quota via GET /api/v1/users/me/quota
+
+### Network & Access
+
+- [x] **NET-01**: API bound to 127.0.0.1:8765 only — never 0.0.0.0
+- [ ] **NET-02**: Cloudflare Tunnel (named, not quick) proxies inbound HTTPS to the API
+- [x] **NET-03**: Health check endpoint at GET /health returns {status, version}
+
+### Deployment
+
+- [ ] **DEP-01**: deploy.sh creates venv, installs deps via uv sync, copies systemd units, symlinks CLI
+- [ ] **DEP-02**: ds01-api.service runs uvicorn from venv with proper ExecStart path
+- [ ] **DEP-03**: ds01-runner.service runs job runner with KillMode=process (preserves Docker containers for startup recovery)
+- [ ] **DEP-04**: ds01-cloudflared.service with Wants=ds01-api.service dependency
+- [ ] **DEP-05**: Pre-deploy check: warn if jobs are currently running (prevent data loss)
+
+### Clients
+
+- [ ] **CLI-01**: `ds01-submit` CLI tool handles HMAC request signing, job submission, status polling, and result download
+- [ ] **CLI-02**: CLI reads API key from `~/.config/ds01/credentials` or `DS01_API_KEY` env var
+- [ ] **GHA-01**: GitHub Action in action/ subdirectory for job submission from CI workflows (uses: hertie-data-science-lab/ds01-jobs/action@v0.1.0)
+- [ ] **GHA-02**: Action handles result retrieval and commits back to user's repo
+
+## v2 Requirements
+
+Deferred to future milestones. Not in current roadmap.
+
+### Multi-Machine
+
+- **MULTI-01**: Dispatch jobs to secondary GPU server (Drew's office A5500)
+- **MULTI-02**: Machine health monitoring and failover
+
+### GitHub Actions Extraction
+
+- **GHA-03**: Extract to ds01-actions repo when org has 3+ actions (ds01-infra already has docs-push action)
+
+### Enhanced Features
+
+- **ENH-01**: Scheduled/recurring job submissions
+- **ENH-02**: Job pipelines (A finishes → B starts)
+- **ENH-03**: Usage analytics dashboard
+- **ENH-04**: Private GitHub repo support (credential handling)
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Slurm integration | ds01-infra already provides resource management; Slurm conflicts with cgroup/GPU allocation |
+| Interactive containers | Handled by ds01-infra's container-deploy; ds01-jobs is batch-only |
+| OAuth/SSO | API key auth sufficient for small user base |
+| Cloud bursting | Future scope; single server first |
+| Web UI | API-first; GitHub Actions is the primary client |
+| Real-time log streaming | WebSockets add complexity; polling is appropriate for batch jobs |
+| Monitoring/admin API | Prometheus/Grafana already handles this; expose Grafana via Cloudflare Tunnel |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| FOUND-01 | Phase 1 | Complete |
+| FOUND-02 | Phase 1 | Complete |
+| FOUND-03 | Phase 1 | Complete |
+| FOUND-04 | Phase 1 | Complete |
+| FOUND-05 | Phase 1 | Complete |
+| FOUND-06 | Phase 1 | Complete |
+| AUTH-01 | Phase 2 | Complete |
+| AUTH-02 | Phase 2 | Complete |
+| AUTH-03 | Phase 2 | Complete |
+| AUTH-04 | Phase 2 | Complete |
+| AUTH-05 | Phase 2 | Complete |
+| AUTH-06 | Phase 2 | Complete |
+| AUTH-07 | Phase 2 | Complete |
+| JOB-01 | Phase 3 | Pending |
+| JOB-02 | Phase 3 | Pending |
+| JOB-03 | Phase 3 | Complete |
+| JOB-04 | Phase 3 | Complete |
+| JOB-05 | Phase 3 | Complete |
+| SCAN-01 | Phase 3 | Complete |
+| SCAN-02 | Phase 3 | Complete |
+| SCAN-03 | Phase 3 | Complete |
+| SCAN-04 | Phase 3 | Complete |
+| SCAN-05 | Phase 3 | Complete |
+| RATE-01 | Phase 3 | Pending |
+| RATE-02 | Phase 3 | Pending |
+| RATE-03 | Phase 3 | Pending |
+| RATE-04 | Phase 3 | Pending |
+| RATE-05 | Phase 2 | Complete |
+| RUN-01 | Phase 4 | Complete |
+| RUN-02 | Phase 4 | Complete |
+| RUN-03 | Phase 4 | Complete |
+| RUN-04 | Phase 4 | Complete |
+| RUN-05 | Phase 4 | Complete |
+| RUN-06 | Phase 4 | Complete |
+| RUN-07 | Phase 4 | Complete |
+| RUN-08 | Phase 4 | Complete |
+| RUN-09 | Phase 4 | Complete |
+| RUN-10 | Phase 4 | Complete |
+| RUN-11 | Phase 4 | Complete |
+| STAT-01 | Phase 5 | Complete |
+| STAT-02 | Phase 5 | Pending |
+| STAT-03 | Phase 5 | Pending |
+| STAT-04 | Phase 5 | Complete |
+| NET-01 | Phase 1 | Complete |
+| NET-02 | Phase 7 | Pending |
+| NET-03 | Phase 2 | Complete |
+| CLI-01 | Phase 6 | Pending |
+| CLI-02 | Phase 6 | Pending |
+| GHA-01 | Phase 6 | Pending |
+| GHA-02 | Phase 6 | Pending |
+| DEP-01 | Phase 7 | Pending |
+| DEP-02 | Phase 7 | Pending |
+| DEP-03 | Phase 7 | Pending |
+| DEP-04 | Phase 7 | Pending |
+| DEP-05 | Phase 7 | Pending |
+
+**Coverage:**
+- v1 requirements: 55 total
+- Mapped to phases: 55
+- Unmapped: 0
+
+---
+*Requirements defined: 2026-03-04*
+*Last updated: 2026-03-04 — 55 requirements mapped to phases 1-7 (clients added to v0.1.0)*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -68,7 +68,7 @@ Requirements for v0.1.0 milestone. Each maps to roadmap phases.
 
 - [x] **STAT-01**: User can poll job status via GET /api/v1/jobs/{id} (status, phase timestamps, error message)
 - [ ] **STAT-02**: User can retrieve stdout/stderr logs via GET /api/v1/jobs/{id}/logs
-- [ ] **STAT-03**: User can download result files via GET /api/v1/jobs/{id}/results
+- [x] **STAT-03**: User can download result files via GET /api/v1/jobs/{id}/results
 - [x] **STAT-04**: User can check remaining quota via GET /api/v1/users/me/quota
 
 ### Network & Access
@@ -169,7 +169,7 @@ Deferred to future milestones. Not in current roadmap.
 | RUN-11 | Phase 4 | Complete |
 | STAT-01 | Phase 5 | Complete |
 | STAT-02 | Phase 5 | Pending |
-| STAT-03 | Phase 5 | Pending |
+| STAT-03 | Phase 5 | Complete |
 | STAT-04 | Phase 5 | Complete |
 | NET-01 | Phase 1 | Complete |
 | NET-02 | Phase 7 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -67,7 +67,7 @@ Requirements for v0.1.0 milestone. Each maps to roadmap phases.
 ### Status & Results
 
 - [x] **STAT-01**: User can poll job status via GET /api/v1/jobs/{id} (status, phase timestamps, error message)
-- [ ] **STAT-02**: User can retrieve stdout/stderr logs via GET /api/v1/jobs/{id}/logs
+- [x] **STAT-02**: User can retrieve stdout/stderr logs via GET /api/v1/jobs/{id}/logs
 - [x] **STAT-03**: User can download result files via GET /api/v1/jobs/{id}/results
 - [x] **STAT-04**: User can check remaining quota via GET /api/v1/users/me/quota
 
@@ -168,7 +168,7 @@ Deferred to future milestones. Not in current roadmap.
 | RUN-10 | Phase 4 | Complete |
 | RUN-11 | Phase 4 | Complete |
 | STAT-01 | Phase 5 | Complete |
-| STAT-02 | Phase 5 | Pending |
+| STAT-02 | Phase 5 | Complete |
 | STAT-03 | Phase 5 | Complete |
 | STAT-04 | Phase 5 | Complete |
 | NET-01 | Phase 1 | Complete |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,142 @@
+# Roadmap: ds01-jobs — v0.1.0
+
+## Overview
+
+Seven phases take ds01-jobs from empty repository to a deployed GPU job submission service with usable clients (v0.1.0). Foundation establishes the package structure and CI pipelines that every subsequent phase depends on. Authentication and the job submission API are built as the API gateway. The job runner — the highest-risk component — gets its own phase with full operational hardening. Status and result retrieval complete the server-side workflow. A CLI client and GitHub Action make the API accessible to researchers (tested against a local dev server). Finally, production deployment wires the three systemd services and Cloudflare Tunnel into a live service.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [x] **Phase 1: Foundation** - Package layout, uv, pre-commit, CI pipelines (Tier 1 + Tier 2), config
+- [x] **Phase 2: Authentication** - HMAC auth, API key lifecycle, admin CLI, health endpoint, global rate limit
+- [ ] **Phase 3: Job Submission** - Submission endpoint, Dockerfile scanning, per-user rate limiting
+- [ ] **Phase 4: Job Runner** - Polling runner, job lifecycle execution, GPU slot management, operational hardening
+- [ ] **Phase 5: Status and Results** - Job status polling, log retrieval, result download, quota endpoint
+- [ ] **Phase 6: Clients** - ds01-submit CLI tool, GitHub Action in action/ subdirectory (tested against local dev server)
+- [ ] **Phase 7: Deployment** - deploy.sh, systemd units, Cloudflare Tunnel service, pre-deploy safety check
+
+## Phase Details
+
+### Phase 1: Foundation
+**Goal**: The project skeleton is fully operational — importable package, enforced code quality, and both CI tiers passing before any feature code is written
+**Depends on**: Nothing (first phase)
+**Requirements**: FOUND-01, FOUND-02, FOUND-03, FOUND-04, FOUND-05, FOUND-06, NET-01
+**Success Criteria** (what must be TRUE):
+  1. `import ds01_jobs` succeeds in a clean venv created by `uv sync`
+  2. `ruff check` and `mypy` pass with zero errors on an empty-but-typed package skeleton
+  3. A PR to main triggers Tier 1 CI (lint, type check, unit tests) on a GitHub-hosted runner and goes green
+  4. A push to main triggers Tier 2 CI (integration tests) on the self-hosted GPU runner and goes green
+  5. Configuration values (DB path, API host/port, resource-limits.yaml path) are readable from environment variables via Pydantic Settings
+**Plans**: 2 plans
+Plans:
+- [x] 01-01-PLAN.md — Package skeleton, pyproject.toml, Pydantic Settings, test suite
+- [x] 01-02-PLAN.md — Pre-commit verification, CI workflows (Tier 1 + Tier 2)
+
+### Phase 2: Authentication
+**Goal**: Users can authenticate via signed API keys, and admins can provision and revoke those keys via a CLI
+**Depends on**: Phase 1
+**Requirements**: AUTH-01, AUTH-02, AUTH-03, AUTH-04, AUTH-05, AUTH-06, AUTH-07, NET-03, RATE-05
+**Success Criteria** (what must be TRUE):
+  1. A signed request with a valid API key passes authentication; an unsigned or tampered request returns 401
+  2. A replayed request (duplicate nonce within 5 minutes) is rejected with 401
+  3. A request made with an API key within 14 days of expiry receives the `X-DS01-Key-Expiry-Warning` header
+  4. `ds01-job-admin key-create <username>` prints the raw key once and stores only the bcrypt hash
+  5. `ds01-job-admin key-revoke <username>` causes that key to be rejected on subsequent requests
+  6. `GET /health` returns `{status, version}` with no authentication required
+  7. The global rate limiter returns 429 after 60 requests per minute from the same API key
+**Plans**: 3 plans
+Plans:
+- [x] 02-01-PLAN.md — Database layer, response models, config extensions, dependency updates
+- [x] 02-02-PLAN.md — HMAC auth dependency, health endpoint, rate limiter, app factory
+- [x] 02-03-PLAN.md — Admin CLI (key-create, key-list, key-revoke, key-rotate)
+
+### Phase 3: Job Submission
+**Goal**: Authenticated users can submit GPU jobs, with Dockerfile scanning and rate limit enforcement before any job reaches the queue
+**Depends on**: Phase 2
+**Requirements**: JOB-01, JOB-02, JOB-03, JOB-04, JOB-05, SCAN-01, SCAN-02, SCAN-03, SCAN-04, SCAN-05, RATE-01, RATE-02, RATE-03, RATE-04
+**Success Criteria** (what must be TRUE):
+  1. `POST /api/v1/jobs` with a valid repo URL and Dockerfile returns `{job_id, status: "queued", status_url}` immediately
+  2. A submission with a non-GitHub URL (or a private IP) is rejected with a structured 422 before any network request is made
+  3. A Dockerfile containing a disallowed base image or `ENV LD_PRELOAD` is rejected with a structured error showing line number, directive, and reason
+  4. A user who has reached their concurrent job limit receives a 429 with `retry_after_seconds`, `limit_type`, `current_count`, and `max_allowed`
+  5. Rate limits for a user reflect their group membership as defined in `resource-limits.yaml`
+**Plans**: 2 plans
+Plans:
+- [x] 03-01-PLAN.md — Contracts, Dockerfile scanner, URL validation (models, config, schema, scanner.py, url_validation.py)
+- [ ] 03-02-PLAN.md — Per-user rate limiter, jobs router, app wiring (rate_limit.py, jobs.py, endpoint tests)
+
+### Phase 4: Job Runner
+**Goal**: Queued jobs execute reliably through the full Docker lifecycle, with the runner surviving restarts and shutdowns without leaving orphaned containers or stuck job states
+**Depends on**: Phase 3
+**Requirements**: RUN-01, RUN-02, RUN-03, RUN-04, RUN-05, RUN-06, RUN-07, RUN-08, RUN-09, RUN-10, RUN-11
+**Success Criteria** (what must be TRUE):
+  1. A queued job progresses through `queued → cloning → building → running → succeeded` with each transition committed to SQLite before the corresponding subprocess starts
+  2. A job that exceeds its build timeout (15 min) or run timeout is killed via process group and transitions to `failed`
+  3. Killing and restarting the runner marks any in-progress jobs as `failed` rather than leaving them stuck in `running`
+  4. SIGTERM causes the runner to stop accepting new jobs and exit cleanly after draining
+  5. A `POST /api/v1/jobs/{id}/cancel` on a running job kills the process group and transitions status to `failed`
+  6. All docker commands are invoked via `/usr/local/bin/docker` (the DS01 wrapper), never the real Docker binary
+**Plans**: 3 plans
+Plans:
+- [ ] 04-01-PLAN.md — Database schema extensions, runner config, GPU availability module
+- [ ] 04-02-PLAN.md — Job executor (clone/build/run subprocess pipeline, timeouts, cleanup)
+- [ ] 04-03-PLAN.md — Runner poll loop, signal handling, startup recovery, cancel endpoint
+
+### Phase 5: Status and Results
+**Goal**: Users can observe job progress, retrieve logs for debugging, download result files, and check their remaining quota
+**Depends on**: Phase 4
+**Requirements**: STAT-01, STAT-02, STAT-03, STAT-04
+**Success Criteria** (what must be TRUE):
+  1. `GET /api/v1/jobs/{id}` returns current status, per-phase timestamps, and a human-readable error message on failure
+  2. `GET /api/v1/jobs/{id}/logs` returns captured stdout/stderr for each completed phase (clone, build, run)
+  3. `GET /api/v1/jobs/{id}/results` delivers the job's output files as a downloadable artifact
+  4. `GET /api/v1/users/me/quota` returns the user's current concurrent job count, daily count, and configured limits
+**Plans**: 3 plans
+Plans:
+- [ ] 05-01-PLAN.md — Schema extension, config, response models, helpers, executor phase timestamps
+- [ ] 05-02-PLAN.md — Status, logs, listing, and quota endpoints
+- [ ] 05-03-PLAN.md — Results download endpoint with tar.gz streaming
+
+### Phase 6: Clients
+**Goal**: Researchers can submit jobs, check status, and retrieve results without constructing HMAC-signed requests by hand — via either a CLI tool or a GitHub Action (tested against local dev server)
+**Depends on**: Phase 5
+**Requirements**: CLI-01, CLI-02, GHA-01, GHA-02
+**Success Criteria** (what must be TRUE):
+  1. `ds01-submit run https://github.com/user/repo --gpus 1` submits a job and prints the job ID and status URL
+  2. `ds01-submit status <job-id>` shows current job status and phase timestamps
+  3. `ds01-submit results <job-id> -o ./output/` downloads result files to the local directory
+  4. The CLI reads the API key from `~/.config/ds01/credentials` or `DS01_API_KEY` env var and handles all HMAC signing transparently
+  5. The GitHub Action (`uses: hertie-data-science-lab/ds01-jobs/action@v0.1.0`) submits a job from a CI workflow and commits results back to the triggering repo
+**Plans**: TBD
+
+### Phase 7: Deployment
+**Goal**: The complete service — API server, job runner, and Cloudflare Tunnel — can be installed and upgraded on the production server with a single script and zero manual steps
+**Depends on**: Phase 6
+**Requirements**: DEP-01, DEP-02, DEP-03, DEP-04, DEP-05, NET-02
+**Success Criteria** (what must be TRUE):
+  1. Running `deploy.sh` on the server creates the venv, installs deps via `uv sync`, copies systemd units, and symlinks the admin CLI — with no manual steps after
+  2. `ds01-api.service`, `ds01-runner.service`, and `ds01-cloudflared.service` all start, pass health checks, and survive a server reboot
+  3. `ds01-cloudflared.service` lists `ds01-api.service` as a dependency and only starts after the API is healthy
+  4. Running `deploy.sh` while jobs are active prints a warning and requires confirmation before proceeding
+  5. The API is reachable from an off-campus network via the Cloudflare Tunnel URL without VPN
+**Plans**: TBD
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6 → 7
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Foundation | 2/2 | Complete | 2026-03-05 |
+| 2. Authentication | 3/3 | Complete | 2026-03-06 |
+| 3. Job Submission | 1/2 | In Progress | - |
+| 4. Job Runner | 0/3 | Not started | - |
+| 5. Status and Results | 0/3 | Not started | - |
+| 6. Clients | 0/TBD | Not started | - |
+| 7. Deployment | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,12 +3,12 @@ gsd_state_version: 1.0
 milestone: v0.1
 milestone_name: milestone
 status: in-progress
-last_updated: "2026-03-07T17:42:22Z"
+last_updated: "2026-03-07T17:48:20Z"
 progress:
   total_phases: 5
   completed_phases: 4
   total_plans: 13
-  completed_plans: 10
+  completed_plans: 11
 ---
 
 # Project State
@@ -23,18 +23,18 @@ See: .planning/PROJECT.md (updated 2026-03-04)
 ## Current Position
 
 Phase: 5 of 7 (Status and Results)
-Plan: 1 of 3 in current phase - COMPLETE
+Plan: 3 of 3 in current phase - COMPLETE
 Status: Executing Phase 5
-Last activity: 2026-03-07 — Completed 05-01 (status foundations)
+Last activity: 2026-03-07 — Completed 05-03 (results download)
 
-Progress: [████████░░] 77%
+Progress: [████████░░] 85%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 10
+- Total plans completed: 11
 - Average duration: 3min
-- Total execution time: 31min
+- Total execution time: 35min
 
 **By Phase:**
 
@@ -44,10 +44,10 @@ Progress: [████████░░] 77%
 | 02-authentication | 3 | 12min | 4min |
 | 03-job-submission | 1 | 4min | 4min |
 | 04-job-runner | 3 | 9min | 3min |
-| 05-status-and-results | 1 | 2min | 2min |
+| 05-status-and-results | 2 | 6min | 3min |
 
 **Recent Trend:**
-- Last 5 plans: 03-01 (4min), 04-01 (1min), 04-02 (5min), 04-03 (3min), 05-01 (2min)
+- Last 5 plans: 04-01 (1min), 04-02 (5min), 04-03 (3min), 05-01 (2min), 05-03 (4min)
 - Trend: stable
 
 *Updated after each plan completion*
@@ -87,6 +87,7 @@ Recent decisions affecting current work:
 - [Phase 04-job-runner]: Completed task cleanup happens synchronously in poll loop, not via task callbacks
 - [Phase 05-status-and-results]: queued phase started_at uses job created_at timestamp for accurate queue time measurement
 - [Phase 05-status-and-results]: Phase timestamps stored as JSON dict with started_at/ended_at per phase
+- [Phase 05-status-and-results]: Used unittest.mock.patch for _get_settings override in tests since it is called directly (not via Depends)
 
 ### Pending Todos
 
@@ -102,5 +103,5 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-03-07
-Stopped at: Completed 05-01-PLAN.md (status foundations)
+Stopped at: Completed 05-03-PLAN.md (results download)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,106 @@
+---
+gsd_state_version: 1.0
+milestone: v0.1
+milestone_name: milestone
+status: in-progress
+last_updated: "2026-03-07T17:42:22Z"
+progress:
+  total_phases: 5
+  completed_phases: 4
+  total_plans: 13
+  completed_plans: 10
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-03-04)
+
+**Core value:** Researchers can submit GPU jobs remotely and get results back without direct server access.
+**Current focus:** Phase 5 — Status and Results
+
+## Current Position
+
+Phase: 5 of 7 (Status and Results)
+Plan: 1 of 3 in current phase - COMPLETE
+Status: Executing Phase 5
+Last activity: 2026-03-07 — Completed 05-01 (status foundations)
+
+Progress: [████████░░] 77%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 10
+- Average duration: 3min
+- Total execution time: 31min
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| 01-foundation | 2 | 4min | 2min |
+| 02-authentication | 3 | 12min | 4min |
+| 03-job-submission | 1 | 4min | 4min |
+| 04-job-runner | 3 | 9min | 3min |
+| 05-status-and-results | 1 | 2min | 2min |
+
+**Recent Trend:**
+- Last 5 plans: 03-01 (4min), 04-01 (1min), 04-02 (5min), 04-03 (3min), 05-01 (2min)
+- Trend: stable
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- mypy scoped to src/ds01_jobs/ — brownfield files at src/ level have pre-existing errors (out of scope)
+- Settings uses _env_file=None in tests for isolation from .env files
+- Ruff excludes brownfield src/ files — consistent with mypy scoping
+- CI mypy scoped to src/ds01_jobs/ — brownfield files out of scope
+- Tier 2 handles pytest exit code 5 (no tests collected) as success
+- Result delivery: server stores output files, serves via API endpoint. CLI and GitHub Action handle retrieval client-side.
+- Clients (Phase 6) before Deployment (Phase 7): build CLI + Action against local dev server, validate end-to-end before production deploy.
+- CLI client (`ds01-submit`) and GitHub Action both in v0.1.0 scope (Phase 6). CLI handles HMAC signing. Action lives in action/ subdirectory — extract to ds01-actions when org has 3+ actions.
+- Runner is separate systemd service with `KillMode=process` (not control-group) — preserves Docker containers for startup recovery.
+- GPU availability: runner checks real GPU state (nvidia-smi / allocator), not internal SUM query. Retries on rejection.
+- Auth: GitHub org membership (hertie-data-science-lab) verified at key creation time, not on every request. Admin roles deferred to v0.2.0+.
+- Phase 4 (runner) is highest-risk phase — needs its own phase-level research pass before implementation.
+- Database functions accept optional db_path param for testability, defaulting to Settings
+- Async/sync database split: aiosqlite for FastAPI handlers, sqlite3 for Typer CLI commands
+- Nonce cache is in-memory dict with monotonic clock TTL - cleared on restart
+- bcrypt.checkpw runs via asyncio.to_thread to avoid blocking event loop
+- All auth failures return generic 401 - specific reasons logged server-side
+- Rate limiter keyed by key_id from Bearer token, falls back to client IP
+- key-rotate uses UPDATE approach (overwrites existing row) for simplicity - single-key-per-user means no history needed
+- Added @contextmanager decorator to get_db_sync for proper with-statement usage
+- Non-greedy regex for repo name to correctly strip .git suffix in URL validation
+- Unresolved build args in FROM produce info-level violation, not error
+- [Phase 04-job-runner]: GPU idle threshold set at 100 MiB - GPUs below this are considered available
+- [Phase 04-job-runner]: nvidia-smi query uses asyncio.create_subprocess_exec - output is small so PIPE is fine
+- [Phase 04-job-runner]: Cancel endpoint uses DB status update only - runner detects on next poll cycle (up to 5s latency)
+- [Phase 04-job-runner]: Completed task cleanup happens synchronously in poll loop, not via task callbacks
+- [Phase 05-status-and-results]: queued phase started_at uses job created_at timestamp for accurate queue time measurement
+- [Phase 05-status-and-results]: Phase timestamps stored as JSON dict with started_at/ended_at per phase
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- Max job duration per group: confirm whether resource-limits.yaml defines `max_duration_minutes` per group before runner implementation.
+- Shallow clone assumption: confirm whether `--recurse-submodules` is needed for primary users.
+- Docker wrapper path (`/usr/local/bin/docker`): confirm correct on production server before runner executor code.
+- GPU availability check mechanism: confirm whether nvidia-smi parsing or allocator state file is the better approach during Phase 4 research.
+
+## Session Continuity
+
+Last session: 2026-03-07
+Stopped at: Completed 05-01-PLAN.md (status foundations)
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v0.1
 milestone_name: milestone
-status: in-progress
-last_updated: "2026-03-07T17:48:20Z"
+status: unknown
+last_updated: "2026-03-07T17:51:51.824Z"
 progress:
   total_phases: 5
   completed_phases: 4
   total_plans: 13
-  completed_plans: 11
+  completed_plans: 12
 ---
 
 # Project State
@@ -51,6 +51,7 @@ Progress: [████████░░] 85%
 - Trend: stable
 
 *Updated after each plan completion*
+| Phase 05 P02 | 6 | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -88,6 +89,7 @@ Recent decisions affecting current work:
 - [Phase 05-status-and-results]: queued phase started_at uses job created_at timestamp for accurate queue time measurement
 - [Phase 05-status-and-results]: Phase timestamps stored as JSON dict with started_at/ended_at per phase
 - [Phase 05-status-and-results]: Used unittest.mock.patch for _get_settings override in tests since it is called directly (not via Depends)
+- [Phase 05]: Used unittest.mock.patch for _get_settings in log tests since lru_cache prevents FastAPI dependency_overrides
 
 ### Pending Todos
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v0.1
 milestone_name: milestone
 status: unknown
-last_updated: "2026-03-07T17:51:51.824Z"
+last_updated: "2026-03-07T17:58:22.018Z"
 progress:
   total_phases: 5
   completed_phases: 4

--- a/.planning/phases/05-status-and-results/05-01-PLAN.md
+++ b/.planning/phases/05-status-and-results/05-01-PLAN.md
@@ -1,0 +1,336 @@
+---
+phase: 05-status-and-results
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/ds01_jobs/database.py
+  - src/ds01_jobs/config.py
+  - src/ds01_jobs/models.py
+  - src/ds01_jobs/rate_limit.py
+  - src/ds01_jobs/executor.py
+  - tests/unit/test_rate_limit.py
+  - tests/unit/test_executor.py
+autonomous: true
+requirements:
+  - STAT-01
+  - STAT-04
+
+must_haves:
+  truths:
+    - "Jobs table schema includes phase_timestamps TEXT column for per-phase timing data"
+    - "Settings includes default_max_result_size_mb with a sensible default"
+    - "Response models exist for job detail, job listing, logs, and quota"
+    - "get_user_quota_info returns group name, limits, and max result size for a user"
+    - "Executor records phase start/end timestamps as JSON on each status transition"
+  artifacts:
+    - path: "src/ds01_jobs/database.py"
+      provides: "Extended jobs schema with phase_timestamps column"
+      contains: "phase_timestamps"
+    - path: "src/ds01_jobs/config.py"
+      provides: "default_max_result_size_mb setting"
+      contains: "default_max_result_size_mb"
+    - path: "src/ds01_jobs/models.py"
+      provides: "Response models for status, logs, listing, quota endpoints"
+      contains: "JobDetailResponse"
+    - path: "src/ds01_jobs/rate_limit.py"
+      provides: "get_user_quota_info helper returning group + limits + result size"
+      exports: ["get_user_quota_info"]
+    - path: "src/ds01_jobs/executor.py"
+      provides: "Phase timestamps recording in _update_status"
+      contains: "phase_timestamps"
+  key_links:
+    - from: "src/ds01_jobs/rate_limit.py"
+      to: "src/ds01_jobs/config.py"
+      via: "get_user_quota_info reads default_max_result_size_mb from Settings"
+      pattern: "default_max_result_size_mb"
+    - from: "src/ds01_jobs/executor.py"
+      to: "src/ds01_jobs/database.py"
+      via: "_update_status writes phase_timestamps JSON to DB"
+      pattern: "phase_timestamps"
+---
+
+<objective>
+Add the schema extension, configuration, response models, and helper functions that the status/logs/results/quota endpoints (Plans 02 and 03) depend on. Update the executor to record per-phase timestamps.
+
+Purpose: Plans 02 and 03 need the phase_timestamps column, response models, and quota helper to exist before the endpoints can be built. This plan creates all shared contracts and foundational changes.
+Output: Extended database.py, config.py, models.py, rate_limit.py, and executor.py with tests.
+</objective>
+
+<execution_context>
+@/home/datasciencelab/.claude/get-shit-done/workflows/execute-plan.md
+@/home/datasciencelab/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-status-and-results/05-CONTEXT.md
+@.planning/phases/05-status-and-results/05-RESEARCH.md
+
+@src/ds01_jobs/database.py
+@src/ds01_jobs/config.py
+@src/ds01_jobs/models.py
+@src/ds01_jobs/rate_limit.py
+@src/ds01_jobs/executor.py
+@tests/unit/test_rate_limit.py
+@tests/unit/test_executor.py
+
+<interfaces>
+<!-- Existing interfaces this plan extends -->
+
+From src/ds01_jobs/database.py:
+```python
+SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    username TEXT NOT NULL,
+    repo_url TEXT NOT NULL,
+    branch TEXT NOT NULL DEFAULT 'main',
+    gpu_count INTEGER NOT NULL DEFAULT 1,
+    job_name TEXT NOT NULL,
+    timeout_seconds INTEGER,
+    dockerfile_content TEXT,
+    status TEXT NOT NULL DEFAULT 'queued',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    failed_phase TEXT,
+    exit_code INTEGER,
+    error_summary TEXT,
+    started_at TEXT,
+    completed_at TEXT,
+    FOREIGN KEY (username) REFERENCES api_keys(username)
+);
+"""
+```
+
+From src/ds01_jobs/config.py:
+```python
+class Settings(BaseSettings):
+    # ... existing fields ...
+    default_concurrent_limit: int = 3
+    default_daily_limit: int = 10
+    workspace_root: Path = Path("/var/lib/ds01-jobs/workspaces")
+```
+
+From src/ds01_jobs/rate_limit.py:
+```python
+def load_resource_limits(path: Path) -> dict: ...
+def get_user_limits(username: str, settings: Settings) -> tuple[int, int]: ...
+async def get_user_job_counts(db: aiosqlite.Connection, username: str) -> tuple[int, int]: ...
+```
+
+From src/ds01_jobs/executor.py:
+```python
+class JobExecutor:
+    async def _update_status(self, db_path, job_id, status, *, failed_phase=None, exit_code=None, error_summary=None) -> None: ...
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Schema extension, config, and response models</name>
+  <files>
+    src/ds01_jobs/database.py
+    src/ds01_jobs/config.py
+    src/ds01_jobs/models.py
+  </files>
+  <action>
+    **database.py** - Add `phase_timestamps TEXT DEFAULT '{}'` column to the jobs table in SCHEMA_SQL. Place it after `completed_at` and before the FOREIGN KEY line. This stores a JSON object with per-phase start/end timestamps. Since we use `CREATE TABLE IF NOT EXISTS`, existing dev databases will need to be recreated (pre-v1, acceptable).
+
+    **config.py** - Add one new field to the Settings class:
+    ```python
+    # Result size limit
+    default_max_result_size_mb: int = 1024
+    ```
+    Place it after the existing rate limiting defaults section.
+
+    **models.py** - Add the following response models after the existing `ScanViolationModel`. All models use the existing Pydantic v2 `BaseModel`:
+
+    ```python
+    # --- Status and results models ---
+
+    class PhaseTimestamp(BaseModel):
+        """Start/end timestamps for a single job phase."""
+        started_at: str
+        ended_at: str | None = None
+
+    class JobError(BaseModel):
+        """Structured error info for failed jobs."""
+        phase: str
+        message: str
+        exit_code: int | None = None
+
+    class JobDetailResponse(BaseModel):
+        """Response for GET /api/v1/jobs/{id}."""
+        job_id: str
+        status: str
+        job_name: str
+        repo_url: str
+        branch: str
+        gpu_count: int
+        submitted_by: str
+        created_at: str
+        started_at: str | None = None
+        completed_at: str | None = None
+        phases: dict[str, PhaseTimestamp]
+        error: JobError | None = None
+        queue_position: int | None = None
+
+    class JobSummary(BaseModel):
+        """Single job entry in a listing response."""
+        job_id: str
+        status: str
+        job_name: str
+        repo_url: str
+        created_at: str
+        completed_at: str | None = None
+
+    class JobListResponse(BaseModel):
+        """Response for GET /api/v1/jobs."""
+        jobs: list[JobSummary]
+        total: int
+        limit: int
+        offset: int
+
+    class JobLogsResponse(BaseModel):
+        """Response for GET /api/v1/jobs/{id}/logs."""
+        job_id: str
+        logs: dict[str, str]
+        truncated: dict[str, bool] | None = None
+
+    class UsageCount(BaseModel):
+        """Current usage vs configured limit."""
+        used: int
+        limit: int
+
+    class QuotaResponse(BaseModel):
+        """Response for GET /api/v1/users/me/quota."""
+        username: str
+        group: str
+        concurrent: UsageCount
+        daily: UsageCount
+        max_result_size_mb: int
+    ```
+  </action>
+  <verify>
+    <automated>cd /opt/ds01-jobs && uv run python -c "
+from ds01_jobs.database import SCHEMA_SQL
+assert 'phase_timestamps' in SCHEMA_SQL, 'phase_timestamps missing from schema'
+from ds01_jobs.config import Settings
+s = Settings(_env_file=None)
+assert s.default_max_result_size_mb == 1024
+from ds01_jobs.models import JobDetailResponse, JobListResponse, JobLogsResponse, QuotaResponse, PhaseTimestamp, JobError, JobSummary, UsageCount
+print('All models import OK')
+" && uv run ruff check src/ds01_jobs/models.py src/ds01_jobs/database.py src/ds01_jobs/config.py && uv run mypy src/ds01_jobs/models.py src/ds01_jobs/database.py src/ds01_jobs/config.py</automated>
+  </verify>
+  <done>
+    - phase_timestamps TEXT column added to jobs schema
+    - default_max_result_size_mb setting added with default 1024
+    - All 8 response models created (PhaseTimestamp, JobError, JobDetailResponse, JobSummary, JobListResponse, JobLogsResponse, UsageCount, QuotaResponse)
+    - All models import cleanly, ruff and mypy pass
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Quota helper, executor phase timestamps, and tests</name>
+  <files>
+    src/ds01_jobs/rate_limit.py
+    src/ds01_jobs/executor.py
+    tests/unit/test_rate_limit.py
+    tests/unit/test_executor.py
+  </files>
+  <action>
+    **rate_limit.py** - Add `get_user_quota_info` function after the existing `get_user_limits` function. This reuses the same `load_resource_limits` and YAML parsing pattern:
+
+    ```python
+    def get_user_quota_info(username: str, settings: Settings) -> tuple[str, int, int, int]:
+        """Return (group_name, concurrent_limit, daily_limit, max_result_size_mb) for a user.
+
+        Reads group membership and limits from resource-limits.yaml,
+        falling back to settings defaults for unmapped users.
+        """
+        concurrent = settings.default_concurrent_limit
+        daily = settings.default_daily_limit
+        max_result_mb = settings.default_max_result_size_mb
+        group = "default"
+
+        data = load_resource_limits(settings.resource_limits_path)
+        groups = data.get("groups", {})
+        users = data.get("users", {})
+
+        group_name = users.get(username)
+        if group_name and group_name in groups:
+            group = group_name
+            group_cfg = groups[group_name]
+            concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
+            daily = group_cfg.get("max_daily_submissions", daily)
+            max_result_mb = group_cfg.get("max_result_size_mb", max_result_mb)
+
+        return group, concurrent, daily, max_result_mb
+    ```
+
+    **executor.py** - Update `_update_status` to record phase timestamps in JSON. The method currently handles status transitions and writes to the `status`, `updated_at`, and other columns. Add phase timestamp recording:
+
+    1. Add `import json` at the top of the file.
+    2. In `_update_status`, before executing the UPDATE query, read the current `phase_timestamps` JSON from the DB:
+       ```python
+       cursor = await db.execute("SELECT phase_timestamps FROM jobs WHERE id=?", (job_id,))
+       row = await cursor.fetchone()
+       timestamps = json.loads(row[0]) if row and row[0] else {}
+       ```
+    3. Update the timestamps dict based on the new status:
+       - For `cloning`, `building`, `running`: set `timestamps[status] = {"started_at": now}`. Also set `ended_at` on the previous phase if applicable (cloning->building means cloning ended, building->running means building ended).
+       - For `succeeded` or `failed`: set `ended_at` on whatever phase was last active (the phase before the terminal state).
+       - Phase order is: `["cloning", "building", "running"]`. When entering phase N, set ended_at on phase N-1.
+    4. Include `phase_timestamps=?` with `json.dumps(timestamps)` in all three UPDATE branches (terminal, cloning, and other statuses).
+
+    The initial `queued` phase timestamp is set at job insertion time (in `execute()` method). Add this: after creating the workspace and before calling `_clone()`, update the phase_timestamps with `{"queued": {"started_at": now}}`.
+
+    **tests/unit/test_rate_limit.py** - Add tests for `get_user_quota_info`:
+
+    - `test_get_user_quota_info_defaults` - No YAML file, returns ("default", 3, 10, 1024).
+    - `test_get_user_quota_info_from_yaml` - YAML with student group having `max_result_size_mb: 512`. User mapped to student group returns ("student", concurrent, daily, 512).
+    - `test_get_user_quota_info_no_result_size_in_yaml` - YAML group without `max_result_size_mb` falls back to settings default.
+
+    **tests/unit/test_executor.py** - Add test for phase timestamp recording:
+
+    - `test_phase_timestamps_recorded` - Run a successful job execution (mocking subprocesses as in existing tests). After completion, query the DB for `phase_timestamps` and verify it contains entries for `queued`, `cloning`, `building`, `running` phases, each with `started_at` set, and completed phases have `ended_at`. Parse the JSON and check structure.
+  </action>
+  <verify>
+    <automated>cd /opt/ds01-jobs && uv run pytest tests/unit/test_rate_limit.py tests/unit/test_executor.py -v --tb=short -k "quota or phase_timestamps" && uv run ruff check src/ds01_jobs/rate_limit.py src/ds01_jobs/executor.py && uv run mypy src/ds01_jobs/rate_limit.py src/ds01_jobs/executor.py</automated>
+  </verify>
+  <done>
+    - get_user_quota_info returns (group, concurrent_limit, daily_limit, max_result_size_mb)
+    - Falls back to settings defaults when YAML is missing or user is unmapped
+    - Reads max_result_size_mb from per-group config in resource-limits.yaml
+    - Executor _update_status writes phase_timestamps JSON on each transition
+    - Phase timestamps include started_at for active phases and ended_at for completed phases
+    - All new and existing tests pass
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+1. `cd /opt/ds01-jobs && uv run pytest tests/unit/test_rate_limit.py tests/unit/test_executor.py -v --tb=short` - all tests pass
+2. `cd /opt/ds01-jobs && uv run ruff check src/ds01_jobs/` - no lint errors
+3. `cd /opt/ds01-jobs && uv run mypy src/ds01_jobs/` - no type errors
+4. `cd /opt/ds01-jobs && uv run python -c "from ds01_jobs.models import JobDetailResponse, QuotaResponse; print('Models OK')"` - models import
+</verification>
+
+<success_criteria>
+- phase_timestamps column in jobs schema for per-phase timing data (STAT-01 foundation)
+- default_max_result_size_mb configurable via Settings
+- All response models defined for status detail, listing, logs, and quota
+- get_user_quota_info helper returns group name + all limits (STAT-04 foundation)
+- Executor records phase timestamps on every status transition (STAT-01 foundation)
+- All tests pass, ruff and mypy clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-status-and-results/05-01-SUMMARY.md`
+</output>

--- a/.planning/phases/05-status-and-results/05-01-SUMMARY.md
+++ b/.planning/phases/05-status-and-results/05-01-SUMMARY.md
@@ -1,0 +1,107 @@
+---
+phase: 05-status-and-results
+plan: 01
+subsystem: api
+tags: [pydantic, sqlite, json, phase-timestamps, quota]
+
+# Dependency graph
+requires:
+  - phase: 04-job-runner
+    provides: executor _update_status method, rate_limit module, jobs schema
+provides:
+  - phase_timestamps column in jobs schema for per-phase timing
+  - default_max_result_size_mb config setting
+  - Response models for job detail, listing, logs, and quota endpoints
+  - get_user_quota_info helper returning group + limits + result size
+  - Executor records phase timestamps on every status transition
+affects: [05-02, 05-03]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Phase timestamps as JSON column for per-phase timing data"
+    - "get_user_quota_info extends get_user_limits pattern with result size"
+
+key-files:
+  created: []
+  modified:
+    - src/ds01_jobs/database.py
+    - src/ds01_jobs/config.py
+    - src/ds01_jobs/models.py
+    - src/ds01_jobs/rate_limit.py
+    - src/ds01_jobs/executor.py
+    - tests/unit/test_rate_limit.py
+    - tests/unit/test_executor.py
+
+key-decisions:
+  - "queued phase started_at uses job created_at timestamp for accurate queue time measurement"
+  - "Phase timestamps stored as JSON dict with started_at/ended_at per phase"
+
+patterns-established:
+  - "Phase timestamp recording: each _update_status call reads/updates JSON timestamps column"
+  - "Quota info helper: extends user limits pattern to include group name and result size"
+
+requirements-completed: [STAT-01, STAT-04]
+
+# Metrics
+duration: 2min
+completed: 2026-03-07
+---
+
+# Phase 05 Plan 01: Status Foundations Summary
+
+**Extended jobs schema with phase timestamps, added 8 response models and quota helper for status/logs/results/quota endpoints**
+
+## Performance
+
+- **Duration:** 2 min
+- **Started:** 2026-03-07T17:38:46Z
+- **Completed:** 2026-03-07T17:41:14Z
+- **Tasks:** 2
+- **Files modified:** 7
+
+## Accomplishments
+- Added phase_timestamps TEXT column to jobs table for per-phase timing data
+- Created 8 Pydantic response models (PhaseTimestamp, JobError, JobDetailResponse, JobSummary, JobListResponse, JobLogsResponse, UsageCount, QuotaResponse)
+- Added get_user_quota_info helper returning group, concurrent/daily limits, and max result size
+- Executor now records per-phase start/end timestamps as JSON on each status transition
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Schema extension, config, and response models** - `604d7a1` (feat)
+2. **Task 2: Quota helper, executor phase timestamps, and tests** - `050fa71` (feat)
+
+## Files Created/Modified
+- `src/ds01_jobs/database.py` - Added phase_timestamps column to jobs schema
+- `src/ds01_jobs/config.py` - Added default_max_result_size_mb setting (default 1024)
+- `src/ds01_jobs/models.py` - Added 8 response models for status/results endpoints
+- `src/ds01_jobs/rate_limit.py` - Added get_user_quota_info function
+- `src/ds01_jobs/executor.py` - Updated _update_status for phase timestamps, added queued timestamp recording
+- `tests/unit/test_rate_limit.py` - Added 3 tests for get_user_quota_info
+- `tests/unit/test_executor.py` - Added test for phase timestamps recording
+
+## Decisions Made
+- queued phase started_at uses the job's created_at timestamp for accurate queue time measurement
+- Phase timestamps stored as JSON dict with started_at/ended_at per phase, matching the phase_timestamps column default of '{}'
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- All response models ready for Plans 02 (status/logs endpoints) and 03 (results/quota endpoints)
+- phase_timestamps column available for job detail responses
+- get_user_quota_info available for quota endpoint
+
+---
+*Phase: 05-status-and-results*
+*Completed: 2026-03-07*

--- a/.planning/phases/05-status-and-results/05-02-PLAN.md
+++ b/.planning/phases/05-status-and-results/05-02-PLAN.md
@@ -1,0 +1,396 @@
+---
+phase: 05-status-and-results
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - "05-01"
+files_modified:
+  - src/ds01_jobs/jobs.py
+  - tests/unit/test_status.py
+autonomous: true
+requirements:
+  - STAT-01
+  - STAT-02
+  - STAT-04
+
+must_haves:
+  truths:
+    - "GET /api/v1/jobs/{id} returns status, per-phase timestamps, error info, and queue position"
+    - "GET /api/v1/jobs/{id}/logs returns per-phase log content with truncation for large logs"
+    - "GET /api/v1/jobs returns the user's jobs with optional status filter and offset pagination"
+    - "GET /api/v1/users/me/quota returns concurrent/daily usage and limits plus group info"
+    - "All job-specific endpoints return 404 for non-existent jobs and other users' jobs (no information leakage)"
+  artifacts:
+    - path: "src/ds01_jobs/jobs.py"
+      provides: "Four new GET endpoints: status detail, logs, listing, quota"
+      contains: "get_job_status"
+    - path: "tests/unit/test_status.py"
+      provides: "Unit tests for all four read endpoints"
+      min_lines: 150
+  key_links:
+    - from: "src/ds01_jobs/jobs.py"
+      to: "src/ds01_jobs/models.py"
+      via: "Endpoints return JobDetailResponse, JobLogsResponse, JobListResponse, QuotaResponse"
+      pattern: "JobDetailResponse|JobLogsResponse|JobListResponse|QuotaResponse"
+    - from: "src/ds01_jobs/jobs.py"
+      to: "src/ds01_jobs/rate_limit.py"
+      via: "Quota endpoint calls get_user_quota_info and get_user_job_counts"
+      pattern: "get_user_quota_info|get_user_job_counts"
+    - from: "src/ds01_jobs/jobs.py"
+      to: "src/ds01_jobs/config.py"
+      via: "Log endpoint reads log files from settings.workspace_root"
+      pattern: "settings\\.workspace_root"
+---
+
+<objective>
+Add the four read-only GET endpoints to the existing jobs router: job status detail, log retrieval, job listing with pagination, and user quota. All endpoints require authentication and enforce ownership via 404 masking.
+
+Purpose: These endpoints complete the server-side observability story - users can check job progress, debug failures via logs, list their jobs, and discover their quota limits.
+Output: Extended jobs.py with four new endpoints, comprehensive test file.
+</objective>
+
+<execution_context>
+@/home/datasciencelab/.claude/get-shit-done/workflows/execute-plan.md
+@/home/datasciencelab/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-status-and-results/05-CONTEXT.md
+@.planning/phases/05-status-and-results/05-RESEARCH.md
+@.planning/phases/05-status-and-results/05-01-PLAN.md
+
+@src/ds01_jobs/jobs.py
+@src/ds01_jobs/models.py
+@src/ds01_jobs/rate_limit.py
+@src/ds01_jobs/config.py
+@tests/unit/test_jobs.py
+@tests/unit/test_cancel.py
+
+<interfaces>
+<!-- Interfaces from Plan 01 that this plan consumes -->
+
+From src/ds01_jobs/models.py (added in Plan 01):
+```python
+class PhaseTimestamp(BaseModel):
+    started_at: str
+    ended_at: str | None = None
+
+class JobError(BaseModel):
+    phase: str
+    message: str
+    exit_code: int | None = None
+
+class JobDetailResponse(BaseModel):
+    job_id: str
+    status: str
+    job_name: str
+    repo_url: str
+    branch: str
+    gpu_count: int
+    submitted_by: str
+    created_at: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    phases: dict[str, PhaseTimestamp]
+    error: JobError | None = None
+    queue_position: int | None = None
+
+class JobSummary(BaseModel):
+    job_id: str
+    status: str
+    job_name: str
+    repo_url: str
+    created_at: str
+    completed_at: str | None = None
+
+class JobListResponse(BaseModel):
+    jobs: list[JobSummary]
+    total: int
+    limit: int
+    offset: int
+
+class JobLogsResponse(BaseModel):
+    job_id: str
+    logs: dict[str, str]
+    truncated: dict[str, bool] | None = None
+
+class UsageCount(BaseModel):
+    used: int
+    limit: int
+
+class QuotaResponse(BaseModel):
+    username: str
+    group: str
+    concurrent: UsageCount
+    daily: UsageCount
+    max_result_size_mb: int
+```
+
+From src/ds01_jobs/rate_limit.py (added in Plan 01):
+```python
+def get_user_quota_info(username: str, settings: Settings) -> tuple[str, int, int, int]:
+    """Return (group_name, concurrent_limit, daily_limit, max_result_size_mb)."""
+    ...
+
+async def get_user_job_counts(db: aiosqlite.Connection, username: str) -> tuple[int, int]:
+    """Return (concurrent_active_count, daily_submission_count)."""
+    ...
+```
+
+From src/ds01_jobs/config.py:
+```python
+class Settings(BaseSettings):
+    workspace_root: Path = Path("/var/lib/ds01-jobs/workspaces")
+    default_max_result_size_mb: int = 1024  # added in Plan 01
+```
+
+From src/ds01_jobs/database.py:
+```python
+# Jobs table now includes phase_timestamps TEXT DEFAULT '{}' (added in Plan 01)
+```
+
+From src/ds01_jobs/jobs.py (existing):
+```python
+router = APIRouter(prefix="/api/v1")
+@lru_cache(maxsize=1)
+def _get_settings() -> Settings: ...
+ACTIVE_STATUSES = ("queued", "cloning", "building", "running")
+```
+
+From src/ds01_jobs/auth.py:
+```python
+async def get_current_user(...) -> dict[str, str]:
+    # Returns {"username": "...", "key_id": "..."}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add status, logs, listing, and quota endpoints</name>
+  <files>src/ds01_jobs/jobs.py</files>
+  <action>
+    Add four new GET endpoints to the existing `jobs.py` router. Also add necessary imports and helpers.
+
+    **New imports** at top of jobs.py:
+    ```python
+    import json
+    from pathlib import Path
+    from ds01_jobs.models import (
+        JobDetailResponse, JobError, JobListResponse, JobLogsResponse,
+        JobSummary, PhaseTimestamp, QuotaResponse, UsageCount,
+    )
+    from ds01_jobs.rate_limit import get_user_job_counts, get_user_quota_info
+    ```
+
+    **Helper: `_get_owned_job`** - Private async function for ownership-checked job lookup. Place before the endpoints:
+    ```python
+    async def _get_owned_job(
+        job_id: str, username: str, db: aiosqlite.Connection,
+    ) -> aiosqlite.Row:
+        """Fetch a job row, raising 404 if missing or not owned by user."""
+        cursor = await db.execute("SELECT * FROM jobs WHERE id = ?", (job_id,))
+        row = await cursor.fetchone()
+        if row is None or row["username"] != username:
+            raise HTTPException(status_code=404, detail="Job not found")
+        return row
+    ```
+
+    **Helper: `_read_log_file`** - Reads a log file with tail-truncation for large logs. Place near the helper:
+    ```python
+    MAX_LOG_BYTES = 1_048_576  # 1 MB per phase
+
+    def _read_log_file(path: Path, max_bytes: int = MAX_LOG_BYTES) -> tuple[str, bool]:
+        """Read a log file, tail-truncating if too large. Returns (content, truncated)."""
+        if not path.exists():
+            return "", False
+        size = path.stat().st_size
+        if size <= max_bytes:
+            return path.read_text(errors="replace"), False
+        with path.open("rb") as f:
+            f.seek(size - max_bytes)
+            content = f.read().decode(errors="replace")
+        return content, True
+    ```
+
+    **Pagination constants:**
+    ```python
+    DEFAULT_PAGE_LIMIT = 20
+    MAX_PAGE_LIMIT = 100
+    ```
+
+    **Endpoint 1: GET /api/v1/jobs/{job_id}** (status detail - STAT-01)
+    ```python
+    @router.get("/jobs/{job_id}", response_model=JobDetailResponse)
+    async def get_job_status(
+        job_id: str,
+        user: dict[str, str] = Depends(get_current_user),
+        db: aiosqlite.Connection = Depends(get_db),
+    ) -> JobDetailResponse:
+    ```
+    1. Call `_get_owned_job(job_id, user["username"], db)` for ownership check.
+    2. Parse `phase_timestamps` from JSON: `json.loads(row["phase_timestamps"] or "{}")`.
+    3. Convert to `dict[str, PhaseTimestamp]` by creating PhaseTimestamp objects.
+    4. Build `error: JobError | None` - if `row["failed_phase"]` is set, create `JobError(phase=row["failed_phase"], message=row["error_summary"] or "", exit_code=row["exit_code"])`. Otherwise None.
+    5. Calculate `queue_position: int | None` - if `row["status"] == "queued"`, query `SELECT COUNT(*) FROM jobs WHERE status = 'queued' AND created_at < ?` with `row["created_at"]`, add 1 for 1-based position. Otherwise None.
+    6. Return `JobDetailResponse` with all fields mapped from the row. Map `row["username"]` to `submitted_by`.
+
+    **Endpoint 2: GET /api/v1/jobs/{job_id}/logs** (log retrieval - STAT-02)
+    ```python
+    @router.get("/jobs/{job_id}/logs", response_model=JobLogsResponse)
+    async def get_job_logs(
+        job_id: str,
+        user: dict[str, str] = Depends(get_current_user),
+        db: aiosqlite.Connection = Depends(get_db),
+    ) -> JobLogsResponse:
+    ```
+    1. Call `_get_owned_job(job_id, user["username"], db)`.
+    2. Get workspace path: `_get_settings().workspace_root / job_id`.
+    3. Read each log file using `_read_log_file`:
+       - `clone.log`, `build.log`, `run.log`
+    4. Only include phases that have log content (non-empty string) in the `logs` dict.
+    5. Build `truncated` dict only if any phase was truncated; set to None if no truncation occurred.
+    6. Return `JobLogsResponse(job_id=job_id, logs=logs, truncated=truncated_dict)`.
+
+    **Endpoint 3: GET /api/v1/jobs** (job listing)
+    ```python
+    @router.get("/jobs", response_model=JobListResponse)
+    async def list_jobs(
+        status: str | None = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        offset: int = 0,
+        user: dict[str, str] = Depends(get_current_user),
+        db: aiosqlite.Connection = Depends(get_db),
+    ) -> JobListResponse:
+    ```
+    1. Clamp limit to `min(limit, MAX_PAGE_LIMIT)`, ensure `offset >= 0`.
+    2. Build query: `SELECT id, status, job_name, repo_url, created_at, completed_at FROM jobs WHERE username = ?`. If `status` param is provided, add `AND status = ?`.
+    3. Run a COUNT query with the same WHERE clause to get `total`.
+    4. Add `ORDER BY created_at DESC LIMIT ? OFFSET ?`.
+    5. Map rows to `JobSummary` objects (mapping `id` to `job_id`).
+    6. Return `JobListResponse(jobs=summaries, total=total, limit=limit, offset=offset)`.
+
+    **Endpoint 4: GET /api/v1/users/me/quota** (quota info - STAT-04)
+    ```python
+    @router.get("/users/me/quota", response_model=QuotaResponse)
+    async def get_quota(
+        user: dict[str, str] = Depends(get_current_user),
+        db: aiosqlite.Connection = Depends(get_db),
+    ) -> QuotaResponse:
+    ```
+    1. Get settings via `_get_settings()`.
+    2. Call `get_user_quota_info(user["username"], settings)` for (group, concurrent_limit, daily_limit, max_result_size_mb).
+    3. Call `get_user_job_counts(db, user["username"])` for (concurrent_used, daily_used).
+    4. Return `QuotaResponse(username=user["username"], group=group, concurrent=UsageCount(used=concurrent_used, limit=concurrent_limit), daily=UsageCount(used=daily_used, limit=daily_limit), max_result_size_mb=max_result_size_mb)`.
+
+    Note: The `/users/me/quota` path is under the same `/api/v1` prefix router. FastAPI path matching is order-independent for non-overlapping paths, so this works fine alongside `/jobs/*` routes.
+  </action>
+  <verify>
+    <automated>cd /opt/ds01-jobs && uv run python -c "
+from ds01_jobs.jobs import get_job_status, get_job_logs, list_jobs, get_quota
+print('All 4 endpoints defined')
+" && uv run ruff check src/ds01_jobs/jobs.py && uv run mypy src/ds01_jobs/jobs.py</automated>
+  </verify>
+  <done>
+    - GET /api/v1/jobs/{id} returns status detail with phases, error, queue position (STAT-01)
+    - GET /api/v1/jobs/{id}/logs returns per-phase log content with truncation (STAT-02)
+    - GET /api/v1/jobs returns paginated job listing with optional status filter
+    - GET /api/v1/users/me/quota returns usage and limits (STAT-04)
+    - All endpoints use _get_owned_job for 404 masking on other users' jobs
+    - ruff and mypy clean
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Unit tests for status, logs, listing, and quota endpoints</name>
+  <files>tests/unit/test_status.py</files>
+  <action>
+    Create `tests/unit/test_status.py` following the same patterns as `test_cancel.py` and `test_jobs.py`: use `httpx.AsyncClient` with `ASGITransport`, `_create_test_key`, `_sign_request`, `_seed_key`, `_insert_job`, and `_make_app` helpers.
+
+    **Test helpers** (copy the auth helper pattern from test_cancel.py):
+    - `_create_test_key()`, `_sign_request()`, `_seed_key()` - same as existing tests.
+    - `_make_app(db_path)` - same as test_cancel.py pattern (create_app + override get_db).
+    - `_insert_job(db_path, job_id=None, username="testuser", status="succeeded", created_at=None, phase_timestamps=None)` - extends the existing pattern to also insert `phase_timestamps` JSON string. Return the job_id.
+    - `_build_get_headers(raw_key, method, path)` - Build auth headers for a GET request (no body, so body_hash is hash of empty bytes).
+
+    **Status detail tests:**
+
+    - `test_get_status_succeeded_job` - Insert a succeeded job with phase_timestamps JSON containing queued, cloning, building, running phases. GET the status endpoint. Assert 200 with correct `job_id`, `status`, `submitted_by`, `repo_url`, `phases` dict containing PhaseTimestamp entries, and no `error`.
+
+    - `test_get_status_failed_job` - Insert a failed job with `failed_phase="build"`, `exit_code=1`, `error_summary="Docker build failed"`. Assert response includes `error` with phase, message, exit_code fields.
+
+    - `test_get_status_queued_job_has_queue_position` - Insert 3 queued jobs. GET the status of the third job. Assert `queue_position` is 3.
+
+    - `test_get_status_not_found` - GET status for a random UUID. Assert 404.
+
+    - `test_get_status_other_users_job` - Insert a job owned by "alice". Authenticate as "bob". GET status. Assert 404 (not 403).
+
+    **Log tests:**
+
+    - `test_get_logs_with_log_files` - Create workspace directory at `tmp_path / "workspaces" / job_id`. Write `clone.log` and `build.log` files with test content. Override settings to use `workspace_root=tmp_path / "workspaces"`. GET the logs endpoint. Assert 200 with `logs` containing clone and build content.
+
+    - `test_get_logs_no_log_files` - Don't create any log files. GET logs. Assert 200 with empty `logs` dict.
+
+    - `test_get_logs_truncated` - Write a log file larger than 1 MB. Assert response has `truncated` dict with the phase set to True.
+
+    - `test_get_logs_other_users_job` - Assert 404 for another user's job.
+
+    **Listing tests:**
+
+    - `test_list_jobs_returns_own_jobs` - Insert 3 jobs for "testuser" and 2 for "otheruser". List jobs. Assert only testuser's 3 jobs returned, total=3.
+
+    - `test_list_jobs_status_filter` - Insert jobs with various statuses. Filter `?status=running`. Assert only running jobs returned.
+
+    - `test_list_jobs_pagination` - Insert 5 jobs. Request `?limit=2&offset=0`. Assert 2 jobs, total=5. Request `?limit=2&offset=2`. Assert next 2 jobs.
+
+    - `test_list_jobs_empty` - No jobs. Assert 200 with empty jobs list, total=0.
+
+    **Quota tests:**
+
+    - `test_get_quota_defaults` - No resource-limits.yaml. Assert response has group="default", concurrent and daily limits matching settings defaults, max_result_size_mb=1024.
+
+    - `test_get_quota_with_active_jobs` - Insert 2 active jobs (queued, running). Assert `concurrent.used` is 2.
+
+    - `test_get_quota_other_user_isolation` - Insert jobs for "otheruser". Assert testuser's quota shows used=0.
+
+    For the log tests, override `_get_settings` in the app to return settings with `workspace_root=tmp_path / "workspaces"`. Follow the pattern from test_jobs.py where `_make_app` overrides `_get_settings`.
+
+    All tests use `@pytest.mark.asyncio` and `async def`.
+  </action>
+  <verify>
+    <automated>cd /opt/ds01-jobs && uv run pytest tests/unit/test_status.py -v --tb=short</automated>
+  </verify>
+  <done>
+    - Status detail endpoint tested: succeeded, failed (with error), queued (with position), not found, other user's job
+    - Logs endpoint tested: with log files, no logs, truncation, ownership check
+    - Listing endpoint tested: own jobs only, status filter, pagination, empty list
+    - Quota endpoint tested: defaults, active job counts, user isolation
+    - All tests pass
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+1. `cd /opt/ds01-jobs && uv run pytest tests/unit/test_status.py -v --tb=short` - all status/logs/listing/quota tests pass
+2. `cd /opt/ds01-jobs && uv run pytest tests/unit/ -v --tb=short` - all existing tests still pass
+3. `cd /opt/ds01-jobs && uv run ruff check src/ds01_jobs/jobs.py` - no lint errors
+4. `cd /opt/ds01-jobs && uv run mypy src/ds01_jobs/jobs.py` - no type errors
+</verification>
+
+<success_criteria>
+- GET /api/v1/jobs/{id} returns current status, per-phase timestamps, structured error, and queue position when queued (STAT-01)
+- GET /api/v1/jobs/{id}/logs returns per-phase log content with tail-truncation for large logs (STAT-02)
+- GET /api/v1/jobs returns paginated listing of user's own jobs with optional status filter
+- GET /api/v1/users/me/quota returns concurrent/daily usage, limits, group, and max result size (STAT-04)
+- All endpoints return 404 for other users' jobs (not 403)
+- All tests pass, ruff and mypy clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-status-and-results/05-02-SUMMARY.md`
+</output>

--- a/.planning/phases/05-status-and-results/05-02-SUMMARY.md
+++ b/.planning/phases/05-status-and-results/05-02-SUMMARY.md
@@ -1,0 +1,118 @@
+---
+phase: 05-status-and-results
+plan: 02
+subsystem: api
+tags: [fastapi, sqlite, pagination, logs, quota]
+
+# Dependency graph
+requires:
+  - phase: 05-status-and-results/01
+    provides: "Response models (JobDetailResponse, JobLogsResponse, etc.) and rate_limit helpers"
+provides:
+  - "GET /api/v1/jobs/{id} status detail endpoint with phases, error, queue position"
+  - "GET /api/v1/jobs/{id}/logs per-phase log retrieval with truncation"
+  - "GET /api/v1/jobs paginated job listing with status filter"
+  - "GET /api/v1/users/me/quota usage and limits endpoint"
+  - "_get_owned_job helper for ownership-checked job lookup with 404 masking"
+  - "_read_log_file helper for tail-truncated log reading"
+affects: [06-clients]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: ["ownership-checked lookup with 404 masking", "tail-truncation for large log files", "offset pagination with count"]
+
+key-files:
+  created:
+    - tests/unit/test_status.py
+  modified:
+    - src/ds01_jobs/jobs.py
+
+key-decisions:
+  - "Used unittest.mock.patch for _get_settings in log tests since lru_cache prevents dependency_overrides"
+  - "Pagination uses offset/limit with clamped MAX_PAGE_LIMIT=100"
+  - "Log truncation reads last 1MB of file for large logs"
+
+patterns-established:
+  - "_get_owned_job: ownership-checked job lookup returning 404 for both missing and other-user jobs"
+  - "_read_log_file: tail-truncation pattern for safely reading potentially large log files"
+  - "_build_get_headers: test helper for signing GET requests with empty body"
+
+requirements-completed: [STAT-01, STAT-02, STAT-04]
+
+# Metrics
+duration: 6min
+completed: 2026-03-07
+---
+
+# Phase 5 Plan 02: Status and Read Endpoints Summary
+
+**Four GET endpoints for job status detail, log retrieval, paginated listing, and user quota with ownership-based 404 masking**
+
+## Performance
+
+- **Duration:** 6 min
+- **Started:** 2026-03-07T17:43:49Z
+- **Completed:** 2026-03-07T17:49:49Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Four new GET endpoints added to the jobs router covering full read-only observability
+- 16 unit tests covering all endpoints including edge cases (truncation, pagination, ownership isolation)
+- All endpoints enforce ownership via _get_owned_job returning 404 for other users' jobs (no information leakage)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add status, logs, listing, and quota endpoints** - `ab5e201` (feat)
+2. **Task 2: Unit tests for all four endpoints** - `5594991` (test)
+
+## Files Created/Modified
+- `src/ds01_jobs/jobs.py` - Added four GET endpoints, _get_owned_job and _read_log_file helpers, pagination constants
+- `tests/unit/test_status.py` - 16 tests: 5 status detail, 4 logs, 4 listing, 3 quota
+
+## Decisions Made
+- Used `unittest.mock.patch` for `_get_settings` in log tests because it's called directly via `lru_cache`, not through FastAPI `Depends()`, so `dependency_overrides` doesn't intercept it
+- Fresh auth headers generated per request in pagination test to avoid nonce replay rejection
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed _get_settings override for log tests**
+- **Found during:** Task 2 (unit tests)
+- **Issue:** Log tests failed because `_get_settings()` is called directly (lru_cache), not via Depends - `dependency_overrides` doesn't work for it
+- **Fix:** Used `unittest.mock.patch("ds01_jobs.jobs._get_settings")` to inject test Settings with custom workspace_root
+- **Files modified:** tests/unit/test_status.py
+- **Verification:** All 16 tests pass
+- **Committed in:** 5594991
+
+**2. [Rule 1 - Bug] Fixed nonce replay in pagination test**
+- **Found during:** Task 2 (unit tests)
+- **Issue:** Pagination test reused same auth headers for two requests, causing nonce replay rejection on second request
+- **Fix:** Generate fresh headers via `_build_get_headers` for each request in pagination test
+- **Files modified:** tests/unit/test_status.py
+- **Verification:** Pagination test passes
+- **Committed in:** 5594991
+
+---
+
+**Total deviations:** 2 auto-fixed (2 bugs)
+**Impact on plan:** Both fixes necessary for test correctness. No scope creep.
+
+## Issues Encountered
+- Plan 03 (results endpoint) was already applied to jobs.py before this plan ran - accommodated by preserving existing results endpoint code and imports
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- All four read endpoints operational with comprehensive test coverage
+- Ready for Plan 03 (results download) if not already applied
+- Phase 6 (clients) can integrate against all status/logs/listing/quota endpoints
+
+---
+*Phase: 05-status-and-results*
+*Completed: 2026-03-07*

--- a/.planning/phases/05-status-and-results/05-03-PLAN.md
+++ b/.planning/phases/05-status-and-results/05-03-PLAN.md
@@ -1,0 +1,253 @@
+---
+phase: 05-status-and-results
+plan: 03
+type: execute
+wave: 2
+depends_on:
+  - "05-01"
+files_modified:
+  - src/ds01_jobs/jobs.py
+  - tests/unit/test_results.py
+autonomous: true
+requirements:
+  - STAT-03
+
+must_haves:
+  truths:
+    - "GET /api/v1/jobs/{id}/results streams a tar.gz archive of the job's output files"
+    - "Results exceeding max_result_size_mb return 413 with size info"
+    - "Jobs with no output files return 404 with {error: 'no_results'} body"
+    - "Only the job owner can download results (404 for other users)"
+    - "Only completed (succeeded) jobs can have results downloaded"
+  artifacts:
+    - path: "src/ds01_jobs/jobs.py"
+      provides: "GET /api/v1/jobs/{id}/results endpoint with tar.gz streaming"
+      contains: "download_results"
+    - path: "tests/unit/test_results.py"
+      provides: "Unit tests for results endpoint with mock filesystem"
+      min_lines: 100
+  key_links:
+    - from: "src/ds01_jobs/jobs.py"
+      to: "tarfile"
+      via: "Creates tar.gz archive from workspace/results/ directory"
+      pattern: "tarfile\\.open"
+    - from: "src/ds01_jobs/jobs.py"
+      to: "fastapi.responses.StreamingResponse"
+      via: "Streams the tar.gz archive back to the client"
+      pattern: "StreamingResponse"
+    - from: "src/ds01_jobs/jobs.py"
+      to: "src/ds01_jobs/rate_limit.py"
+      via: "Gets max_result_size_mb from get_user_quota_info"
+      pattern: "get_user_quota_info"
+---
+
+<objective>
+Add the results download endpoint that creates a tar.gz archive from the job's workspace/results/ directory and streams it to the client. Includes size enforcement, empty-results handling, and ownership checks.
+
+Purpose: This completes the server-side data retrieval story - users can download the output files their GPU jobs produced. Separated from Plan 02 because tar.gz creation and streaming is a distinct concern with its own edge cases.
+Output: Results endpoint in jobs.py, dedicated test file with filesystem fixtures.
+</objective>
+
+<execution_context>
+@/home/datasciencelab/.claude/get-shit-done/workflows/execute-plan.md
+@/home/datasciencelab/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-status-and-results/05-CONTEXT.md
+@.planning/phases/05-status-and-results/05-RESEARCH.md
+@.planning/phases/05-status-and-results/05-01-PLAN.md
+
+@src/ds01_jobs/jobs.py
+@src/ds01_jobs/rate_limit.py
+@src/ds01_jobs/config.py
+@tests/unit/test_cancel.py
+
+<interfaces>
+<!-- Interfaces from Plan 01 that this plan consumes -->
+
+From src/ds01_jobs/jobs.py (existing + Plan 02 additions):
+```python
+router = APIRouter(prefix="/api/v1")
+
+@lru_cache(maxsize=1)
+def _get_settings() -> Settings: ...
+
+async def _get_owned_job(
+    job_id: str, username: str, db: aiosqlite.Connection,
+) -> aiosqlite.Row: ...
+```
+
+From src/ds01_jobs/rate_limit.py (added in Plan 01):
+```python
+def get_user_quota_info(username: str, settings: Settings) -> tuple[str, int, int, int]:
+    """Return (group_name, concurrent_limit, daily_limit, max_result_size_mb)."""
+```
+
+From src/ds01_jobs/config.py (extended in Plan 01):
+```python
+class Settings(BaseSettings):
+    workspace_root: Path = Path("/var/lib/ds01-jobs/workspaces")
+    default_max_result_size_mb: int = 1024
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add results download endpoint</name>
+  <files>src/ds01_jobs/jobs.py</files>
+  <action>
+    Add the results download endpoint to the existing `jobs.py` router. Add necessary imports at the top:
+
+    ```python
+    import io
+    import tarfile
+    from fastapi.responses import StreamingResponse
+    ```
+
+    Note: `get_user_quota_info` should already be imported from Plan 02. If not, add it.
+
+    **Helper: `_get_results_dir_size`** - Place near other helpers:
+    ```python
+    def _get_results_dir_size(results_dir: Path) -> int:
+        """Calculate total size of files in results directory (bytes)."""
+        return sum(f.stat().st_size for f in results_dir.rglob("*") if f.is_file())
+    ```
+
+    **Endpoint: GET /api/v1/jobs/{job_id}/results** (STAT-03)
+    ```python
+    @router.get("/jobs/{job_id}/results")
+    async def download_results(
+        job_id: str,
+        user: dict[str, str] = Depends(get_current_user),
+        db: aiosqlite.Connection = Depends(get_db),
+    ) -> StreamingResponse:
+    ```
+
+    Implementation:
+    1. Call `_get_owned_job(job_id, user["username"], db)` for ownership check.
+    2. Check job status - only allow download for `succeeded` jobs. If status is in ACTIVE_STATUSES, return 409 with `"Job is still running"`. If status is `failed`, return 409 with `"Job failed - no results available"`.
+    3. Get settings via `_get_settings()`.
+    4. Build results path: `settings.workspace_root / job_id / "results"`.
+    5. Check if results directory exists and has files:
+       ```python
+       if not results_dir.exists() or not any(results_dir.iterdir()):
+           return JSONResponse(
+               status_code=404,
+               content={"error": "no_results", "detail": "Job produced no output files"},
+           )
+       ```
+    6. Get max result size for this user via `get_user_quota_info(user["username"], settings)` - use the 4th return value (max_result_size_mb).
+    7. Check total size:
+       ```python
+       total_size = _get_results_dir_size(results_dir)
+       max_size_bytes = max_result_size_mb * 1024 * 1024
+       if total_size > max_size_bytes:
+           raise HTTPException(
+               status_code=413,
+               detail=f"Result size ({total_size} bytes) exceeds limit ({max_size_bytes} bytes)",
+           )
+       ```
+    8. Create tar.gz in memory:
+       ```python
+       buffer = io.BytesIO()
+       with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+           tar.add(str(results_dir), arcname="results")
+       buffer.seek(0)
+       ```
+    9. Return `StreamingResponse`:
+       ```python
+       return StreamingResponse(
+           buffer,
+           media_type="application/gzip",
+           headers={
+               "Content-Disposition": f'attachment; filename="job-{job_id}-results.tar.gz"',
+           },
+       )
+       ```
+
+    The `download_results` return type annotation should be `StreamingResponse` but the actual return includes a possible `JSONResponse` for the no_results case. Add `# type: ignore[return-value]` on the JSONResponse return (same pattern used in submit_job). Or change the return annotation to `Response` from fastapi.
+  </action>
+  <verify>
+    <automated>cd /opt/ds01-jobs && uv run python -c "from ds01_jobs.jobs import download_results; print('Endpoint defined')" && uv run ruff check src/ds01_jobs/jobs.py && uv run mypy src/ds01_jobs/jobs.py</automated>
+  </verify>
+  <done>
+    - GET /api/v1/jobs/{id}/results creates and streams tar.gz archive (STAT-03)
+    - Size check against per-user max_result_size_mb, returns 413 if exceeded
+    - Empty/missing results directory returns 404 with {"error": "no_results"}
+    - Only succeeded jobs allow result download (409 for active/failed)
+    - Ownership check via _get_owned_job (404 masking)
+    - ruff and mypy clean
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Unit tests for results endpoint</name>
+  <files>tests/unit/test_results.py</files>
+  <action>
+    Create `tests/unit/test_results.py` following the same patterns as `test_cancel.py`: use `httpx.AsyncClient` with `ASGITransport`, auth helpers, and `_make_app`.
+
+    **Test helpers** (same auth pattern as other test files):
+    - `_create_test_key()`, `_sign_request()`, `_seed_key()` - same as test_cancel.py.
+    - `_make_app(db_path, workspace_root)` - Like test_cancel.py but ALSO override `_get_settings` to return Settings with the given `workspace_root`. Import `_get_settings` from `ds01_jobs.jobs`.
+    - `_insert_job(db_path, job_id=None, username="testuser", status="succeeded")` - insert a job row, return job_id.
+    - `_build_get_headers(raw_key, path)` - Build auth headers for GET request (method="GET", empty body).
+
+    **Tests:**
+
+    - `test_download_results_success` - Create `tmp_path / "workspaces" / job_id / "results"` directory. Write 2 small files into it (e.g. `output.txt` with "Hello" and `data.csv` with "a,b,c"). Insert a succeeded job. GET `/api/v1/jobs/{job_id}/results`. Assert 200, content-type is `application/gzip`, Content-Disposition header contains the job_id. Read the response content and verify it's a valid tar.gz by opening with `tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz")` and checking the file list contains the expected files.
+
+    - `test_download_results_no_results_dir` - Insert a succeeded job but don't create any workspace directory. GET results. Assert 404 with `{"error": "no_results"}` in response body.
+
+    - `test_download_results_empty_results_dir` - Create the results directory but put no files in it. Assert 404 with `{"error": "no_results"}`.
+
+    - `test_download_results_size_exceeded` - Override settings with `default_max_result_size_mb=0` (or 1 byte equivalent). Create a results directory with a file larger than the limit. Assert 413 response.
+
+    - `test_download_results_not_found` - GET results for a random UUID. Assert 404.
+
+    - `test_download_results_other_users_job` - Insert a job owned by "alice". Authenticate as "bob". GET results. Assert 404.
+
+    - `test_download_results_running_job` - Insert a job with status="running". GET results. Assert 409.
+
+    - `test_download_results_failed_job` - Insert a job with status="failed". GET results. Assert 409.
+
+    All tests use `@pytest.mark.asyncio`, `tmp_path` for workspace, and follow existing test patterns.
+  </action>
+  <verify>
+    <automated>cd /opt/ds01-jobs && uv run pytest tests/unit/test_results.py -v --tb=short</automated>
+  </verify>
+  <done>
+    - Successful download produces valid tar.gz with expected files
+    - Missing or empty results directory returns 404 with no_results error
+    - Oversized results return 413
+    - Non-existent and other users' jobs return 404
+    - Active and failed jobs return 409
+    - All tests pass
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+1. `cd /opt/ds01-jobs && uv run pytest tests/unit/test_results.py -v --tb=short` - all results tests pass
+2. `cd /opt/ds01-jobs && uv run pytest tests/unit/ -v --tb=short` - all tests pass (including existing)
+3. `cd /opt/ds01-jobs && uv run ruff check src/ds01_jobs/jobs.py` - no lint errors
+4. `cd /opt/ds01-jobs && uv run mypy src/ds01_jobs/jobs.py` - no type errors
+</verification>
+
+<success_criteria>
+- GET /api/v1/jobs/{id}/results delivers output files as a downloadable tar.gz archive (STAT-03)
+- Size enforcement: 413 when results exceed configured max_result_size_mb
+- Empty output: 404 with {"error": "no_results", "detail": "Job produced no output files"}
+- Only succeeded jobs allow download (409 for active/failed)
+- Ownership check: 404 for other users' jobs
+- All tests pass, ruff and mypy clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-status-and-results/05-03-SUMMARY.md`
+</output>

--- a/.planning/phases/05-status-and-results/05-03-SUMMARY.md
+++ b/.planning/phases/05-status-and-results/05-03-SUMMARY.md
@@ -1,0 +1,100 @@
+---
+phase: 05-status-and-results
+plan: 03
+subsystem: api
+tags: [fastapi, tarfile, streaming, results]
+
+requires:
+  - phase: 05-status-and-results
+    provides: "status models, _get_owned_job helper, get_user_quota_info"
+provides:
+  - "GET /api/v1/jobs/{id}/results tar.gz streaming endpoint"
+  - "_get_results_dir_size helper for size enforcement"
+affects: [06-clients]
+
+tech-stack:
+  added: [tarfile, io.BytesIO, StreamingResponse]
+  patterns: [in-memory tar.gz archive streaming, per-user result size enforcement]
+
+key-files:
+  created:
+    - tests/unit/test_results.py
+  modified:
+    - src/ds01_jobs/jobs.py
+
+key-decisions:
+  - "Used unittest.mock.patch for _get_settings override in tests since it is called directly (not via Depends)"
+
+patterns-established:
+  - "Result size enforcement: _get_results_dir_size calculates total bytes, compared against per-user max_result_size_mb from get_user_quota_info"
+
+requirements-completed: [STAT-03]
+
+duration: 4min
+completed: 2026-03-07
+---
+
+# Phase 05 Plan 03: Results Download Summary
+
+**GET /api/v1/jobs/{id}/results endpoint streaming tar.gz archives with size enforcement and ownership checks**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-03-07T17:43:55Z
+- **Completed:** 2026-03-07T17:48:20Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Results download endpoint creates and streams tar.gz archive from workspace/results/ directory
+- Size enforcement returns 413 when results exceed per-user max_result_size_mb
+- Empty/missing results return 404 with structured no_results error
+- Only succeeded jobs allow download (409 for active/failed statuses)
+- Ownership check via _get_owned_job returns 404 for other users' jobs (no information leakage)
+- 8 unit tests covering all edge cases
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add results download endpoint** - `1515ac7` (feat)
+2. **Task 2: Unit tests for results endpoint** - `6a9011c` (test)
+
+## Files Created/Modified
+- `src/ds01_jobs/jobs.py` - Added download_results endpoint and _get_results_dir_size helper
+- `tests/unit/test_results.py` - 8 tests covering success, 404, 413, 409, and ownership cases
+
+## Decisions Made
+- Used `unittest.mock.patch` for `_get_settings` override in tests since it is called directly (not via Depends), and the lru_cache needs explicit clearing
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Removed unused imports left by Plan 02 pre-additions**
+- **Found during:** Task 1
+- **Issue:** Plan 02's imports (json, JobDetailResponse, JobError, etc.) were pre-added to jobs.py but the corresponding endpoints weren't implemented yet, causing ruff F401 errors
+- **Fix:** Removed unused imports, kept only those needed for Plan 03
+- **Files modified:** src/ds01_jobs/jobs.py
+- **Verification:** ruff check passes clean
+- **Committed in:** 1515ac7 (Task 1 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug)
+**Impact on plan:** Necessary for ruff compliance. No scope creep.
+
+## Issues Encountered
+- Test for `_get_settings` override required `unittest.mock.patch` instead of `app.dependency_overrides` because the function is called directly, not injected via FastAPI Depends
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Results endpoint complete, ready for CLI client integration in Phase 6
+- All status and results endpoints (Plans 01-03) provide the server-side observability story
+
+---
+*Phase: 05-status-and-results*
+*Completed: 2026-03-07*

--- a/.planning/phases/05-status-and-results/05-VERIFICATION.md
+++ b/.planning/phases/05-status-and-results/05-VERIFICATION.md
@@ -1,0 +1,107 @@
+---
+phase: 05-status-and-results
+verified: 2026-03-07T18:30:00Z
+status: passed
+score: 4/4 must-haves verified
+gaps: []
+---
+
+# Phase 5: Status and Results Verification Report
+
+**Phase Goal:** Users can observe job progress, retrieve logs for debugging, download result files, and check their remaining quota
+**Verified:** 2026-03-07T18:30:00Z
+**Status:** passed
+**Re-verification:** No - initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | GET /api/v1/jobs/{id} returns current status, per-phase timestamps, and error message on failure | VERIFIED | Endpoint `get_job_status` at jobs.py:277 parses `phase_timestamps` JSON, builds `JobError` from `failed_phase`/`error_summary`, includes `queue_position` for queued jobs. 5 tests pass (succeeded, failed with error, queued with position, 404, ownership isolation). |
+| 2 | GET /api/v1/jobs/{id}/logs returns captured stdout/stderr for each completed phase | VERIFIED | Endpoint `get_job_logs` at jobs.py:326 reads clone.log/build.log/run.log from workspace via `_read_log_file` helper with 1MB tail-truncation. 4 tests pass (with files, no files, truncation, ownership). |
+| 3 | GET /api/v1/jobs/{id}/results delivers output files as a downloadable artifact | VERIFIED | Endpoint `download_results` at jobs.py:425 creates in-memory tar.gz via `tarfile.open` and streams via `StreamingResponse`. Size enforcement (413), empty results (404), ownership (404), status guards (409 for active/failed). 8 tests pass. |
+| 4 | GET /api/v1/users/me/quota returns concurrent count, daily count, and configured limits | VERIFIED | Endpoint `get_quota` at jobs.py:399 calls `get_user_quota_info` for limits and `get_user_job_counts` for usage. Returns `QuotaResponse` with username, group, concurrent/daily `UsageCount`, and max_result_size_mb. 3 tests pass (defaults, active jobs reflected, user isolation). |
+
+**Score:** 4/4 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/ds01_jobs/database.py` | phase_timestamps column in jobs schema | VERIFIED | Line 47: `phase_timestamps TEXT DEFAULT '{}'` in SCHEMA_SQL |
+| `src/ds01_jobs/config.py` | default_max_result_size_mb setting | VERIFIED | Line 46: `default_max_result_size_mb: int = 1024` |
+| `src/ds01_jobs/models.py` | Response models for all endpoints | VERIFIED | 8 models: PhaseTimestamp, JobError, JobDetailResponse, JobSummary, JobListResponse, JobLogsResponse, UsageCount, QuotaResponse (lines 100-175) |
+| `src/ds01_jobs/rate_limit.py` | get_user_quota_info helper | VERIFIED | Lines 54-77: returns (group, concurrent, daily, max_result_mb) with YAML fallback |
+| `src/ds01_jobs/executor.py` | Phase timestamps in _update_status | VERIFIED | Lines 122-168: reads/writes phase_timestamps JSON on every status transition; queued timestamp set at lines 67-78 |
+| `src/ds01_jobs/jobs.py` | 5 GET endpoints (status, logs, listing, quota, results) | VERIFIED | get_job_status (277), get_job_logs (326), list_jobs (353), get_quota (399), download_results (425) |
+| `tests/unit/test_status.py` | Unit tests for status/logs/listing/quota | VERIFIED | 623 lines, 16 tests covering all 4 endpoints with edge cases |
+| `tests/unit/test_results.py` | Unit tests for results endpoint | VERIFIED | 363 lines, 8 tests covering success, 404, 413, 409, ownership |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| rate_limit.py | config.py | get_user_quota_info reads default_max_result_size_mb | WIRED | Line 62: `max_result_mb = settings.default_max_result_size_mb` |
+| executor.py | database.py | _update_status writes phase_timestamps JSON | WIRED | Lines 126, 154, 160, 166: reads/writes phase_timestamps column |
+| jobs.py | models.py | Endpoints return typed response models | WIRED | Imports and uses JobDetailResponse, JobLogsResponse, JobListResponse, QuotaResponse |
+| jobs.py | rate_limit.py | Quota and results endpoints call helpers | WIRED | Lines 406-409 (quota), line 451 (results) |
+| jobs.py | config.py | Log and results endpoints use workspace_root | WIRED | Lines 335 (logs), 441 (results) |
+| jobs.py | tarfile/StreamingResponse | Results creates tar.gz and streams | WIRED | Line 462: `tarfile.open`, line 466: `StreamingResponse` |
+| jobs.py | app.py | Router included in app | WIRED | app.py line 72: `app.include_router(jobs_router)` |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| STAT-01 | 05-01, 05-02 | Poll job status via GET /api/v1/jobs/{id} (status, phase timestamps, error) | SATISFIED | get_job_status endpoint returns JobDetailResponse with phases dict, error info, and queue_position; phase_timestamps column in DB; executor records timestamps on transitions |
+| STAT-02 | 05-02 | Retrieve stdout/stderr logs via GET /api/v1/jobs/{id}/logs | SATISFIED | get_job_logs reads clone.log/build.log/run.log from workspace with 1MB tail-truncation |
+| STAT-03 | 05-03 | Download result files via GET /api/v1/jobs/{id}/results | SATISFIED | download_results creates tar.gz from workspace/results/ with size enforcement, status guards, and ownership checks |
+| STAT-04 | 05-01, 05-02 | Check remaining quota via GET /api/v1/users/me/quota | SATISFIED | get_quota returns concurrent/daily usage and limits via get_user_quota_info + get_user_job_counts |
+
+No orphaned requirements found.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| - | - | No anti-patterns detected | - | - |
+
+No TODO/FIXME/PLACEHOLDER comments, no empty implementations, no console.log patterns, no stub returns found in any phase 05 files.
+
+### Human Verification Required
+
+### 1. End-to-end log retrieval with real executor output
+
+**Test:** Submit a job via POST, let executor run, then GET /api/v1/jobs/{id}/logs
+**Expected:** Logs contain actual clone/build/run output from the executor subprocess pipeline
+**Why human:** Unit tests use mock filesystem; verifying real executor log output requires a running Docker environment
+
+### 2. Results tar.gz download with real Docker output
+
+**Test:** Run a job that produces output files to /output/ in the container, then download results
+**Expected:** tar.gz contains the actual files the container produced
+**Why human:** Requires real Docker execution and result collection pipeline
+
+### 3. Phase timestamps accuracy under real execution
+
+**Test:** Submit a job and observe phase_timestamps in the status response during execution
+**Expected:** Timestamps reflect actual wall-clock time for each phase transition
+**Why human:** Timing accuracy and transition correctness require real asynchronous execution
+
+### Gaps Summary
+
+No gaps found. All four success criteria from ROADMAP.md are satisfied:
+
+1. Status endpoint returns current status, per-phase timestamps, and error messages
+2. Logs endpoint returns per-phase stdout/stderr with truncation for large logs
+3. Results endpoint delivers output files as downloadable tar.gz
+4. Quota endpoint returns concurrent/daily usage and configured limits
+
+All 24 unit tests pass. Ruff and mypy report zero issues. All key links are wired. No anti-patterns detected.
+
+---
+
+_Verified: 2026-03-07T18:30:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -42,6 +42,9 @@ class Settings(BaseSettings):
     default_concurrent_limit: int = 3
     default_daily_limit: int = 10
 
+    # Result size limit
+    default_max_result_size_mb: int = 1024
+
     # URL validation
     allowed_github_orgs: list[str] = []
     preflight_timeout_seconds: float = 5.0

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     error_summary TEXT,
     started_at TEXT,
     completed_at TEXT,
+    phase_timestamps TEXT DEFAULT '{}',
     FOREIGN KEY (username) REFERENCES api_keys(username)
 );
 CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -1,6 +1,7 @@
 """Job executor - runs a single job through clone, build, run, collect, cleanup."""
 
 import asyncio
+import json
 import logging
 import os
 import signal
@@ -62,12 +63,17 @@ class JobExecutor:
         workspace.mkdir(parents=True, exist_ok=True)
 
         try:
-            # Set started_at
+            # Set started_at and record queued phase timestamp
             async with aiosqlite.connect(db_path) as db:
                 now = datetime.now(UTC).isoformat()
+                # Read existing created_at for the queued started_at
+                cursor = await db.execute("SELECT created_at FROM jobs WHERE id=?", (job_id,))
+                row = await cursor.fetchone()
+                created_at = row[0] if row else now
+                timestamps = {"queued": {"started_at": created_at, "ended_at": now}}
                 await db.execute(
-                    "UPDATE jobs SET started_at=?, updated_at=? WHERE id=?",
-                    (now, now, job_id),
+                    "UPDATE jobs SET started_at=?, updated_at=?, phase_timestamps=? WHERE id=?",
+                    (now, now, json.dumps(timestamps), job_id),
                 )
                 await db.commit()
 
@@ -113,24 +119,52 @@ class JobExecutor:
     ) -> None:
         """Atomically update job status in SQLite."""
         now = datetime.now(UTC).isoformat()
+        phase_order = ["cloning", "building", "running"]
+
         async with aiosqlite.connect(db_path) as db:
+            # Read current phase_timestamps
+            cursor = await db.execute("SELECT phase_timestamps FROM jobs WHERE id=?", (job_id,))
+            row = await cursor.fetchone()
+            timestamps: dict[str, dict[str, str | None]] = (
+                json.loads(row[0]) if row and row[0] else {}
+            )
+
+            # Update timestamps based on the new status
+            if status in phase_order:
+                # Close the previous phase if applicable
+                idx = phase_order.index(status)
+                if idx > 0:
+                    prev_phase = phase_order[idx - 1]
+                    if prev_phase in timestamps and timestamps[prev_phase].get("ended_at") is None:
+                        timestamps[prev_phase]["ended_at"] = now
+                # Start the new phase
+                timestamps[status] = {"started_at": now, "ended_at": None}
+            elif status in ("succeeded", "failed"):
+                # Close whatever phase was last active
+                for phase in reversed(phase_order):
+                    if phase in timestamps and timestamps[phase].get("ended_at") is None:
+                        timestamps[phase]["ended_at"] = now
+                        break
+
+            ts_json = json.dumps(timestamps)
+
             if status in ("succeeded", "failed"):
                 await db.execute(
                     "UPDATE jobs SET status=?, updated_at=?, completed_at=?, "
-                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
-                    (status, now, now, failed_phase, exit_code, error_summary, job_id),
+                    "failed_phase=?, exit_code=?, error_summary=?, phase_timestamps=? WHERE id=?",
+                    (status, now, now, failed_phase, exit_code, error_summary, ts_json, job_id),
                 )
             elif status == "cloning":
                 await db.execute(
                     "UPDATE jobs SET status=?, updated_at=?, started_at=?, "
-                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
-                    (status, now, now, failed_phase, exit_code, error_summary, job_id),
+                    "failed_phase=?, exit_code=?, error_summary=?, phase_timestamps=? WHERE id=?",
+                    (status, now, now, failed_phase, exit_code, error_summary, ts_json, job_id),
                 )
             else:
                 await db.execute(
                     "UPDATE jobs SET status=?, updated_at=?, "
-                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
-                    (status, now, failed_phase, exit_code, error_summary, job_id),
+                    "failed_phase=?, exit_code=?, error_summary=?, phase_timestamps=? WHERE id=?",
+                    (status, now, failed_phase, exit_code, error_summary, ts_json, job_id),
                 )
             await db.commit()
 

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -4,21 +4,30 @@ POST /api/v1/jobs orchestrates the full validation pipeline and returns
 202 Accepted with a queued job.
 
 POST /api/v1/jobs/{job_id}/cancel marks a job as cancelled (failed).
+
+GET /api/v1/jobs/{job_id} returns detailed job status.
+GET /api/v1/jobs/{job_id}/logs returns per-phase log content.
+GET /api/v1/jobs returns paginated listing of the user's jobs.
+GET /api/v1/users/me/quota returns the user's quota and usage.
+GET /api/v1/jobs/{job_id}/results streams a tar.gz archive of job output.
 """
 
+import io
+import tarfile
 import uuid
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
+from pathlib import Path
 
 import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from ds01_jobs.auth import get_current_user
 from ds01_jobs.config import Settings
 from ds01_jobs.database import get_db
 from ds01_jobs.models import JobResponse, JobSubmitRequest
-from ds01_jobs.rate_limit import check_rate_limits
+from ds01_jobs.rate_limit import check_rate_limits, get_user_quota_info
 from ds01_jobs.scanner import scan_dockerfile
 from ds01_jobs.url_validation import check_ssrf, validate_repo_url_format, verify_repo_accessible
 
@@ -31,6 +40,37 @@ MAX_TIMEOUT_SECONDS = 86400  # 24 hours
 def _get_settings() -> Settings:
     """Return cached Settings instance."""
     return Settings()
+
+
+MAX_LOG_BYTES = 1_048_576  # 1 MB per phase
+DEFAULT_PAGE_LIMIT = 20
+MAX_PAGE_LIMIT = 100
+
+
+async def _get_owned_job(
+    job_id: str,
+    username: str,
+    db: aiosqlite.Connection,
+) -> aiosqlite.Row:
+    """Fetch a job row, raising 404 if missing or not owned by user."""
+    cursor = await db.execute("SELECT * FROM jobs WHERE id = ?", (job_id,))
+    row = await cursor.fetchone()
+    if row is None or row["username"] != username:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return row
+
+
+def _read_log_file(path: Path, max_bytes: int = MAX_LOG_BYTES) -> tuple[str, bool]:
+    """Read a log file, tail-truncating if too large. Returns (content, truncated)."""
+    if not path.exists():
+        return "", False
+    size = path.stat().st_size
+    if size <= max_bytes:
+        return path.read_text(errors="replace"), False
+    with path.open("rb") as f:
+        f.seek(size - max_bytes)
+        content = f.read().decode(errors="replace")
+    return content, True
 
 
 @router.post("/jobs", status_code=202, response_model=JobResponse)
@@ -220,3 +260,58 @@ async def cancel_job(
     await db.commit()
 
     return {"job_id": job_id, "status": "failed", "message": "Job cancelled"}
+
+
+def _get_results_dir_size(results_dir: Path) -> int:
+    """Calculate total size of files in results directory (bytes)."""
+    return sum(f.stat().st_size for f in results_dir.rglob("*") if f.is_file())
+
+
+@router.get("/jobs/{job_id}/results")
+async def download_results(
+    job_id: str,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> Response:
+    """Stream a tar.gz archive of the job's output files."""
+    row = await _get_owned_job(job_id, user["username"], db)
+
+    # Only succeeded jobs can have results downloaded
+    if row["status"] in ACTIVE_STATUSES:
+        raise HTTPException(status_code=409, detail="Job is still running")
+    if row["status"] == "failed":
+        raise HTTPException(status_code=409, detail="Job failed - no results available")
+
+    settings = _get_settings()
+    results_dir = settings.workspace_root / job_id / "results"
+
+    # Check if results exist
+    if not results_dir.exists() or not any(results_dir.iterdir()):
+        return JSONResponse(
+            status_code=404,
+            content={"error": "no_results", "detail": "Job produced no output files"},
+        )
+
+    # Size enforcement
+    _, _, _, max_result_size_mb = get_user_quota_info(user["username"], settings)
+    total_size = _get_results_dir_size(results_dir)
+    max_size_bytes = max_result_size_mb * 1024 * 1024
+    if total_size > max_size_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Result size ({total_size} bytes) exceeds limit ({max_size_bytes} bytes)",
+        )
+
+    # Create tar.gz in memory
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        tar.add(str(results_dir), arcname="results")
+    buffer.seek(0)
+
+    return StreamingResponse(
+        buffer,
+        media_type="application/gzip",
+        headers={
+            "Content-Disposition": f'attachment; filename="job-{job_id}-results.tar.gz"',
+        },
+    )

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -13,6 +13,7 @@ GET /api/v1/jobs/{job_id}/results streams a tar.gz archive of job output.
 """
 
 import io
+import json
 import tarfile
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -26,8 +27,19 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from ds01_jobs.auth import get_current_user
 from ds01_jobs.config import Settings
 from ds01_jobs.database import get_db
-from ds01_jobs.models import JobResponse, JobSubmitRequest
-from ds01_jobs.rate_limit import check_rate_limits, get_user_quota_info
+from ds01_jobs.models import (
+    JobDetailResponse,
+    JobError,
+    JobListResponse,
+    JobLogsResponse,
+    JobResponse,
+    JobSubmitRequest,
+    JobSummary,
+    PhaseTimestamp,
+    QuotaResponse,
+    UsageCount,
+)
+from ds01_jobs.rate_limit import check_rate_limits, get_user_job_counts, get_user_quota_info
 from ds01_jobs.scanner import scan_dockerfile
 from ds01_jobs.url_validation import check_ssrf, validate_repo_url_format, verify_repo_accessible
 
@@ -260,6 +272,149 @@ async def cancel_job(
     await db.commit()
 
     return {"job_id": job_id, "status": "failed", "message": "Job cancelled"}
+
+
+@router.get("/jobs/{job_id}", response_model=JobDetailResponse)
+async def get_job_status(
+    job_id: str,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> JobDetailResponse:
+    """Return detailed status for a single job."""
+    row = await _get_owned_job(job_id, user["username"], db)
+
+    # Parse phase timestamps
+    raw_phases = json.loads(row["phase_timestamps"] or "{}")
+    phases = {k: PhaseTimestamp(**v) for k, v in raw_phases.items()}
+
+    # Build error info
+    error: JobError | None = None
+    if row["failed_phase"]:
+        error = JobError(
+            phase=row["failed_phase"],
+            message=row["error_summary"] or "",
+            exit_code=row["exit_code"],
+        )
+
+    # Queue position (1-based)
+    queue_position: int | None = None
+    if row["status"] == "queued":
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM jobs WHERE status = 'queued' AND created_at < ?",
+            (row["created_at"],),
+        )
+        count_row = await cursor.fetchone()
+        queue_position = (count_row[0] if count_row else 0) + 1
+
+    return JobDetailResponse(
+        job_id=row["id"],
+        status=row["status"],
+        job_name=row["job_name"],
+        repo_url=row["repo_url"],
+        branch=row["branch"],
+        gpu_count=row["gpu_count"],
+        submitted_by=row["username"],
+        created_at=row["created_at"],
+        started_at=row["started_at"],
+        completed_at=row["completed_at"],
+        phases=phases,
+        error=error,
+        queue_position=queue_position,
+    )
+
+
+@router.get("/jobs/{job_id}/logs", response_model=JobLogsResponse)
+async def get_job_logs(
+    job_id: str,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> JobLogsResponse:
+    """Return per-phase log content for a job."""
+    await _get_owned_job(job_id, user["username"], db)
+
+    workspace = _get_settings().workspace_root / job_id
+    logs: dict[str, str] = {}
+    truncated: dict[str, bool] = {}
+
+    for phase in ("clone", "build", "run"):
+        content, was_truncated = _read_log_file(workspace / f"{phase}.log")
+        if content:
+            logs[phase] = content
+            if was_truncated:
+                truncated[phase] = True
+
+    return JobLogsResponse(
+        job_id=job_id,
+        logs=logs,
+        truncated=truncated if truncated else None,
+    )
+
+
+@router.get("/jobs", response_model=JobListResponse)
+async def list_jobs(
+    status: str | None = None,
+    limit: int = DEFAULT_PAGE_LIMIT,
+    offset: int = 0,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> JobListResponse:
+    """Return a paginated listing of the user's jobs."""
+    limit = min(limit, MAX_PAGE_LIMIT)
+    offset = max(offset, 0)
+
+    where = "WHERE username = ?"
+    params: list[str | int] = [user["username"]]
+    if status is not None:
+        where += " AND status = ?"
+        params.append(status)
+
+    # Total count
+    cursor = await db.execute(f"SELECT COUNT(*) FROM jobs {where}", params)
+    count_row = await cursor.fetchone()
+    total = count_row[0] if count_row else 0
+
+    # Fetch page
+    cursor = await db.execute(
+        f"SELECT id, status, job_name, repo_url, created_at, completed_at "
+        f"FROM jobs {where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        [*params, limit, offset],
+    )
+    rows = await cursor.fetchall()
+
+    summaries = [
+        JobSummary(
+            job_id=r["id"],
+            status=r["status"],
+            job_name=r["job_name"],
+            repo_url=r["repo_url"],
+            created_at=r["created_at"],
+            completed_at=r["completed_at"],
+        )
+        for r in rows
+    ]
+
+    return JobListResponse(jobs=summaries, total=total, limit=limit, offset=offset)
+
+
+@router.get("/users/me/quota", response_model=QuotaResponse)
+async def get_quota(
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> QuotaResponse:
+    """Return quota usage and limits for the authenticated user."""
+    settings = _get_settings()
+    group, concurrent_limit, daily_limit, max_result_size_mb = get_user_quota_info(
+        user["username"], settings
+    )
+    concurrent_used, daily_used = await get_user_job_counts(db, user["username"])
+
+    return QuotaResponse(
+        username=user["username"],
+        group=group,
+        concurrent=UsageCount(used=concurrent_used, limit=concurrent_limit),
+        daily=UsageCount(used=daily_used, limit=daily_limit),
+        max_result_size_mb=max_result_size_mb,
+    )
 
 
 def _get_results_dir_size(results_dir: Path) -> int:

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -92,3 +92,84 @@ class ScanViolationModel(BaseModel):
     severity: str
     rule: str
     message: str
+
+
+# --- Status and results models ---
+
+
+class PhaseTimestamp(BaseModel):
+    """Start/end timestamps for a single job phase."""
+
+    started_at: str
+    ended_at: str | None = None
+
+
+class JobError(BaseModel):
+    """Structured error info for failed jobs."""
+
+    phase: str
+    message: str
+    exit_code: int | None = None
+
+
+class JobDetailResponse(BaseModel):
+    """Response for GET /api/v1/jobs/{id}."""
+
+    job_id: str
+    status: str
+    job_name: str
+    repo_url: str
+    branch: str
+    gpu_count: int
+    submitted_by: str
+    created_at: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    phases: dict[str, PhaseTimestamp]
+    error: JobError | None = None
+    queue_position: int | None = None
+
+
+class JobSummary(BaseModel):
+    """Single job entry in a listing response."""
+
+    job_id: str
+    status: str
+    job_name: str
+    repo_url: str
+    created_at: str
+    completed_at: str | None = None
+
+
+class JobListResponse(BaseModel):
+    """Response for GET /api/v1/jobs."""
+
+    jobs: list[JobSummary]
+    total: int
+    limit: int
+    offset: int
+
+
+class JobLogsResponse(BaseModel):
+    """Response for GET /api/v1/jobs/{id}/logs."""
+
+    job_id: str
+    logs: dict[str, str]
+    truncated: dict[str, bool] | None = None
+
+
+class UsageCount(BaseModel):
+    """Current usage vs configured limit."""
+
+    used: int
+    limit: int
+
+
+class QuotaResponse(BaseModel):
+    """Response for GET /api/v1/users/me/quota."""
+
+    username: str
+    group: str
+    concurrent: UsageCount
+    daily: UsageCount
+    max_result_size_mb: int

--- a/src/ds01_jobs/rate_limit.py
+++ b/src/ds01_jobs/rate_limit.py
@@ -51,6 +51,32 @@ def get_user_limits(username: str, settings: Settings) -> tuple[int, int]:
     return concurrent, daily
 
 
+def get_user_quota_info(username: str, settings: Settings) -> tuple[str, int, int, int]:
+    """Return (group_name, concurrent_limit, daily_limit, max_result_size_mb) for a user.
+
+    Reads group membership and limits from resource-limits.yaml,
+    falling back to settings defaults for unmapped users.
+    """
+    concurrent = settings.default_concurrent_limit
+    daily = settings.default_daily_limit
+    max_result_mb = settings.default_max_result_size_mb
+    group = "default"
+
+    data = load_resource_limits(settings.resource_limits_path)
+    groups = data.get("groups", {})
+    users = data.get("users", {})
+
+    group_name = users.get(username)
+    if group_name and group_name in groups:
+        group = group_name
+        group_cfg = groups[group_name]
+        concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
+        daily = group_cfg.get("max_daily_submissions", daily)
+        max_result_mb = group_cfg.get("max_result_size_mb", max_result_mb)
+
+    return group, concurrent, daily, max_result_mb
+
+
 async def get_user_job_counts(db: aiosqlite.Connection, username: str) -> tuple[int, int]:
     """Return (concurrent_active_count, daily_submission_count) for a user."""
     # Concurrent: jobs in active statuses

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,6 +1,7 @@
 """Unit tests for the job executor module."""
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -438,3 +439,35 @@ async def test_cancel_check_stops_execution(
     docker_cmds = [c[0] for c in calls if c[0] and c[0][0] == str(executor_settings.docker_bin)]
     build_calls = [c for c in docker_cmds if len(c) > 1 and c[1] == "build"]
     assert len(build_calls) == 0, "Build should not have been called after cancel"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_phase_timestamps_recorded(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Successful execution records phase timestamps for queued, cloning, building, running."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT phase_timestamps FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    timestamps = json.loads(row[0])
+
+    # All four phases should be present
+    for phase in ("queued", "cloning", "building", "running"):
+        assert phase in timestamps, f"Missing phase: {phase}"
+        assert "started_at" in timestamps[phase], f"{phase} missing started_at"
+
+    # Completed phases should have ended_at set
+    for phase in ("queued", "cloning", "building", "running"):
+        assert timestamps[phase]["ended_at"] is not None, f"{phase} missing ended_at"

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -8,7 +8,12 @@ import pytest
 
 from ds01_jobs.config import Settings
 from ds01_jobs.database import init_db
-from ds01_jobs.rate_limit import check_rate_limits, get_user_job_counts, get_user_limits
+from ds01_jobs.rate_limit import (
+    check_rate_limits,
+    get_user_job_counts,
+    get_user_limits,
+    get_user_quota_info,
+)
 
 
 def _test_settings(**overrides: object) -> Settings:
@@ -256,3 +261,55 @@ async def test_rate_limit_429_body_structure(tmp_path: Path) -> None:
     assert "limit" in error
     assert "current" in error
     assert "retry_after" in error
+
+
+# --- get_user_quota_info tests ---
+
+
+def test_get_user_quota_info_defaults() -> None:
+    """No YAML file returns default group and settings defaults."""
+    settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
+    group, concurrent, daily, max_result_mb = get_user_quota_info("someuser", settings)
+    assert group == "default"
+    assert concurrent == 3
+    assert daily == 10
+    assert max_result_mb == 1024
+
+
+def test_get_user_quota_info_from_yaml(tmp_path: Path) -> None:
+    """User mapped to student group with max_result_size_mb returns group values."""
+    yaml_path = tmp_path / "resource-limits.yaml"
+    yaml_path.write_text(
+        "groups:\n"
+        "  student:\n"
+        "    max_concurrent_jobs: 2\n"
+        "    max_daily_submissions: 5\n"
+        "    max_result_size_mb: 512\n"
+        "users:\n"
+        "  bob: student\n"
+    )
+    settings = _test_settings(resource_limits_path=yaml_path)
+    group, concurrent, daily, max_result_mb = get_user_quota_info("bob", settings)
+    assert group == "student"
+    assert concurrent == 2
+    assert daily == 5
+    assert max_result_mb == 512
+
+
+def test_get_user_quota_info_no_result_size_in_yaml(tmp_path: Path) -> None:
+    """Group without max_result_size_mb falls back to settings default."""
+    yaml_path = tmp_path / "resource-limits.yaml"
+    yaml_path.write_text(
+        "groups:\n"
+        "  researcher:\n"
+        "    max_concurrent_jobs: 5\n"
+        "    max_daily_submissions: 20\n"
+        "users:\n"
+        "  alice: researcher\n"
+    )
+    settings = _test_settings(resource_limits_path=yaml_path)
+    group, concurrent, daily, max_result_mb = get_user_quota_info("alice", settings)
+    assert group == "researcher"
+    assert concurrent == 5
+    assert daily == 20
+    assert max_result_mb == 1024

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,0 +1,363 @@
+"""Tests for GET /api/v1/jobs/{job_id}/results endpoint."""
+
+import hashlib
+import hmac
+import io
+import secrets
+import tarfile
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import get_db, init_db
+from ds01_jobs.jobs import _get_settings
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash."""
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request."""
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+) -> None:
+    """Insert a test API key into the database."""
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+        )
+        await db.commit()
+
+
+async def _insert_job(
+    db_path: Path,
+    job_id: str | None = None,
+    username: str = "testuser",
+    status: str = "succeeded",
+) -> str:
+    """Insert a test job and return its ID."""
+    jid = job_id or str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                jid,
+                username,
+                "https://github.com/test/repo",
+                "main",
+                1,
+                "test-job",
+                status,
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+    return jid
+
+
+def _make_app(db_path: Path, workspace_root: Path | None = None):
+    """Create a test app with results endpoint."""
+    from unittest.mock import patch
+
+    from ds01_jobs.app import create_app
+    from ds01_jobs.config import Settings
+
+    app = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    if workspace_root is not None:
+        settings = Settings(_env_file=None, workspace_root=workspace_root)
+        # Clear LRU cache and patch the function so direct calls use test settings
+        _get_settings.cache_clear()
+        patcher = patch("ds01_jobs.jobs._get_settings", return_value=settings)
+        patcher.start()
+        # Store patcher on app so caller could stop it if needed
+        app._test_patcher = patcher  # type: ignore[attr-defined]
+
+    return app
+
+
+def _build_get_headers(raw_key: str, path: str) -> dict[str, str]:
+    """Build auth + signing headers for a GET request."""
+    headers = _sign_request(raw_key, "GET", path, body=b"")
+    headers["Authorization"] = f"Bearer {raw_key}"
+    return headers
+
+
+@pytest.mark.asyncio
+async def test_download_results_success(tmp_path: Path) -> None:
+    """Successful download produces a valid tar.gz with expected files."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    # Create workspace results directory with files
+    workspace_root = tmp_path / "workspaces"
+    results_dir = workspace_root / job_id / "results"
+    results_dir.mkdir(parents=True)
+    (results_dir / "output.txt").write_text("Hello")
+    (results_dir / "data.csv").write_text("a,b,c")
+
+    app = _make_app(db_path, workspace_root=workspace_root)
+    path = f"/api/v1/jobs/{job_id}/results"
+    headers = _build_get_headers(raw_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/gzip"
+    assert job_id in resp.headers["content-disposition"]
+
+    # Verify tar.gz content
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        names = tar.getnames()
+        assert "results/output.txt" in names
+        assert "results/data.csv" in names
+
+
+@pytest.mark.asyncio
+async def test_download_results_no_results_dir(tmp_path: Path) -> None:
+    """No workspace directory returns 404 with no_results error."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    workspace_root = tmp_path / "workspaces"
+    # Don't create any workspace directory
+
+    app = _make_app(db_path, workspace_root=workspace_root)
+    path = f"/api/v1/jobs/{job_id}/results"
+    headers = _build_get_headers(raw_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+    data = resp.json()
+    assert data["error"] == "no_results"
+
+
+@pytest.mark.asyncio
+async def test_download_results_empty_results_dir(tmp_path: Path) -> None:
+    """Empty results directory returns 404 with no_results error."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    workspace_root = tmp_path / "workspaces"
+    results_dir = workspace_root / job_id / "results"
+    results_dir.mkdir(parents=True)
+    # Directory exists but is empty
+
+    app = _make_app(db_path, workspace_root=workspace_root)
+    path = f"/api/v1/jobs/{job_id}/results"
+    headers = _build_get_headers(raw_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+    data = resp.json()
+    assert data["error"] == "no_results"
+
+
+@pytest.mark.asyncio
+async def test_download_results_size_exceeded(tmp_path: Path) -> None:
+    """Oversized results return 413."""
+    from unittest.mock import patch
+
+    from ds01_jobs.config import Settings
+
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    workspace_root = tmp_path / "workspaces"
+    results_dir = workspace_root / job_id / "results"
+    results_dir.mkdir(parents=True)
+    # Write a file that exceeds the limit (we'll set limit to 0 MB via settings)
+    (results_dir / "big.bin").write_bytes(b"x" * 1024)
+
+    # Settings with 0 MB limit so any file exceeds it
+    settings = Settings(_env_file=None, workspace_root=workspace_root, default_max_result_size_mb=0)
+
+    from ds01_jobs.app import create_app
+
+    app = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    _get_settings.cache_clear()
+    with patch("ds01_jobs.jobs._get_settings", return_value=settings):
+        path = f"/api/v1/jobs/{job_id}/results"
+        headers = _build_get_headers(raw_key, path)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_download_results_not_found(tmp_path: Path) -> None:
+    """Non-existent job returns 404."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    fake_id = str(uuid.uuid4())
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{fake_id}/results"
+    headers = _build_get_headers(raw_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_results_other_users_job(tmp_path: Path) -> None:
+    """Other user's job returns 404 (not 403)."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    # Alice's key
+    alice_key, alice_kid, alice_hash = _create_test_key()
+    await _seed_key(db_path, alice_kid, alice_hash, username="alice")
+
+    # Bob's key
+    bob_key, bob_kid, bob_hash = _create_test_key()
+    await _seed_key(db_path, bob_kid, bob_hash, username="bob")
+
+    # Alice's job
+    job_id = await _insert_job(db_path, username="alice", status="succeeded")
+
+    # Bob tries to download Alice's results
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{job_id}/results"
+    headers = _build_get_headers(bob_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_results_running_job(tmp_path: Path) -> None:
+    """Running job returns 409."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="running")
+
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{job_id}/results"
+    headers = _build_get_headers(raw_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 409
+    assert "still running" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_download_results_failed_job(tmp_path: Path) -> None:
+    """Failed job returns 409."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="failed")
+
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{job_id}/results"
+    headers = _build_get_headers(raw_key, path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 409
+    assert "failed" in resp.json()["detail"]

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,623 @@
+"""Tests for GET endpoints: status detail, logs, listing, and quota."""
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import aiosqlite
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import get_db, init_db
+from ds01_jobs.jobs import _get_settings
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash."""
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request."""
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+) -> None:
+    """Insert a test API key into the database."""
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+        )
+        await db.commit()
+
+
+async def _insert_job(
+    db_path: Path,
+    job_id: str | None = None,
+    username: str = "testuser",
+    status: str = "succeeded",
+    created_at: str | None = None,
+    phase_timestamps: str | None = None,
+    failed_phase: str | None = None,
+    exit_code: int | None = None,
+    error_summary: str | None = None,
+) -> str:
+    """Insert a test job and return its ID."""
+    jid = job_id or str(uuid.uuid4())
+    now = created_at or datetime.now(UTC).isoformat()
+    pts = phase_timestamps or "{}"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at, phase_timestamps, failed_phase, exit_code, "
+            "error_summary) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                jid,
+                username,
+                "https://github.com/test/repo",
+                "main",
+                1,
+                "test-job",
+                status,
+                now,
+                now,
+                pts,
+                failed_phase,
+                exit_code,
+                error_summary,
+            ),
+        )
+        await db.commit()
+    return jid
+
+
+def _make_app(db_path: Path, workspace_root: Path | None = None):
+    """Create a test app with overridden DB and optionally settings."""
+    from ds01_jobs.app import create_app
+    from ds01_jobs.config import Settings
+
+    app = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    kwargs: dict[str, object] = {"_env_file": None}
+    if workspace_root is not None:
+        kwargs["workspace_root"] = workspace_root
+    test_settings = Settings(**kwargs)  # type: ignore[arg-type]
+
+    def _override_settings() -> Settings:
+        return test_settings
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[_get_settings] = _override_settings
+
+    # Also clear the lru_cache so direct calls pick up the override
+    _get_settings.cache_clear()
+
+    return app
+
+
+def _build_get_headers(raw_key: str, method: str, path: str) -> dict[str, str]:
+    """Build auth headers for a GET request (no body)."""
+    headers = _sign_request(raw_key, method, path, body=b"")
+    headers["Authorization"] = f"Bearer {raw_key}"
+    return headers
+
+
+# ── Status detail tests ──
+
+
+@pytest.mark.asyncio
+async def test_get_status_succeeded_job(tmp_path: Path) -> None:
+    """Succeeded job returns full detail with phases and no error."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    pts = json.dumps(
+        {
+            "queued": {"started_at": "2026-01-01T00:00:00", "ended_at": "2026-01-01T00:01:00"},
+            "cloning": {"started_at": "2026-01-01T00:01:00", "ended_at": "2026-01-01T00:02:00"},
+            "building": {"started_at": "2026-01-01T00:02:00", "ended_at": "2026-01-01T00:05:00"},
+            "running": {"started_at": "2026-01-01T00:05:00", "ended_at": "2026-01-01T00:10:00"},
+        }
+    )
+    job_id = await _insert_job(db_path, status="succeeded", phase_timestamps=pts)
+
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{job_id}"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["job_id"] == job_id
+    assert data["status"] == "succeeded"
+    assert data["submitted_by"] == "testuser"
+    assert data["repo_url"] == "https://github.com/test/repo"
+    assert "queued" in data["phases"]
+    assert "running" in data["phases"]
+    assert data["phases"]["queued"]["started_at"] == "2026-01-01T00:00:00"
+    assert data["error"] is None
+    assert data["queue_position"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_status_failed_job(tmp_path: Path) -> None:
+    """Failed job returns structured error info."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    job_id = await _insert_job(
+        db_path,
+        status="failed",
+        failed_phase="build",
+        exit_code=1,
+        error_summary="Docker build failed",
+    )
+
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{job_id}"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"]["phase"] == "build"
+    assert data["error"]["message"] == "Docker build failed"
+    assert data["error"]["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_status_queued_job_has_queue_position(tmp_path: Path) -> None:
+    """Queued job returns correct 1-based queue position."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    # Insert 3 queued jobs with increasing timestamps
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    ids = []
+    for i in range(3):
+        ts = (base + timedelta(seconds=i)).isoformat()
+        jid = await _insert_job(db_path, status="queued", created_at=ts)
+        ids.append(jid)
+
+    # Get status of the third job
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{ids[2]}"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["queue_position"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_status_not_found(tmp_path: Path) -> None:
+    """Non-existent job returns 404."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    fake_id = str(uuid.uuid4())
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{fake_id}"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_status_other_users_job(tmp_path: Path) -> None:
+    """Another user's job returns 404 (not 403)."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    # Bob's key
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, username="bob")
+
+    # Alice's job
+    job_id = await _insert_job(db_path, username="alice", status="succeeded")
+
+    app = _make_app(db_path)
+    path = f"/api/v1/jobs/{job_id}"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+
+
+# ── Log tests ──
+
+
+@pytest.mark.asyncio
+async def test_get_logs_with_log_files(tmp_path: Path) -> None:
+    """Log endpoint returns content from existing log files."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    # Create workspace log files
+    workspace = tmp_path / "workspaces" / job_id
+    workspace.mkdir(parents=True)
+    (workspace / "clone.log").write_text("Cloning into 'repo'...\n")
+    (workspace / "build.log").write_text("Step 1/5: FROM python:3.13\n")
+
+    from ds01_jobs.config import Settings
+
+    test_settings = Settings(_env_file=None, workspace_root=tmp_path / "workspaces")
+
+    app = _make_app(db_path, workspace_root=tmp_path / "workspaces")
+    path = f"/api/v1/jobs/{job_id}/logs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    with patch("ds01_jobs.jobs._get_settings", return_value=test_settings):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "clone" in data["logs"]
+    assert "build" in data["logs"]
+    assert "Cloning" in data["logs"]["clone"]
+    assert data["truncated"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_logs_no_log_files(tmp_path: Path) -> None:
+    """No log files returns 200 with empty logs dict."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    job_id = await _insert_job(db_path, status="queued")
+
+    from ds01_jobs.config import Settings
+
+    test_settings = Settings(_env_file=None, workspace_root=tmp_path / "workspaces")
+
+    app = _make_app(db_path, workspace_root=tmp_path / "workspaces")
+    path = f"/api/v1/jobs/{job_id}/logs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    with patch("ds01_jobs.jobs._get_settings", return_value=test_settings):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["logs"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_logs_truncated(tmp_path: Path) -> None:
+    """Large log file is truncated and flagged."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    # Create a >1MB log file
+    workspace = tmp_path / "workspaces" / job_id
+    workspace.mkdir(parents=True)
+    (workspace / "build.log").write_bytes(b"x" * (1_048_576 + 1000))
+
+    from ds01_jobs.config import Settings
+
+    test_settings = Settings(_env_file=None, workspace_root=tmp_path / "workspaces")
+
+    app = _make_app(db_path, workspace_root=tmp_path / "workspaces")
+    path = f"/api/v1/jobs/{job_id}/logs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    with patch("ds01_jobs.jobs._get_settings", return_value=test_settings):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["truncated"] is not None
+    assert data["truncated"]["build"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_logs_other_users_job(tmp_path: Path) -> None:
+    """Logs for another user's job returns 404."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, username="bob")
+
+    job_id = await _insert_job(db_path, username="alice", status="succeeded")
+
+    app = _make_app(db_path, workspace_root=tmp_path / "workspaces")
+    path = f"/api/v1/jobs/{job_id}/logs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 404
+
+
+# ── Listing tests ──
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_returns_own_jobs(tmp_path: Path) -> None:
+    """Listing returns only the authenticated user's jobs."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    # 3 jobs for testuser, 2 for otheruser
+    for _ in range(3):
+        await _insert_job(db_path, username="testuser", status="succeeded")
+    for _ in range(2):
+        await _insert_job(db_path, username="otheruser", status="succeeded")
+
+    app = _make_app(db_path)
+    path = "/api/v1/jobs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+    assert len(data["jobs"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_status_filter(tmp_path: Path) -> None:
+    """Status filter returns only matching jobs."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    await _insert_job(db_path, status="running")
+    await _insert_job(db_path, status="running")
+    await _insert_job(db_path, status="succeeded")
+
+    app = _make_app(db_path)
+    path = "/api/v1/jobs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, params={"status": "running"}, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert all(j["status"] == "running" for j in data["jobs"])
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_pagination(tmp_path: Path) -> None:
+    """Pagination returns correct pages."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    for i in range(5):
+        ts = (base + timedelta(seconds=i)).isoformat()
+        await _insert_job(db_path, status="succeeded", created_at=ts)
+
+    app = _make_app(db_path)
+    path = "/api/v1/jobs"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Page 1
+        headers1 = _build_get_headers(raw_key, "GET", path)
+        resp = await client.get(path, params={"limit": 2, "offset": 0}, headers=headers1)
+        data = resp.json()
+        assert data["total"] == 5
+        assert len(data["jobs"]) == 2
+        assert data["limit"] == 2
+        assert data["offset"] == 0
+
+        # Page 2 (fresh headers to avoid nonce replay)
+        headers2 = _build_get_headers(raw_key, "GET", path)
+        resp = await client.get(path, params={"limit": 2, "offset": 2}, headers=headers2)
+        data = resp.json()
+        assert data["total"] == 5
+        assert len(data["jobs"]) == 2
+        assert data["offset"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_empty(tmp_path: Path) -> None:
+    """No jobs returns 200 with empty list and total=0."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    path = "/api/v1/jobs"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["jobs"] == []
+    assert data["total"] == 0
+
+
+# ── Quota tests ──
+
+
+@pytest.mark.asyncio
+async def test_get_quota_defaults(tmp_path: Path) -> None:
+    """Without resource-limits.yaml, quota returns defaults."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    path = "/api/v1/users/me/quota"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["group"] == "default"
+    assert data["concurrent"]["limit"] == 3
+    assert data["daily"]["limit"] == 10
+    assert data["max_result_size_mb"] == 1024
+    assert data["username"] == "testuser"
+
+
+@pytest.mark.asyncio
+async def test_get_quota_with_active_jobs(tmp_path: Path) -> None:
+    """Active jobs are reflected in concurrent.used."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    await _insert_job(db_path, status="queued")
+    await _insert_job(db_path, status="running")
+
+    app = _make_app(db_path)
+    path = "/api/v1/users/me/quota"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["concurrent"]["used"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_quota_other_user_isolation(tmp_path: Path) -> None:
+    """Other user's jobs do not affect testuser's quota."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    # Insert active jobs for a different user
+    await _insert_job(db_path, username="otheruser", status="running")
+    await _insert_job(db_path, username="otheruser", status="queued")
+
+    app = _make_app(db_path)
+    path = "/api/v1/users/me/quota"
+    headers = _build_get_headers(raw_key, "GET", path)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["concurrent"]["used"] == 0
+    assert data["daily"]["used"] == 0


### PR DESCRIPTION
## Summary
- Add response models for job status (phase timestamps, error messages), logs, listing, and quota
- Add `GET /api/v1/jobs/{id}` - status with per-phase timestamps and human-readable errors
- Add `GET /api/v1/jobs/{id}/logs` - captured stdout/stderr per build phase
- Add `GET /api/v1/jobs` - paginated job listing with filtering
- Add `GET /api/v1/users/me/quota` - concurrent/daily usage and limits
- Add `GET /api/v1/jobs/{id}/results` - tar.gz streaming download of job output files
- Extend rate limiter to return daily counts alongside concurrent counts
- Unit tests for all endpoints (~1000 lines across test_status.py and test_results.py)

**Stack:** PR 3 of 4 (`feature/status-endpoints` → `feature/runner-loop-cancel`)

## Test plan
- [ ] `uv run pytest tests/unit/test_status.py tests/unit/test_results.py -v` passes
- [ ] `uv run pytest -m 'not integration' --tb=short` full Tier 1 suite passes
- [ ] Review tar.gz streaming for large result sets (memory behaviour)
- [ ] Review ownership checks on all job-specific endpoints
- [ ] Review quota calculation logic