### PR TITLE
feat: runner poll loop, signal handling, cancel endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.scripts]
 ds01-job-admin = "ds01_jobs.cli:app"
+ds01-job-runner = "ds01_jobs.runner:cli_main"
 
 [build-system]
 requires = ["uv_build>=0.10.8,<0.11.0"]

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -1,7 +1,9 @@
-"""Job submission endpoint for ds01-jobs.
+"""Job endpoints for ds01-jobs.
 
 POST /api/v1/jobs orchestrates the full validation pipeline and returns
 202 Accepted with a queued job.
+
+POST /api/v1/jobs/{job_id}/cancel marks a job as cancelled (failed).
 """
 
 import uuid
@@ -179,3 +181,42 @@ async def submit_job(
         status_url=f"/api/v1/jobs/{job_id}",
         created_at=now_iso,
     )
+
+
+ACTIVE_STATUSES = ("queued", "cloning", "building", "running")
+
+
+@router.post("/jobs/{job_id}/cancel", status_code=200)
+async def cancel_job(
+    job_id: str,
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> dict[str, str]:
+    """Cancel a job by setting its status to failed."""
+    # 1. Look up job
+    cursor = await db.execute("SELECT username, status FROM jobs WHERE id = ?", (job_id,))
+    row = await cursor.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # 2. Ownership check
+    if row["username"] != user["username"]:
+        raise HTTPException(status_code=403, detail="Not your job")
+
+    # 3. Status check
+    if row["status"] not in ACTIVE_STATUSES:
+        raise HTTPException(status_code=409, detail=f"Job is already {row['status']}")
+
+    # 4. Atomic update with optimistic concurrency
+    now_iso = datetime.now(UTC).isoformat()
+    update_cursor = await db.execute(
+        "UPDATE jobs SET status='failed', updated_at=?, error_summary='Cancelled by user' "
+        "WHERE id=? AND status IN ('queued','cloning','building','running')",
+        (now_iso, job_id),
+    )
+    if update_cursor.rowcount == 0:
+        raise HTTPException(status_code=409, detail="Job status changed during cancel")
+
+    await db.commit()
+
+    return {"job_id": job_id, "status": "failed", "message": "Job cancelled"}

--- a/src/ds01_jobs/runner.py
+++ b/src/ds01_jobs/runner.py
@@ -1,0 +1,148 @@
+"""DS01 job runner - polls SQLite and executes Docker jobs.
+
+Long-running service that polls for queued jobs, checks GPU availability,
+dispatches jobs via JobExecutor, and handles graceful shutdown.
+"""
+
+import asyncio
+import logging
+import signal
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from ds01_jobs.config import Settings
+from ds01_jobs.executor import JobExecutor
+from ds01_jobs.gpu import get_available_gpu_count
+
+logger = logging.getLogger(__name__)
+
+
+class JobRunner:
+    """Async poll-dispatch loop for queued GPU jobs."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.shutdown_event = asyncio.Event()
+        self.active_jobs: dict[str, asyncio.Task[None]] = {}
+        self.active_executors: dict[str, JobExecutor] = {}
+
+    async def run(self) -> None:
+        """Main entry point - poll loop with signal handling and shutdown drain."""
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, self._handle_sigterm)
+        loop.add_signal_handler(signal.SIGINT, self._handle_sigterm)
+
+        await self._recover_orphaned_jobs()
+
+        while not self.shutdown_event.is_set():
+            await self._poll_and_dispatch()
+            self._cleanup_completed_tasks()
+            try:
+                await asyncio.wait_for(
+                    self.shutdown_event.wait(),
+                    timeout=self.settings.runner_poll_interval,
+                )
+            except asyncio.TimeoutError:
+                pass  # Normal - poll interval elapsed
+
+        active_count = len(self.active_jobs)
+        if active_count > 0:
+            logger.info("Shutting down, waiting for %d active jobs to drain...", active_count)
+            await asyncio.gather(*self.active_jobs.values(), return_exceptions=True)
+
+        logger.info("Runner stopped.")
+
+    def _handle_sigterm(self) -> None:
+        """Signal handler for SIGTERM and SIGINT."""
+        self.shutdown_event.set()
+        logger.info("SIGTERM received, draining active jobs...")
+
+    async def _recover_orphaned_jobs(self) -> None:
+        """Mark in-progress jobs as failed on startup (orphan recovery)."""
+        async with aiosqlite.connect(self.settings.db_path) as db:
+            now = datetime.now(UTC).isoformat()
+            cursor = await db.execute(
+                "UPDATE jobs SET status='failed', updated_at=?, "
+                "error_summary='Runner restarted - job interrupted' "
+                "WHERE status IN ('cloning', 'building', 'running')",
+                (now,),
+            )
+            if cursor.rowcount > 0:
+                logger.info("Recovered %d orphaned jobs on startup", cursor.rowcount)
+            await db.commit()
+
+    def _cleanup_completed_tasks(self) -> None:
+        """Remove finished tasks from active_jobs and log any exceptions."""
+        done_ids = [jid for jid, task in self.active_jobs.items() if task.done()]
+        for jid in done_ids:
+            task = self.active_jobs.pop(jid)
+            self.active_executors.pop(jid, None)
+            exc = task.exception() if not task.cancelled() else None
+            if exc is not None:
+                logger.error("Job %s task raised exception: %s", jid, exc)
+
+    async def _poll_and_dispatch(self) -> None:
+        """Query queued jobs and dispatch those that fit available GPUs."""
+        available = await get_available_gpu_count()
+        if available <= 0:
+            return
+
+        async with aiosqlite.connect(self.settings.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT id, username, repo_url, branch, gpu_count, timeout_seconds "
+                "FROM jobs WHERE status='queued' ORDER BY created_at ASC"
+            )
+            rows = await cursor.fetchall()
+
+        for row in rows:
+            job_id: str = row["id"]
+            gpu_count: int = row["gpu_count"]
+
+            if gpu_count > available:
+                continue
+
+            if job_id in self.active_jobs:
+                continue
+
+            executor = JobExecutor(self.settings)
+            task = asyncio.create_task(
+                executor.execute(
+                    job_id,
+                    row["repo_url"],
+                    row["branch"],
+                    gpu_count,
+                    row["timeout_seconds"],
+                    self.settings.db_path,
+                )
+            )
+            self.active_jobs[job_id] = task
+            self.active_executors[job_id] = executor
+            available -= gpu_count
+
+            if available <= 0:
+                break
+
+    async def cancel_job(self, job_id: str) -> bool:
+        """Kill a running job's executor process.
+
+        Returns True if the job was found and killed, False otherwise.
+        """
+        executor = self.active_executors.get(job_id)
+        if executor is not None:
+            await executor.kill_current_process(job_id)
+            self.active_executors.pop(job_id, None)
+            return True
+        return False
+
+
+def cli_main() -> None:
+    """CLI entry point for ds01-job-runner."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    settings = Settings()
+    runner = JobRunner(settings)
+    asyncio.run(runner.run())

--- a/tests/unit/test_cancel.py
+++ b/tests/unit/test_cancel.py
@@ -1,0 +1,275 @@
+"""Tests for POST /api/v1/jobs/{job_id}/cancel endpoint."""
+
+import hashlib
+import hmac
+import secrets
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.database import get_db, init_db
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash."""
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request."""
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+) -> None:
+    """Insert a test API key into the database."""
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+        )
+        await db.commit()
+
+
+async def _insert_job(
+    db_path: Path,
+    job_id: str | None = None,
+    username: str = "testuser",
+    status: str = "running",
+) -> str:
+    """Insert a test job and return its ID."""
+    jid = job_id or str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                jid,
+                username,
+                "https://github.com/test/repo",
+                "main",
+                1,
+                "test-job",
+                status,
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+    return jid
+
+
+def _make_app(db_path: Path):
+    """Create a test app with cancel endpoint."""
+    from ds01_jobs.app import create_app
+
+    app = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return app
+
+
+def _build_cancel_headers(raw_key: str, job_id: str) -> dict[str, str]:
+    """Build auth + signing headers for a POST cancel request."""
+    path = f"/api/v1/jobs/{job_id}/cancel"
+    headers = _sign_request(raw_key, "POST", path, body=b"")
+    headers["Authorization"] = f"Bearer {raw_key}"
+    return headers
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_job(tmp_path: Path) -> None:
+    """Cancel a running job returns 200 with status=failed."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="running")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert data["message"] == "Job cancelled"
+
+    # Verify DB state
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT status, error_summary FROM jobs WHERE id=?", (job_id,))
+        row = await cursor.fetchone()
+    assert row["status"] == "failed"
+    assert row["error_summary"] == "Cancelled by user"
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_job(tmp_path: Path) -> None:
+    """Cancel a queued job returns 200."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="queued")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cancel_completed_job(tmp_path: Path) -> None:
+    """Cancel a succeeded job returns 409."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="succeeded")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 409
+    assert "already succeeded" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_failed_job(tmp_path: Path) -> None:
+    """Cancel an already-failed job returns 409."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+    job_id = await _insert_job(db_path, status="failed")
+
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 409
+    assert "already failed" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_not_found(tmp_path: Path) -> None:
+    """Cancel a non-existent job returns 404."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    fake_id = str(uuid.uuid4())
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(raw_key, fake_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{fake_id}/cancel", headers=headers)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_other_users_job(tmp_path: Path) -> None:
+    """Cancel another user's job returns 403."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    # Alice's key
+    alice_key, alice_kid, alice_hash = _create_test_key()
+    await _seed_key(db_path, alice_kid, alice_hash, username="alice")
+
+    # Bob's key
+    bob_key, bob_kid, bob_hash = _create_test_key()
+    await _seed_key(db_path, bob_kid, bob_hash, username="bob")
+
+    # Alice's job
+    job_id = await _insert_job(db_path, username="alice", status="running")
+
+    # Bob tries to cancel Alice's job
+    app = _make_app(db_path)
+    headers = _build_cancel_headers(bob_key, job_id)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cancel_unauthenticated(tmp_path: Path) -> None:
+    """Cancel without auth returns 401 or 403."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    job_id = await _insert_job(db_path, status="running")
+
+    app = _make_app(db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/jobs/{job_id}/cancel")
+
+    assert resp.status_code in (401, 403)

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,283 @@
+"""Unit tests for the job runner module."""
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import aiosqlite
+import pytest
+
+from ds01_jobs.config import Settings
+from ds01_jobs.database import SCHEMA_SQL
+from ds01_jobs.runner import JobRunner
+
+
+@pytest.fixture
+def runner_settings(tmp_path: Path) -> Settings:
+    """Settings configured for test use."""
+    return Settings(
+        _env_file=None,
+        db_path=tmp_path / "test.db",
+        runner_poll_interval=0.1,
+        workspace_root=tmp_path / "workspaces",
+        docker_bin=Path("/usr/local/bin/docker"),
+    )
+
+
+@pytest.fixture
+def populated_db(tmp_path: Path) -> Path:
+    """Initialise DB with 2 queued jobs and return db_path."""
+    db_path = tmp_path / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+    for i in range(2):
+        conn.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"job-{i}",
+                "testuser",
+                "https://github.com/test/repo.git",
+                "main",
+                1,
+                f"test-job-{i}",
+                "queued",
+                f"2026-01-01T00:00:0{i}",
+                f"2026-01-01T00:00:0{i}",
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _init_db_sync(db_path: Path) -> None:
+    """Initialise schema synchronously for tests."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_recover_orphaned_jobs(runner_settings: Settings) -> None:
+    """Startup recovery marks in-progress jobs as failed."""
+    db_path = runner_settings.db_path
+    _init_db_sync(db_path)
+
+    conn = sqlite3.connect(db_path)
+    for status in ("running", "building", "cloning"):
+        conn.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"orphan-{status}",
+                "testuser",
+                "https://github.com/test/repo.git",
+                "main",
+                1,
+                f"orphan-{status}",
+                status,
+                "2026-01-01T00:00:00",
+                "2026-01-01T00:00:00",
+            ),
+        )
+    # Also add a queued job that should NOT be affected
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "queued-job",
+            "testuser",
+            "https://github.com/test/repo.git",
+            "main",
+            1,
+            "queued-job",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    runner = JobRunner(runner_settings)
+    await runner._recover_orphaned_jobs()
+
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT id, status, error_summary FROM jobs ORDER BY id")
+        rows = await cursor.fetchall()
+
+    results = {row["id"]: (row["status"], row["error_summary"]) for row in rows}
+    assert results["orphan-running"] == ("failed", "Runner restarted - job interrupted")
+    assert results["orphan-building"] == ("failed", "Runner restarted - job interrupted")
+    assert results["orphan-cloning"] == ("failed", "Runner restarted - job interrupted")
+    assert results["queued-job"][0] == "queued"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+@patch("ds01_jobs.runner.JobExecutor")
+async def test_poll_dispatches_queued_jobs(
+    mock_executor_cls: AsyncMock,
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    populated_db: Path,
+) -> None:
+    """Poll dispatches queued jobs when GPUs are available."""
+    runner_settings.db_path = populated_db
+    mock_gpu.return_value = 4
+
+    mock_executor = AsyncMock()
+    mock_executor.execute = AsyncMock()
+    mock_executor_cls.return_value = mock_executor
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    assert len(runner.active_jobs) == 2
+    assert mock_executor_cls.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+async def test_poll_skips_when_no_gpus(
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    populated_db: Path,
+) -> None:
+    """No GPUs available means no jobs dispatched."""
+    runner_settings.db_path = populated_db
+    mock_gpu.return_value = 0
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    assert len(runner.active_jobs) == 0
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+@patch("ds01_jobs.runner.JobExecutor")
+async def test_poll_skips_oversized_jobs(
+    mock_executor_cls: AsyncMock,
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Jobs requiring more GPUs than available are skipped; smaller ones run."""
+    db_path = tmp_path / "test.db"
+    runner_settings.db_path = db_path
+    _init_db_sync(db_path)
+
+    conn = sqlite3.connect(db_path)
+    # Job needing 2 GPUs
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "big-job",
+            "testuser",
+            "https://github.com/test/repo.git",
+            "main",
+            2,
+            "big-job",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    # Job needing 1 GPU
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "small-job",
+            "testuser",
+            "https://github.com/test/repo.git",
+            "main",
+            1,
+            "small-job",
+            "queued",
+            "2026-01-01T00:00:01",
+            "2026-01-01T00:00:01",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    mock_gpu.return_value = 1
+    mock_executor = AsyncMock()
+    mock_executor.execute = AsyncMock()
+    mock_executor_cls.return_value = mock_executor
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    assert "small-job" in runner.active_jobs
+    assert "big-job" not in runner.active_jobs
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+async def test_shutdown_event_stops_loop(
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+) -> None:
+    """Setting shutdown_event before run() causes immediate exit."""
+    _init_db_sync(runner_settings.db_path)
+    mock_gpu.return_value = 0
+
+    runner = JobRunner(runner_settings)
+    runner.shutdown_event.set()
+
+    # run() should exit without blocking
+    await asyncio.wait_for(runner.run(), timeout=5.0)
+
+    # No jobs dispatched
+    assert len(runner.active_jobs) == 0
+
+
+@pytest.mark.asyncio
+async def test_sigterm_sets_shutdown_event(runner_settings: Settings) -> None:
+    """_handle_sigterm sets the shutdown event."""
+    runner = JobRunner(runner_settings)
+    assert not runner.shutdown_event.is_set()
+    runner._handle_sigterm()
+    assert runner.shutdown_event.is_set()
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+async def test_completed_tasks_cleaned_up(
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+) -> None:
+    """Completed asyncio tasks are removed from active_jobs."""
+    _init_db_sync(runner_settings.db_path)
+    mock_gpu.return_value = 0
+
+    runner = JobRunner(runner_settings)
+
+    # Create a done task
+    async def noop() -> None:
+        pass
+
+    done_task = asyncio.create_task(noop())
+    await done_task  # Let it finish
+
+    runner.active_jobs["done-job"] = done_task
+    runner.active_executors["done-job"] = AsyncMock()
+
+    # Run one poll cycle (no jobs to dispatch since GPU=0)
+    await runner._poll_and_dispatch()
+    runner._cleanup_completed_tasks()
+
+    assert "done-job" not in runner.active_jobs
+    assert "done-job" not in runner.active_executors


### PR DESCRIPTION
## Summary
- Runner poll-dispatch loop (`runner.py`) - polls DB for queued jobs, dispatches to executor
- SIGTERM graceful shutdown with in-progress job draining
- Startup recovery - marks orphaned running jobs as failed
- Cancel endpoint (`POST /api/v1/jobs/{id}/cancel`)
- Unit tests for runner and cancel

**Stack:** 3/6 → `feature/job-executor`

## Test plan
- [ ] `uv run pytest tests/unit/test_runner.py tests/unit/test_cancel.py -v` passes
- [ ] Review signal handling behaviour
- [ ] Review cancel ownership checks