### PR TITLE
test: API integration tests - full stack round-trip

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,208 @@
+"""Shared fixtures and helpers for API integration tests.
+
+Provides test key generation, HMAC signing, database seeding, and
+app/client fixtures that wire up a real FastAPI app against a temporary
+SQLite database. These are Tier 1 tests - no @pytest.mark.integration.
+"""
+
+import hashlib
+import hmac
+import secrets
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import aiosqlite
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ds01_jobs.app import create_app
+from ds01_jobs.config import Settings
+from ds01_jobs.database import _get_db_path, get_db, init_db
+from ds01_jobs.jobs import _get_settings
+
+# ---------------------------------------------------------------------------
+# Helper functions (module-level, not fixtures)
+# ---------------------------------------------------------------------------
+
+
+def create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash.
+
+    Returns:
+        (raw_key, key_id, key_hash)
+    """
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request.
+
+    Each call generates a fresh nonce by default, which is critical for
+    multi-step tests to avoid nonce replay rejection.
+    """
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+def build_signed_headers(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+) -> dict[str, str]:
+    """Convenience wrapper: signing headers + Authorization + Content-Type.
+
+    Adds Content-Type: application/json for POST requests with a body.
+    """
+    headers = sign_request(raw_key, method, path, body=body)
+    headers["Authorization"] = f"Bearer {raw_key}"
+    if method.upper() == "POST" and body:
+        headers["Content-Type"] = "application/json"
+    return headers
+
+
+async def seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    expires_at: str | None = None,
+) -> None:
+    """Insert an API key row into the database."""
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+        )
+        await db.commit()
+
+
+async def insert_job(
+    db_path: Path,
+    username: str = "testuser",
+    status: str = "queued",
+    created_at: str | None = None,
+) -> str:
+    """Insert a test job row and return the job_id."""
+    job_id = str(uuid.uuid4())
+    now = created_at or datetime.now(UTC).isoformat()
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                job_id,
+                username,
+                "https://github.com/test/repo",
+                "main",
+                1,
+                "test-job",
+                status,
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+    return job_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path) -> Path:
+    """Create a temporary SQLite database with the full schema."""
+    path = tmp_path / "test.db"
+    await init_db(db_path=path)
+    return path
+
+
+@pytest.fixture
+async def auth_key(db_path: Path) -> tuple[str, str, str]:
+    """Generate and seed a test API key. Returns (raw_key, key_id, key_hash)."""
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
+    return raw_key, key_id, key_hash
+
+
+@pytest.fixture
+def app(db_path: Path, tmp_path: Path):
+    """Create a real FastAPI app wired to the test database."""
+    application = create_app()
+
+    async def _override_get_db():
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            yield db
+
+    application.dependency_overrides[get_db] = _override_get_db
+
+    _get_settings.cache_clear()
+    _get_db_path.cache_clear()
+
+    settings_patch = patch(
+        "ds01_jobs.jobs._get_settings",
+        return_value=Settings(_env_file=None, workspace_root=tmp_path / "workspaces"),
+    )
+    db_path_patch = patch(
+        "ds01_jobs.database._get_db_path",
+        return_value=db_path,
+    )
+
+    settings_patch.start()
+    db_path_patch.start()
+
+    yield application
+
+    settings_patch.stop()
+    db_path_patch.stop()
+    _get_settings.cache_clear()
+    _get_db_path.cache_clear()
+    application.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    """Async HTTP client backed by the test app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_nonces():
+    """Clear the auth nonce cache before each test."""
+    import ds01_jobs.auth
+
+    ds01_jobs.auth._used_nonces.clear()
+    yield
+    ds01_jobs.auth._used_nonces.clear()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import aiosqlite
 import bcrypt
 import pytest
+import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.app import create_app
@@ -138,7 +139,7 @@ async def insert_job(
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def db_path(tmp_path: Path) -> Path:
     """Create a temporary SQLite database with the full schema."""
     path = tmp_path / "test.db"
@@ -146,7 +147,7 @@ async def db_path(tmp_path: Path) -> Path:
     return path
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def auth_key(db_path: Path) -> tuple[str, str, str]:
     """Generate and seed a test API key. Returns (raw_key, key_id, key_hash)."""
     raw_key, key_id, key_hash = create_test_key()
@@ -154,8 +155,8 @@ async def auth_key(db_path: Path) -> tuple[str, str, str]:
     return raw_key, key_id, key_hash
 
 
-@pytest.fixture
-def app(db_path: Path, tmp_path: Path):
+@pytest_asyncio.fixture
+async def app(db_path: Path, tmp_path: Path):
     """Create a real FastAPI app wired to the test database."""
     application = create_app()
 
@@ -190,7 +191,7 @@ def app(db_path: Path, tmp_path: Path):
     application.dependency_overrides.clear()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(app):
     """Async HTTP client backed by the test app."""
     transport = ASGITransport(app=app)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -85,7 +85,6 @@ async def test_full_job_lifecycle(mock_ssrf, mock_verify, client, auth_key, db_p
     assert resp.json()["concurrent"]["used"] >= 1
 
     # 5. Cancel
-    cancel_body = b""
     headers = build_signed_headers(raw_key, "POST", f"/api/v1/jobs/{job_id}/cancel")
     resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
     assert resp.status_code == 200

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,289 @@
+"""API integration tests for ds01-jobs.
+
+Multi-step workflow tests exercising auth middleware -> rate limiter ->
+endpoint -> database -> response. These are Tier 1 tests - no
+@pytest.mark.integration marker.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.integration.conftest import (
+    build_signed_headers,
+    create_test_key,
+    insert_job,
+    seed_key,
+    sign_request,
+)
+
+# ---------------------------------------------------------------------------
+# Test group 1 - Job lifecycle workflows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_then_check_status(mock_ssrf, mock_verify, client, auth_key, db_path):
+    """Submit a job, then fetch its status and verify data round-trips."""
+    raw_key = auth_key[0]
+
+    # Submit
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    body_bytes = json.dumps(body).encode()
+    headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    # Status
+    headers = build_signed_headers(raw_key, "GET", f"/api/v1/jobs/{job_id}")
+    resp = await client.get(f"/api/v1/jobs/{job_id}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["job_id"] == job_id
+    assert data["status"] == "queued"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_full_job_lifecycle(mock_ssrf, mock_verify, client, auth_key, db_path):
+    """Submit -> status -> list -> quota -> cancel -> verify cancel persisted."""
+    raw_key = auth_key[0]
+
+    # 1. Submit
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    body_bytes = json.dumps(body).encode()
+    headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    # 2. Status
+    headers = build_signed_headers(raw_key, "GET", f"/api/v1/jobs/{job_id}")
+    resp = await client.get(f"/api/v1/jobs/{job_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "queued"
+
+    # 3. List
+    headers = build_signed_headers(raw_key, "GET", "/api/v1/jobs")
+    resp = await client.get("/api/v1/jobs", headers=headers)
+    assert resp.status_code == 200
+    list_data = resp.json()
+    assert list_data["total"] >= 1
+    job_ids = [j["job_id"] for j in list_data["jobs"]]
+    assert job_id in job_ids
+
+    # 4. Quota
+    headers = build_signed_headers(raw_key, "GET", "/api/v1/users/me/quota")
+    resp = await client.get("/api/v1/users/me/quota", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["concurrent"]["used"] >= 1
+
+    # 5. Cancel
+    cancel_body = b""
+    headers = build_signed_headers(raw_key, "POST", f"/api/v1/jobs/{job_id}/cancel")
+    resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "failed"
+
+    # 6. Verify cancel persisted
+    headers = build_signed_headers(raw_key, "GET", f"/api/v1/jobs/{job_id}")
+    resp = await client.get(f"/api/v1/jobs/{job_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "failed"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_submit_multiple_then_list(mock_ssrf, mock_verify, client, auth_key, db_path):
+    """Submit 2 jobs, then list and verify both are present."""
+    raw_key = auth_key[0]
+    job_ids = []
+
+    for _ in range(2):
+        body = {"repo_url": "https://github.com/testorg/myrepo"}
+        body_bytes = json.dumps(body).encode()
+        headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+        resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+        assert resp.status_code == 202
+        job_ids.append(resp.json()["job_id"])
+
+    headers = build_signed_headers(raw_key, "GET", "/api/v1/jobs")
+    resp = await client.get("/api/v1/jobs", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 2
+    listed_ids = [j["job_id"] for j in data["jobs"]]
+    for jid in job_ids:
+        assert jid in listed_ids
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_cancel_already_cancelled_returns_409(
+    mock_ssrf, mock_verify, client, auth_key, db_path
+):
+    """Cancelling an already-cancelled job returns 409."""
+    raw_key = auth_key[0]
+
+    # Submit
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    body_bytes = json.dumps(body).encode()
+    headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    # First cancel
+    headers = build_signed_headers(raw_key, "POST", f"/api/v1/jobs/{job_id}/cancel")
+    resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+    assert resp.status_code == 200
+
+    # Second cancel
+    headers = build_signed_headers(raw_key, "POST", f"/api/v1/jobs/{job_id}/cancel")
+    resp = await client.post(f"/api/v1/jobs/{job_id}/cancel", headers=headers)
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_status_other_users_job_returns_404(
+    mock_ssrf, mock_verify, client, auth_key, db_path
+):
+    """Fetching another user's job returns 404 (ownership check)."""
+    raw_key = auth_key[0]
+
+    # Submit as testuser
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    body_bytes = json.dumps(body).encode()
+    headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    # Create otheruser key
+    other_raw, other_kid, other_hash = create_test_key()
+    await seed_key(db_path, other_kid, other_hash, username="otheruser")
+
+    # Fetch as otheruser
+    headers = build_signed_headers(other_raw, "GET", f"/api/v1/jobs/{job_id}")
+    resp = await client.get(f"/api/v1/jobs/{job_id}", headers=headers)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Test group 2 - Auth integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unsigned_request_rejected(client):
+    """GET /api/v1/jobs with no auth headers returns 401 or 403."""
+    resp = await client.get("/api/v1/jobs")
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_tampered_signature_rejected(client, auth_key, db_path):
+    """Tampered X-Signature is rejected with 401."""
+    raw_key = auth_key[0]
+    headers = build_signed_headers(raw_key, "GET", "/api/v1/jobs")
+    headers["X-Signature"] = "0" * 64
+    resp = await client.get("/api/v1/jobs", headers=headers)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_expired_key_rejected(client, db_path):
+    """Expired API key is rejected with 401."""
+    raw_key, key_id, key_hash = create_test_key()
+    expired = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    await seed_key(db_path, key_id, key_hash, expires_at=expired)
+
+    headers = build_signed_headers(raw_key, "GET", "/api/v1/jobs")
+    resp = await client.get("/api/v1/jobs", headers=headers)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_nonce_replay_rejected(client, auth_key, db_path):
+    """Second request with the same nonce is rejected with 401."""
+    raw_key = auth_key[0]
+    fixed_nonce = "replay-test-nonce-unique-123"
+
+    # First request - should succeed
+    signing = sign_request(raw_key, "GET", "/api/v1/jobs", nonce=fixed_nonce)
+    headers = {**signing, "Authorization": f"Bearer {raw_key}"}
+    resp = await client.get("/api/v1/jobs", headers=headers)
+    assert resp.status_code == 200
+
+    # Second request with same nonce - should fail
+    signing2 = sign_request(raw_key, "GET", "/api/v1/jobs", nonce=fixed_nonce)
+    headers2 = {**signing2, "Authorization": f"Bearer {raw_key}"}
+    resp2 = await client.get("/api/v1/jobs", headers=headers2)
+    assert resp2.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_no_auth_required(client):
+    """GET /health with no auth returns 200 with status=ok."""
+    resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Test group 3 - Rate limiting integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_concurrent_rate_limit_enforced(mock_ssrf, mock_verify, client, auth_key, db_path):
+    """Submitting past concurrent limit returns 429 with limit_type=concurrent."""
+    raw_key = auth_key[0]
+
+    # Submit 3 jobs (default concurrent limit)
+    for _ in range(3):
+        body = {"repo_url": "https://github.com/testorg/myrepo"}
+        body_bytes = json.dumps(body).encode()
+        headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+        resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+        assert resp.status_code == 202
+
+    # 4th should be rejected
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    body_bytes = json.dumps(body).encode()
+    headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["error"]["limit_type"] == "concurrent"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+async def test_daily_rate_limit_enforced(mock_ssrf, mock_verify, client, auth_key, db_path):
+    """Seeding 10 completed jobs (default daily limit), next submit returns 429."""
+    raw_key = auth_key[0]
+
+    # Seed 10 completed jobs directly in DB
+    for _ in range(10):
+        await insert_job(db_path, username="testuser", status="succeeded")
+
+    # 11th submission should hit daily limit
+    body = {"repo_url": "https://github.com/testorg/myrepo"}
+    body_bytes = json.dumps(body).encode()
+    headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    resp = await client.post("/api/v1/jobs", content=body_bytes, headers=headers)
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["error"]["limit_type"] == "daily"


### PR DESCRIPTION
## Summary
- Shared integration fixtures (`conftest.py`) - HMAC signing, DB seeding, app factory
- 12 API integration tests exercising real wiring:
  - **Lifecycle:** submit → status → list → quota → cancel
  - **Auth:** unsigned, tampered HMAC, expired key, nonce replay all rejected
  - **Rate limiting:** concurrent and daily 429 enforcement
- All run in Tier 1 CI (no @pytest.mark.integration)

**Stack:** 6/6 → `feature/status-endpoints`

## Test plan
- [ ] `uv run pytest tests/integration/test_api.py -v` all 12 pass
- [ ] Full Tier 1 suite (173 tests) passes
- [ ] Review fixture isolation