### PR TITLE
feat: add signing HTTP client and credential resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 [project.scripts]
 ds01-job-admin = "ds01_jobs.cli:app"
 ds01-job-runner = "ds01_jobs.runner:cli_main"
+ds01-submit = "ds01_jobs.submit:app"
 
 [build-system]
 requires = ["uv_build>=0.10.8,<0.11.0"]

--- a/src/ds01_jobs/client.py
+++ b/src/ds01_jobs/client.py
@@ -1,0 +1,113 @@
+"""Signing HTTP client and credential resolution for ds01-submit CLI.
+
+Provides a client that transparently adds HMAC-SHA256 signing headers
+to every request, mirroring the server's auth.py verification protocol.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import httpx
+
+DEFAULT_API_URL = "https://ds01.hertie-data-science-lab.org"
+CREDENTIALS_PATH = Path.home() / ".config" / "ds01" / "credentials"
+TERMINAL_STATES = {"succeeded", "failed"}
+
+
+def resolve_api_key() -> str | None:
+    """Resolve API key: DS01_API_KEY env var > credentials file > None."""
+    key = os.environ.get("DS01_API_KEY")
+    if key:
+        return key.strip()
+    if CREDENTIALS_PATH.exists():
+        return CREDENTIALS_PATH.read_text().strip()
+    return None
+
+
+def resolve_api_url() -> str:
+    """Resolve API URL: DS01_API_URL env var > hardcoded production default."""
+    return os.environ.get("DS01_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def sign_headers(raw_key: str, method: str, path: str, body: bytes = b"") -> dict[str, str]:
+    """Build HMAC signing headers for a request.
+
+    Mirrors auth.py's _build_canonical format exactly:
+    METHOD\\nPATH\\nTIMESTAMP\\nNONCE\\nBODY_SHA256_HEX
+
+    Query parameters are stripped from the path before signing, since the
+    server uses request.url.path (path only, no query string).
+    """
+    # Strip query string - server signs path only (request.url.path)
+    sign_path = path.split("?", 1)[0]
+    timestamp = str(time.time())
+    nonce = secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{sign_path}\n{timestamp}\n{nonce}\n{body_hash}"
+    signature = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "Authorization": f"Bearer {raw_key}",
+        "X-Timestamp": timestamp,
+        "X-Nonce": nonce,
+        "X-Signature": signature,
+    }
+
+
+class DS01Client:
+    """HTTP client with transparent HMAC-SHA256 request signing."""
+
+    def __init__(self, api_key: str, base_url: str = DEFAULT_API_URL) -> None:
+        self.api_key = api_key
+        self._http = httpx.Client(base_url=base_url, timeout=30.0)
+
+    def request(self, method: str, path: str, **kwargs: object) -> httpx.Response:
+        """Send a signed request.
+
+        If a `json` kwarg is provided, it is serialised to bytes first,
+        signed, then sent as `content=` (not `json=`) to avoid body
+        mismatch between what was signed and what the server reads.
+        """
+        body = b""
+        extra_headers: dict[str, str] = {}
+
+        json_body = kwargs.pop("json", None)
+        if json_body is not None:
+            body = json.dumps(json_body).encode()
+            extra_headers["Content-Type"] = "application/json"
+            kwargs["content"] = body
+
+        headers = sign_headers(self.api_key, method, path, body)
+        headers.update(extra_headers)
+        return self._http.request(method, path, headers=headers, **kwargs)  # type: ignore[arg-type]
+
+    def get(self, path: str, **kwargs: object) -> httpx.Response:
+        """Send a signed GET request."""
+        return self.request("GET", path, **kwargs)
+
+    def post(self, path: str, **kwargs: object) -> httpx.Response:
+        """Send a signed POST request."""
+        return self.request("POST", path, **kwargs)
+
+    @contextmanager
+    def stream(self, method: str, path: str) -> Generator[httpx.Response, None, None]:
+        """Yield a streaming response with signed headers."""
+        headers = sign_headers(self.api_key, method, path)
+        with self._http.stream(method, path, headers=headers) as response:
+            yield response
+
+    def close(self) -> None:
+        """Close the underlying httpx client."""
+        self._http.close()
+
+    def __enter__(self) -> "DS01Client":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,223 @@
+"""Tests for ds01_jobs.client module - signing HTTP client and credential resolution."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import MagicMock, patch
+
+from ds01_jobs.client import (
+    DEFAULT_API_URL,
+    DS01Client,
+    resolve_api_key,
+    resolve_api_url,
+    sign_headers,
+)
+
+# --- sign_headers tests ---
+
+
+def test_sign_headers_canonical_format():
+    """sign_headers produces the correct canonical string format matching auth.py."""
+    key = "ds01_testkey123"
+    method = "GET"
+    path = "/api/v1/jobs"
+    body = b""
+
+    with (
+        patch("ds01_jobs.client.time") as mock_time,
+        patch("ds01_jobs.client.secrets") as mock_secrets,
+    ):
+        mock_time.time.return_value = 1234567890.0
+        mock_secrets.token_urlsafe.return_value = "testnonce123"
+
+        headers = sign_headers(key, method, path, body)
+
+    # Verify canonical matches auth.py: METHOD\nPATH\nTIMESTAMP\nNONCE\nBODY_SHA256
+    body_hash = hashlib.sha256(body).hexdigest()
+    expected_canonical = f"{method}\n{path}\n1234567890.0\ntestnonce123\n{body_hash}"
+    expected_sig = hmac.new(key.encode(), expected_canonical.encode(), hashlib.sha256).hexdigest()
+
+    assert headers["Authorization"] == f"Bearer {key}"
+    assert headers["X-Timestamp"] == "1234567890.0"
+    assert headers["X-Nonce"] == "testnonce123"
+    assert headers["X-Signature"] == expected_sig
+
+
+def test_sign_headers_with_body():
+    """sign_headers correctly hashes a non-empty body."""
+    key = "ds01_testkey123"
+    body = b'{"repo_url": "https://github.com/org/repo"}'
+
+    with (
+        patch("ds01_jobs.client.time") as mock_time,
+        patch("ds01_jobs.client.secrets") as mock_secrets,
+    ):
+        mock_time.time.return_value = 1000000.0
+        mock_secrets.token_urlsafe.return_value = "nonce42"
+
+        headers = sign_headers(key, "POST", "/api/v1/jobs", body)
+
+    body_hash = hashlib.sha256(body).hexdigest()
+    expected_canonical = f"POST\n/api/v1/jobs\n1000000.0\nnonce42\n{body_hash}"
+    expected_sig = hmac.new(key.encode(), expected_canonical.encode(), hashlib.sha256).hexdigest()
+
+    assert headers["X-Signature"] == expected_sig
+
+
+def test_sign_headers_matches_test_auth_reference():
+    """sign_headers output matches the _sign_request helper from test_auth.py."""
+    key = "ds01_abcdefgh12345678"
+    method = "GET"
+    path = "/protected"
+    body = b""
+
+    with (
+        patch("ds01_jobs.client.time") as mock_time,
+        patch("ds01_jobs.client.secrets") as mock_secrets,
+    ):
+        mock_time.time.return_value = 9999.0
+        mock_secrets.token_urlsafe.return_value = "fixednonce"
+
+        headers = sign_headers(key, method, path, body)
+
+    # Replicate test_auth.py's _sign_request
+    ts = "9999.0"
+    n = "fixednonce"
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+
+    assert headers["X-Timestamp"] == ts
+    assert headers["X-Nonce"] == n
+    assert headers["X-Signature"] == sig
+
+
+# --- resolve_api_key tests ---
+
+
+def test_resolve_api_key_from_env(monkeypatch):
+    """DS01_API_KEY env var takes priority."""
+    monkeypatch.setenv("DS01_API_KEY", "  ds01_envkey  ")
+    assert resolve_api_key() == "ds01_envkey"
+
+
+def test_resolve_api_key_from_file(monkeypatch, tmp_path):
+    """Falls back to credentials file when env var unset."""
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
+    creds_file = tmp_path / "credentials"
+    creds_file.write_text("ds01_filekey\n")
+    monkeypatch.setattr("ds01_jobs.client.CREDENTIALS_PATH", creds_file)
+    assert resolve_api_key() == "ds01_filekey"
+
+
+def test_resolve_api_key_none(monkeypatch, tmp_path):
+    """Returns None when neither env var nor file exists."""
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
+    monkeypatch.setattr("ds01_jobs.client.CREDENTIALS_PATH", tmp_path / "nonexistent")
+    assert resolve_api_key() is None
+
+
+def test_resolve_api_key_env_priority_over_file(monkeypatch, tmp_path):
+    """Env var takes priority over credentials file."""
+    monkeypatch.setenv("DS01_API_KEY", "ds01_from_env")
+    creds_file = tmp_path / "credentials"
+    creds_file.write_text("ds01_from_file")
+    monkeypatch.setattr("ds01_jobs.client.CREDENTIALS_PATH", creds_file)
+    assert resolve_api_key() == "ds01_from_env"
+
+
+# --- resolve_api_url tests ---
+
+
+def test_resolve_api_url_from_env(monkeypatch):
+    """DS01_API_URL env var overrides the default."""
+    monkeypatch.setenv("DS01_API_URL", "http://localhost:8765/")
+    assert resolve_api_url() == "http://localhost:8765"
+
+
+def test_resolve_api_url_default(monkeypatch):
+    """Returns DEFAULT_API_URL when env var unset."""
+    monkeypatch.delenv("DS01_API_URL", raising=False)
+    assert resolve_api_url() == DEFAULT_API_URL
+
+
+# --- DS01Client tests ---
+
+
+def test_client_request_sends_signed_headers():
+    """DS01Client.request sends Authorization, X-Timestamp, X-Nonce, X-Signature."""
+    mock_http = MagicMock()
+    mock_response = MagicMock()
+    mock_http.request.return_value = mock_response
+
+    client = DS01Client(api_key="ds01_testkey", base_url="http://localhost:8765")
+    client._http = mock_http
+
+    client.get("/api/v1/jobs")
+
+    call_args = mock_http.request.call_args
+    headers = call_args.kwargs.get("headers") or call_args[1].get("headers")
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer ds01_testkey"
+    assert "X-Timestamp" in headers
+    assert "X-Nonce" in headers
+    assert "X-Signature" in headers
+
+
+def test_client_json_body_serialised_before_signing():
+    """JSON body is serialised to bytes, signed, then sent as content= not json=."""
+    mock_http = MagicMock()
+    mock_response = MagicMock()
+    mock_http.request.return_value = mock_response
+
+    client = DS01Client(api_key="ds01_testkey", base_url="http://localhost:8765")
+    client._http = mock_http
+
+    payload = {"repo_url": "https://github.com/org/repo", "gpu_count": 1}
+    client.post("/api/v1/jobs", json=payload)
+
+    call_args = mock_http.request.call_args
+    kwargs = call_args.kwargs if call_args.kwargs else {}
+    # Should NOT have json= kwarg
+    assert "json" not in kwargs
+    # Should have content= with serialised bytes
+    expected_body = json.dumps(payload).encode()
+    assert kwargs.get("content") == expected_body
+    # Headers should have Content-Type
+    headers = kwargs.get("headers")
+    assert headers is not None
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_client_context_manager():
+    """DS01Client supports context manager protocol."""
+    with patch.object(DS01Client, "close") as mock_close:
+        with DS01Client(api_key="ds01_test", base_url="http://localhost:8765"):
+            pass
+        mock_close.assert_called_once()
+
+
+def test_client_get_convenience():
+    """DS01Client.get calls request with GET method."""
+    client = DS01Client(api_key="ds01_test", base_url="http://localhost:8765")
+    client._http = MagicMock()
+    client._http.request.return_value = MagicMock()
+
+    client.get("/api/v1/jobs")
+
+    call_args = client._http.request.call_args
+    assert call_args[0][0] == "GET"
+    assert call_args[0][1] == "/api/v1/jobs"
+
+
+def test_client_post_convenience():
+    """DS01Client.post calls request with POST method."""
+    client = DS01Client(api_key="ds01_test", base_url="http://localhost:8765")
+    client._http = MagicMock()
+    client._http.request.return_value = MagicMock()
+
+    client.post("/api/v1/jobs", json={"repo_url": "test"})
+
+    call_args = client._http.request.call_args
+    assert call_args[0][0] == "POST"
+    assert call_args[0][1] == "/api/v1/jobs"


### PR DESCRIPTION
## Summary

- Add `DS01Client` with HMAC request signing that mirrors the server's `auth.py` canonical format exactly
- Add credential resolution: `DS01_API_KEY` env var > `~/.config/ds01/credentials` file
- Register `ds01-submit` entry point in pyproject.toml
- 14 unit tests covering signing correctness, credential resolution, and client request handling

## Stack

**PR 1 of 3** — merge this first.
- **PR 2:** `feature/submit-cli` (ds01-submit CLI) — depends on this
- **PR 3:** `feature/github-action` (GitHub Action + integration tests) — depends on PR 2

## Test plan

- [ ] `python -c "from ds01_jobs.client import DS01Client, resolve_api_key, resolve_api_url"` succeeds
- [ ] `pytest tests/unit/test_client.py -v` — all 14 tests pass
- [ ] `ruff check src/ds01_jobs/client.py` and `mypy src/ds01_jobs/client.py --strict` pass
- [ ] Signing output matches `test_auth.py`'s `_sign_request` reference implementation