### PR TITLE
feat: job executor subprocess pipeline

### DIFF
--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -1,0 +1,392 @@
+"""Job executor - runs a single job through clone, build, run, collect, cleanup."""
+
+import asyncio
+import logging
+import os
+import signal
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+
+from ds01_jobs.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class PhaseError(Exception):
+    """A job phase (clone/build/run) failed with a non-zero exit code."""
+
+    def __init__(self, phase: str, exit_code: int, summary: str) -> None:
+        self.phase = phase
+        self.exit_code = exit_code
+        self.summary = summary
+        super().__init__(summary)
+
+
+class PhaseTimeoutError(PhaseError):
+    """A job phase exceeded its timeout and was killed."""
+
+    def __init__(self, phase: str, timeout: float) -> None:
+        super().__init__(phase, -1, f"{phase} timed out after {timeout:.0f}s")
+        self.timeout = timeout
+
+
+class JobExecutor:
+    """Executes a single job through the clone -> build -> run pipeline."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._current_process: asyncio.subprocess.Process | None = None
+
+    async def execute(
+        self,
+        job_id: str,
+        repo_url: str,
+        branch: str,
+        gpu_count: int,
+        timeout_seconds: int | None,
+        db_path: Path,
+    ) -> None:
+        """Run a job through the full execution pipeline.
+
+        Args:
+            job_id: Unique job identifier.
+            repo_url: Git repository URL to clone.
+            branch: Git branch to check out.
+            gpu_count: Number of GPUs requested.
+            timeout_seconds: Job run timeout (None = use default).
+            db_path: Path to the SQLite database.
+        """
+        workspace = self.settings.workspace_root / job_id
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # Set started_at
+            async with aiosqlite.connect(db_path) as db:
+                now = datetime.now(UTC).isoformat()
+                await db.execute(
+                    "UPDATE jobs SET started_at=?, updated_at=? WHERE id=?",
+                    (now, now, job_id),
+                )
+                await db.commit()
+
+            await self._clone(job_id, repo_url, branch, workspace, db_path)
+            await self._build(job_id, workspace, db_path)
+            await self._run_container(job_id, workspace, gpu_count, timeout_seconds, db_path)
+            await self._collect_results(job_id, workspace)
+
+            # Success
+            await self._update_status(db_path, job_id, "succeeded")
+            logger.info("Job %s succeeded", job_id)
+
+        except PhaseError as exc:
+            logger.error("Job %s failed in %s: %s", job_id, exc.phase, exc.summary)
+            await self._update_status(
+                db_path,
+                job_id,
+                "failed",
+                failed_phase=exc.phase,
+                exit_code=exc.exit_code,
+                error_summary=exc.summary,
+            )
+        except Exception:
+            logger.exception("Job %s failed with unexpected error", job_id)
+            await self._update_status(
+                db_path,
+                job_id,
+                "failed",
+                error_summary="Unexpected executor error",
+            )
+        finally:
+            await self._cleanup(job_id)
+
+    async def _update_status(
+        self,
+        db_path: Path,
+        job_id: str,
+        status: str,
+        *,
+        failed_phase: str | None = None,
+        exit_code: int | None = None,
+        error_summary: str | None = None,
+    ) -> None:
+        """Atomically update job status in SQLite."""
+        now = datetime.now(UTC).isoformat()
+        async with aiosqlite.connect(db_path) as db:
+            if status in ("succeeded", "failed"):
+                await db.execute(
+                    "UPDATE jobs SET status=?, updated_at=?, completed_at=?, "
+                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
+                    (status, now, now, failed_phase, exit_code, error_summary, job_id),
+                )
+            elif status == "cloning":
+                await db.execute(
+                    "UPDATE jobs SET status=?, updated_at=?, started_at=?, "
+                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
+                    (status, now, now, failed_phase, exit_code, error_summary, job_id),
+                )
+            else:
+                await db.execute(
+                    "UPDATE jobs SET status=?, updated_at=?, "
+                    "failed_phase=?, exit_code=?, error_summary=? WHERE id=?",
+                    (status, now, failed_phase, exit_code, error_summary, job_id),
+                )
+            await db.commit()
+
+    async def _check_cancelled(self, db_path: Path, job_id: str) -> bool:
+        """Check if the job has been cancelled (status set to failed externally)."""
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("SELECT status FROM jobs WHERE id=?", (job_id,))
+            row = await cursor.fetchone()
+            if row and row[0] == "failed":
+                return True
+        return False
+
+    async def _run_phase(
+        self,
+        job_id: str,
+        cmd: list[str],
+        log_path: Path,
+        timeout: float,
+    ) -> int:
+        """Execute a subprocess phase with process group isolation and timeout.
+
+        Args:
+            job_id: Job identifier (for logging).
+            cmd: Command and arguments to execute.
+            log_path: Path to write stdout/stderr.
+            timeout: Maximum seconds before killing the process group.
+
+        Returns:
+            The subprocess return code.
+
+        Raises:
+            PhaseTimeoutError: If the process exceeds the timeout.
+        """
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("w") as log_file:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=log_file,
+                stderr=asyncio.subprocess.STDOUT,
+                process_group=0,
+            )
+            self._current_process = proc
+            try:
+                returncode = await asyncio.wait_for(proc.wait(), timeout=timeout)
+                return returncode
+            except asyncio.TimeoutError:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                await proc.wait()
+                raise
+            finally:
+                self._current_process = None
+
+    async def _clone(
+        self,
+        job_id: str,
+        repo_url: str,
+        branch: str,
+        workspace: Path,
+        db_path: Path,
+    ) -> None:
+        """Clone repository with shallow depth, retrying once on failure."""
+        await self._update_status(db_path, job_id, "cloning")
+
+        cmd = [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            repo_url,
+            str(workspace / "repo"),
+        ]
+        log_path = workspace / "clone.log"
+
+        exit_code = await self._run_phase(
+            job_id, cmd, log_path, self.settings.clone_timeout_seconds
+        )
+
+        if exit_code != 0:
+            logger.warning("Job %s clone failed (exit %d), retrying in 10s", job_id, exit_code)
+            await asyncio.sleep(10)
+            exit_code = await self._run_phase(
+                job_id, cmd, log_path, self.settings.clone_timeout_seconds
+            )
+            if exit_code != 0:
+                raise PhaseError("clone", exit_code, "Clone failed after retry")
+
+    async def _build(self, job_id: str, workspace: Path, db_path: Path) -> None:
+        """Build Docker image from the repo Dockerfile."""
+        if await self._check_cancelled(db_path, job_id):
+            raise PhaseError("build", -1, "Job cancelled before build")
+
+        await self._update_status(db_path, job_id, "building")
+
+        image_tag = f"ds01-job-{job_id}"
+        cmd = [
+            str(self.settings.docker_bin),
+            "build",
+            "-t",
+            image_tag,
+            "-f",
+            str(workspace / "repo" / "Dockerfile"),
+            str(workspace / "repo"),
+        ]
+        log_path = workspace / "build.log"
+
+        try:
+            exit_code = await self._run_phase(
+                job_id, cmd, log_path, self.settings.build_timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            raise PhaseTimeoutError("build", self.settings.build_timeout_seconds)
+
+        if exit_code != 0:
+            raise PhaseError("build", exit_code, "Docker build failed")
+
+    async def _run_container(
+        self,
+        job_id: str,
+        workspace: Path,
+        gpu_count: int,
+        timeout_seconds: int | None,
+        db_path: Path,
+    ) -> None:
+        """Run the Docker container with GPU access."""
+        if await self._check_cancelled(db_path, job_id):
+            raise PhaseError("run", -1, "Job cancelled before run")
+
+        await self._update_status(db_path, job_id, "running")
+
+        image_tag = f"ds01-job-{job_id}"
+        container_name = f"ds01-job-{job_id}"
+
+        # Resolve timeout
+        resolved_timeout = float(
+            timeout_seconds
+            if timeout_seconds is not None
+            else self.settings.default_job_timeout_seconds
+        )
+        resolved_timeout = min(resolved_timeout, self.settings.max_job_timeout_seconds)
+
+        cmd = [
+            str(self.settings.docker_bin),
+            "run",
+            "--name",
+            container_name,
+            "--gpus",
+            "all",
+            image_tag,
+        ]
+        log_path = workspace / "run.log"
+
+        try:
+            exit_code = await self._run_phase(job_id, cmd, log_path, resolved_timeout)
+        except asyncio.TimeoutError:
+            raise PhaseTimeoutError("run", resolved_timeout)
+
+        if exit_code != 0:
+            raise PhaseError("run", exit_code, "Container exited with error")
+
+    async def _collect_results(self, job_id: str, workspace: Path) -> None:
+        """Copy results from container /output/ to workspace/results/."""
+        container_name = f"ds01-job-{job_id}"
+        results_dir = workspace / "results"
+        results_dir.mkdir(exist_ok=True)
+
+        proc = await asyncio.create_subprocess_exec(
+            str(self.settings.docker_bin),
+            "cp",
+            f"{container_name}:/output/.",
+            str(results_dir),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            logger.warning("Failed to collect results for %s: %s", job_id, stderr.decode().strip())
+
+    async def _cleanup(self, job_id: str) -> None:
+        """Remove container, image, and prune build cache."""
+        docker = str(self.settings.docker_bin)
+
+        # Remove container
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                docker,
+                "rm",
+                "-f",
+                f"ds01-job-{job_id}",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+        except Exception:
+            logger.debug("Failed to remove container for job %s", job_id, exc_info=True)
+
+        # Remove image
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                docker,
+                "image",
+                "rm",
+                "-f",
+                f"ds01-job-{job_id}",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+        except Exception:
+            logger.debug("Failed to remove image for job %s", job_id, exc_info=True)
+
+        # Prune build cache
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                docker,
+                "builder",
+                "prune",
+                "--force",
+                "--filter",
+                "until=1h",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+        except Exception:
+            logger.debug("Failed to prune build cache for job %s", job_id, exc_info=True)
+
+    async def kill_current_process(self, job_id: str) -> None:
+        """Kill the currently running subprocess and its Docker container.
+
+        Used by the runner for cancel and shutdown.
+        """
+        proc = self._current_process
+        if proc is not None and proc.returncode is None:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+
+        # Also force-remove any Docker container (survives process group kill)
+        docker = str(self.settings.docker_bin)
+        try:
+            rm_proc = await asyncio.create_subprocess_exec(
+                docker,
+                "rm",
+                "-f",
+                f"ds01-job-{job_id}",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await rm_proc.wait()
+        except Exception:
+            pass

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,0 +1,440 @@
+"""Unit tests for the job executor module."""
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+from ds01_jobs.config import Settings
+from ds01_jobs.database import SCHEMA_SQL
+from ds01_jobs.executor import JobExecutor
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+JOB_ID = "test-job-001"
+REPO_URL = "https://github.com/example/repo.git"
+BRANCH = "main"
+
+
+@pytest.fixture
+def executor_settings(tmp_path: Path) -> Settings:
+    """Settings configured for test use."""
+    return Settings(
+        _env_file=None,
+        workspace_root=tmp_path / "workspaces",
+        docker_bin=Path("/usr/local/bin/docker"),
+        build_timeout_seconds=60.0,
+        clone_timeout_seconds=30.0,
+        default_job_timeout_seconds=120.0,
+        max_job_timeout_seconds=300.0,
+        db_path=tmp_path / "test.db",
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Initialise a test database with a queued job row (sync)."""
+    path = tmp_path / "test.db"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            JOB_ID,
+            "testuser",
+            REPO_URL,
+            BRANCH,
+            1,
+            "test-job",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _mock_process(returncode: int = 0) -> AsyncMock:
+    """Create a mock subprocess with the given return code."""
+    proc = AsyncMock()
+    proc.pid = 12345
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    proc.communicate.return_value = (b"", b"")
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_success(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Successful execution completes with status=succeeded."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status, completed_at FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "succeeded"
+    assert row[1] is not None  # completed_at set
+
+    # Workspace was created
+    workspace = executor_settings.workspace_root / JOB_ID
+    assert workspace.exists()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.sleep", new_callable=AsyncMock)
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_clone_failure_retries(
+    mock_exec: AsyncMock,
+    mock_sleep: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Clone retries once on failure and succeeds on second attempt."""
+    # First clone call fails, second succeeds, rest succeed
+    fail_proc = _mock_process(128)
+    ok_proc = _mock_process(0)
+    mock_exec.side_effect = [fail_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "succeeded"
+
+    # Verify sleep was called for the retry delay
+    mock_sleep.assert_awaited_with(10)
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.sleep", new_callable=AsyncMock)
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_clone_failure_after_retry(
+    mock_exec: AsyncMock,
+    mock_sleep: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Clone fails both attempts, job transitions to failed with clone phase."""
+    fail_proc = _mock_process(128)
+    ok_proc = _mock_process(0)
+    # Both clone attempts fail; cleanup procs succeed
+    mock_exec.side_effect = [fail_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status, failed_phase FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "clone"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_build_failure(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Build failure sets status=failed with failed_phase=build."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    # clone ok, build fails, cleanup procs
+    mock_exec.side_effect = [ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            "SELECT status, failed_phase, exit_code FROM jobs WHERE id=?", (JOB_ID,)
+        )
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "build"
+    assert row[2] == 1
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_run_failure(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Run failure sets status=failed with failed_phase=run."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    # clone ok, build ok, run fails, cleanup procs
+    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("SELECT status, failed_phase FROM jobs WHERE id=?", (JOB_ID,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "run"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.os.killpg")
+@patch("ds01_jobs.executor.asyncio.wait_for")
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_execute_build_timeout(
+    mock_exec: AsyncMock,
+    mock_wait_for: AsyncMock,
+    mock_killpg: MagicMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Build timeout kills process group and transitions to failed."""
+    ok_proc = _mock_process(0)
+
+    # Build proc - will be "timed out" by mocking wait_for
+    timeout_proc = AsyncMock()
+    timeout_proc.pid = 99999
+    timeout_proc.returncode = None
+    timeout_proc.wait.return_value = -9
+
+    cleanup_proc = _mock_process(0)
+    # clone ok, build times out, cleanup procs
+    mock_exec.side_effect = [ok_proc, timeout_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    # First wait_for call (clone) succeeds, second (build) times out
+    call_count = 0
+
+    async def selective_wait_for(coro: object, *, timeout: float) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Clone phase - return success
+            return await coro  # type: ignore[misc]
+        # Build phase - raise TimeoutError
+        raise asyncio.TimeoutError
+
+    mock_wait_for.side_effect = selective_wait_for
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            "SELECT status, failed_phase, error_summary FROM jobs WHERE id=?", (JOB_ID,)
+        )
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == "failed"
+    assert row[1] == "build"
+    assert "timed out" in row[2]
+
+    # Verify process group kill was called
+    mock_killpg.assert_called()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_status_transitions_order(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Status transitions happen in the correct order for a successful job."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    # Spy on _update_status to track call order
+    statuses: list[str] = []
+    original_update = executor._update_status
+
+    async def tracking_update(db_path_: Path, job_id: str, status: str, **kwargs: object) -> None:
+        statuses.append(status)
+        await original_update(db_path_, job_id, status, **kwargs)
+
+    executor._update_status = tracking_update  # type: ignore[assignment]
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    assert statuses == ["cloning", "building", "running", "succeeded"]
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_cleanup_called_on_failure(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Cleanup subprocess calls are made even when build fails."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    cleanup_proc = _mock_process(0)
+    # clone ok, build fails, then 3 cleanup calls (rm, image rm, builder prune)
+    mock_exec.side_effect = [ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    # Check cleanup calls were made (the last 3 create_subprocess_exec calls)
+    calls = mock_exec.call_args_list
+    docker = str(executor_settings.docker_bin)
+
+    # Find cleanup calls - they use docker rm, docker image rm, docker builder prune
+    cleanup_cmds = []
+    for c in calls:
+        args = c[0] if c[0] else ()
+        if args and args[0] == docker:
+            if len(args) > 1 and args[1] in ("rm", "image", "builder"):
+                cleanup_cmds.append(args[1])
+
+    assert "rm" in cleanup_cmds
+    assert "image" in cleanup_cmds
+    assert "builder" in cleanup_cmds
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_docker_bin_path_used(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """All docker subprocess calls use settings.docker_bin, not a hardcoded path."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    docker = str(executor_settings.docker_bin)
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        # Skip the git clone call
+        if args and args[0] == "git":
+            continue
+        # All other calls should use the docker wrapper path
+        if args:
+            assert args[0] == docker, f"Expected {docker} but got {args[0]} in call {args}"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_log_files_created(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Log files are created at expected paths for each phase."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    workspace = executor_settings.workspace_root / JOB_ID
+    assert (workspace / "clone.log").exists()
+    assert (workspace / "build.log").exists()
+    assert (workspace / "run.log").exists()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_cancel_check_stops_execution(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """If job is cancelled between phases, executor stops before the next phase."""
+    ok_proc = _mock_process(0)
+    cleanup_proc = _mock_process(0)
+    mock_exec.side_effect = [ok_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    executor = JobExecutor(executor_settings)
+
+    # After clone succeeds, set the job status to failed (simulating cancel)
+    original_check = executor._check_cancelled
+
+    call_count = 0
+
+    async def cancel_after_clone(db_path_: Path, job_id: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First check (before build) - simulate cancel
+            async with aiosqlite.connect(db_path_) as db:
+                await db.execute(
+                    "UPDATE jobs SET status='failed', error_summary='Cancelled by user' WHERE id=?",
+                    (job_id,),
+                )
+                await db.commit()
+            return True
+        return await original_check(db_path_, job_id)
+
+    executor._check_cancelled = cancel_after_clone  # type: ignore[assignment]
+
+    await executor.execute(
+        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+    )
+
+    # Verify build was never started - no docker build call should exist
+    calls = mock_exec.call_args_list
+    docker_cmds = [c[0] for c in calls if c[0] and c[0][0] == str(executor_settings.docker_bin)]
+    build_calls = [c for c in docker_cmds if len(c) > 1 and c[1] == "build"]
+    assert len(build_calls) == 0, "Build should not have been called after cancel"


### PR DESCRIPTION
## Summary
- Add job executor (`executor.py`) - subprocess pipeline: clone → build → run
- Timeout enforcement per phase (build: 15min, run: configurable)
- Process group cleanup on timeout/cancel
- Phase timestamp tracking in DB
- Unit tests with mocked subprocesses

**Stack:** 2/6 → `feature/runner-schema-gpu`

## Test plan
- [ ] `uv run pytest tests/unit/test_executor.py -v` passes
- [ ] Review subprocess pipeline for correctness
- [ ] Review timeout/cleanup logic