### PR TITLE
feat: add GitHub Action and CLI integration tests

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,85 @@
+name: 'DS01 Submit Job'
+description: 'Submit a GPU job to DS01 cluster and retrieve results'
+
+inputs:
+  api-key:
+    description: 'DS01 API key for authentication'
+    required: true
+  repo-url:
+    description: 'GitHub repository URL'
+    required: false
+    default: '${{ github.server_url }}/${{ github.repository }}'
+  branch:
+    description: 'Branch to build'
+    required: false
+    default: '${{ github.ref_name }}'
+  gpus:
+    description: 'Number of GPUs'
+    required: false
+    default: '1'
+  timeout:
+    description: 'Job timeout in seconds'
+    required: false
+    default: '14400'
+  commit-results:
+    description: 'Whether to commit results back or upload as artifact'
+    required: false
+    default: 'true'
+  results-path:
+    description: 'Local path to download results to'
+    required: false
+    default: './results'
+
+outputs:
+  job-id:
+    description: 'Submitted job ID'
+    value: ${{ steps.run-job.outputs.job-id }}
+  status:
+    description: 'Final job status'
+    value: ${{ steps.run-job.outputs.status }}
+  results-path:
+    description: 'Path where results were downloaded'
+    value: ${{ steps.run-job.outputs.results-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install ds01-jobs
+      shell: bash
+      run: pip install "${{ github.action_path }}/.."
+
+    - name: Submit, wait, and download
+      id: run-job
+      shell: bash
+      env:
+        DS01_API_KEY: ${{ inputs.api-key }}
+        DS01_API_URL: ${{ inputs.repo-url && '' }}
+      run: |
+        python "${{ github.action_path }}/entrypoint.py" \
+          --repo-url "${{ inputs.repo-url }}" \
+          --branch "${{ inputs.branch }}" \
+          --gpus "${{ inputs.gpus }}" \
+          --timeout "${{ inputs.timeout }}" \
+          --results-path "${{ inputs.results-path }}"
+
+    - name: Commit results
+      if: inputs.commit-results == 'true' && steps.run-job.outputs.status == 'succeeded'
+      shell: bash
+      run: |
+        git config user.name "ds01-bot"
+        git config user.email "ds01-bot@users.noreply.github.com"
+        git add "${{ inputs.results-path }}"
+        git commit -m "feat: add ds01 job results (${{ steps.run-job.outputs.job-id }})"
+        git push
+
+    - name: Upload results as artifact
+      if: inputs.commit-results == 'false' && steps.run-job.outputs.status == 'succeeded'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ds01-results-${{ steps.run-job.outputs.job-id }}
+        path: ${{ inputs.results-path }}

--- a/action/entrypoint.py
+++ b/action/entrypoint.py
@@ -1,0 +1,124 @@
+"""GitHub Action entrypoint: submit a GPU job, poll until done, download results.
+
+Uses argparse (stdlib) for lightweight CLI parsing in CI environments.
+Imports DS01Client from the installed ds01-jobs package for HMAC-signed requests.
+"""
+
+import argparse
+import io
+import os
+import sys
+import tarfile
+import time
+from pathlib import Path
+
+from ds01_jobs.client import TERMINAL_STATES, DS01Client, resolve_api_key, resolve_api_url
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments passed from action.yml composite step."""
+    parser = argparse.ArgumentParser(description="DS01 job submit + wait + download")
+    parser.add_argument("--repo-url", required=True, help="GitHub repository URL")
+    parser.add_argument("--branch", default="main", help="Branch to build")
+    parser.add_argument("--gpus", type=int, default=1, help="Number of GPUs")
+    parser.add_argument("--timeout", type=int, default=14400, help="Job timeout in seconds")
+    parser.add_argument("--results-path", default="./results", help="Path to download results to")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Submit job, poll until terminal state, download results on success."""
+    args = parse_args()
+
+    # Resolve credentials
+    api_key = resolve_api_key()
+    if not api_key:
+        print("Error: DS01_API_KEY not set", file=sys.stderr)
+        return 1
+
+    api_url = resolve_api_url()
+    client = DS01Client(api_key=api_key, base_url=api_url)
+
+    try:
+        # Submit job
+        body = {
+            "repo_url": args.repo_url,
+            "branch": args.branch,
+            "gpu_count": args.gpus,
+            "timeout_seconds": args.timeout,
+        }
+        resp = client.post("/api/v1/jobs", json=body)
+        if resp.status_code != 202:
+            msg = f"Error: job submission failed ({resp.status_code}): {resp.text}"
+            print(msg, file=sys.stderr)
+            return 1
+
+        data = resp.json()
+        job_id = data["job_id"]
+        print(f"Submitted job {job_id}")
+
+        # Poll with exponential backoff
+        backoff = 2.0
+        max_backoff = 30.0
+        poll_count = 0
+
+        while True:
+            poll_count += 1
+            time.sleep(backoff)
+
+            resp = client.get(f"/api/v1/jobs/{job_id}")
+            if resp.status_code != 200:
+                print(
+                    f"Error: status check failed ({resp.status_code}): {resp.text}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            status_data = resp.json()
+            current_status = status_data["status"]
+            print(f"Status: {current_status} (poll {poll_count})")
+
+            if current_status in TERMINAL_STATES:
+                break
+
+            backoff = min(backoff * 2, max_backoff)
+
+        final_status = current_status
+
+        # Download results on success
+        results_path = Path(args.results_path)
+        if final_status == "succeeded":
+            with client.stream("GET", f"/api/v1/jobs/{job_id}/results") as results_resp:
+                if results_resp.status_code == 200:
+                    buffer = io.BytesIO()
+                    for chunk in results_resp.iter_bytes():
+                        buffer.write(chunk)
+                    buffer.seek(0)
+                    results_path.mkdir(parents=True, exist_ok=True)
+                    with tarfile.open(fileobj=buffer, mode="r:gz") as tar:
+                        tar.extractall(path=results_path, filter="data")
+                    print(f"Results downloaded to {results_path}")
+                else:
+                    print(f"Warning: could not download results ({results_resp.status_code})")
+
+        # Write GitHub Action outputs
+        output_file = os.environ.get("GITHUB_OUTPUT", "")
+        if output_file:
+            with open(output_file, "a") as f:
+                f.write(f"job-id={job_id}\n")
+                f.write(f"status={final_status}\n")
+                f.write(f"results-path={results_path}\n")
+
+        if final_status == "succeeded":
+            print(f"Job {job_id} completed successfully")
+            return 0
+        else:
+            print(f"Job {job_id} finished with status: {final_status}", file=sys.stderr)
+            return 1
+
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -63,8 +63,8 @@ def _print_key_result(
         typer.echo("")
         typer.echo("Setup instructions (send to researcher):")
         typer.echo("\u2500" * 41)
-        typer.echo("mkdir -p ~/.config/ds01")
-        typer.echo(f'echo "DS01_API_KEY={raw_key}" > ~/.config/ds01/credentials')
+        typer.echo("pip install ds01-jobs")
+        typer.echo(f"DS01_API_KEY={raw_key} ds01-submit configure")
         typer.echo("\u2500" * 41)
 
 

--- a/src/ds01_jobs/submit.py
+++ b/src/ds01_jobs/submit.py
@@ -1,0 +1,318 @@
+"""ds01-submit CLI for researchers to submit GPU jobs and retrieve results.
+
+Commands: configure, run, status, results, list, cancel.
+All commands support --json for machine-readable output.
+"""
+
+import io
+import json
+import tarfile
+import time
+from pathlib import Path
+from typing import Annotated
+
+import httpx
+import typer
+from rich.progress import BarColumn, DownloadColumn, Progress, TransferSpeedColumn
+
+from ds01_jobs.client import (
+    CREDENTIALS_PATH,
+    TERMINAL_STATES,
+    DS01Client,
+    resolve_api_key,
+    resolve_api_url,
+)
+
+app = typer.Typer(
+    name="ds01-submit",
+    help="DS01 Job Submission Service - Researcher CLI",
+)
+
+JsonOption = Annotated[bool, typer.Option("--json", help="JSON output")]
+
+
+def _get_client() -> DS01Client:
+    """Resolve credentials and return a signing client.
+
+    Exits with a helpful message if no API key is found.
+    """
+    api_key = resolve_api_key()
+    if not api_key:
+        typer.echo(
+            "Error: No API key found. Set DS01_API_KEY or run 'ds01-submit configure'.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return DS01Client(api_key=api_key, base_url=resolve_api_url())
+
+
+def _handle_error(resp: httpx.Response) -> None:
+    """Print a structured error message from an API error response and exit."""
+    try:
+        body = resp.json()
+        if "error" in body and isinstance(body["error"], dict):
+            typer.echo(f"Error: {body['error'].get('message', resp.status_code)}", err=True)
+        elif "detail" in body:
+            typer.echo(f"Error: {body['detail']}", err=True)
+        else:
+            typer.echo(f"Error: {resp.status_code} {resp.text}", err=True)
+    except Exception:
+        typer.echo(f"Error: {resp.status_code} {resp.text}", err=True)
+    raise typer.Exit(code=1)
+
+
+@app.command()
+def configure() -> None:
+    """Set up API credentials for ds01-submit."""
+    api_key = typer.prompt("DS01 API key")
+    api_url = resolve_api_url()
+
+    client = DS01Client(api_key=api_key, base_url=api_url)
+    try:
+        resp = client.get("/api/v1/users/me/quota")
+        resp.raise_for_status()
+    except httpx.HTTPStatusError:
+        typer.echo("Error: Invalid or expired API key", err=True)
+        raise typer.Exit(code=1)
+    finally:
+        client.close()
+
+    CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CREDENTIALS_PATH.write_text(api_key)
+    CREDENTIALS_PATH.chmod(0o600)
+
+    quota = resp.json()
+    typer.echo(f"Authenticated as {quota['username']} (group: {quota['group']})")
+    typer.echo(f"Credentials saved to {CREDENTIALS_PATH}")
+
+
+@app.command("run")
+def run_job(
+    repo_url: Annotated[str, typer.Argument(help="GitHub repository URL")],
+    gpus: Annotated[int, typer.Option(help="Number of GPUs")] = 1,
+    branch: Annotated[str, typer.Option(help="Git branch to build")] = "main",
+    name: Annotated[str | None, typer.Option(help="Job name")] = None,
+    timeout: Annotated[int | None, typer.Option(help="Job timeout in seconds")] = None,
+    dockerfile: Annotated[Path | None, typer.Option(help="Path to Dockerfile")] = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Submit a GPU job and print the job ID."""
+    client = _get_client()
+    try:
+        body: dict[str, object] = {
+            "repo_url": repo_url,
+            "gpu_count": gpus,
+            "branch": branch,
+        }
+        if name is not None:
+            body["job_name"] = name
+        if timeout is not None:
+            body["timeout_seconds"] = timeout
+        if dockerfile is not None:
+            body["dockerfile_content"] = dockerfile.read_text()
+
+        resp = client.post("/api/v1/jobs", json=body)
+        if resp.status_code != 202:
+            _handle_error(resp)
+
+        data = resp.json()
+        if json_output:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            typer.echo(data["job_id"])
+    finally:
+        client.close()
+
+
+@app.command()
+def status(
+    job_id: Annotated[str, typer.Argument(help="Job ID")],
+    follow: Annotated[
+        bool, typer.Option("--follow", "-f", help="Poll until terminal state")
+    ] = False,
+    json_output: JsonOption = False,
+) -> None:
+    """Show job status. Use --follow to poll until completion."""
+    client = _get_client()
+    try:
+        backoff = 2.0
+        max_backoff = 30.0
+
+        while True:
+            resp = client.get(f"/api/v1/jobs/{job_id}")
+            if resp.status_code != 200:
+                _handle_error(resp)
+
+            data = resp.json()
+            current_status = data["status"]
+
+            if not follow or current_status in TERMINAL_STATES:
+                if json_output:
+                    typer.echo(json.dumps(data, indent=2))
+                else:
+                    _print_status(data)
+
+                if current_status == "failed":
+                    raise typer.Exit(code=2)
+                return
+
+            # Polling mode: print a short update
+            typer.echo(f"Status: {current_status} (polling...)")
+            time.sleep(backoff)
+            backoff = min(backoff * 2, max_backoff)
+    finally:
+        client.close()
+
+
+def _print_status(data: dict[str, object]) -> None:
+    """Print human-readable job status snapshot."""
+    typer.echo(f"Job:     {data['job_id']}")
+    typer.echo(f"Status:  {data['status']}")
+    typer.echo(f"Name:    {data.get('job_name', '-')}")
+    typer.echo(f"Repo:    {data.get('repo_url', '-')}")
+    typer.echo(f"Branch:  {data.get('branch', '-')}")
+    typer.echo(f"GPUs:    {data.get('gpu_count', '-')}")
+    typer.echo(f"Created: {data.get('created_at', '-')}")
+
+    if data.get("queue_position") is not None:
+        typer.echo(f"Queue:   #{data['queue_position']}")
+
+    phases = data.get("phases")
+    if phases and isinstance(phases, dict):
+        typer.echo("")
+        typer.echo("Phases:")
+        for phase_name, ts in phases.items():
+            if isinstance(ts, dict):
+                started = ts.get("started_at", "-")
+                ended = ts.get("ended_at", "-")
+                typer.echo(f"  {phase_name}: started={started} ended={ended}")
+
+    error = data.get("error")
+    if error and isinstance(error, dict):
+        typer.echo("")
+        typer.echo(f"Error:   [{error.get('phase', '?')}] {error.get('message', '-')}")
+        if error.get("exit_code") is not None:
+            typer.echo(f"         exit code {error['exit_code']}")
+
+
+@app.command()
+def results(
+    job_id: Annotated[str, typer.Argument(help="Job ID")],
+    output: Annotated[Path, typer.Option("-o", "--output", help="Output directory")] = Path(
+        "./results"
+    ),
+    json_output: JsonOption = False,
+) -> None:
+    """Download and extract job results."""
+    client = _get_client()
+    try:
+        path = f"/api/v1/jobs/{job_id}/results"
+        with client.stream("GET", path) as resp:
+            if resp.status_code == 404:
+                typer.echo(f"Error: No results found for job {job_id}", err=True)
+                raise typer.Exit(code=1)
+            resp.raise_for_status()
+
+            total = int(resp.headers.get("content-length", "0"))
+            buffer = io.BytesIO()
+
+            if total > 1_048_576:
+                with Progress(
+                    "[progress.description]{task.description}",
+                    BarColumn(),
+                    DownloadColumn(),
+                    TransferSpeedColumn(),
+                ) as progress:
+                    task = progress.add_task("Downloading results", total=total)
+                    for chunk in resp.iter_bytes():
+                        buffer.write(chunk)
+                        progress.update(task, advance=len(chunk))
+            else:
+                for chunk in resp.iter_bytes():
+                    buffer.write(chunk)
+
+        buffer.seek(0)
+        output.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(fileobj=buffer, mode="r:gz") as tar:
+            tar.extractall(path=output, filter="data")
+
+        if json_output:
+            typer.echo(json.dumps({"job_id": job_id, "path": str(output)}))
+        else:
+            typer.echo(f"Results downloaded to {output}")
+    finally:
+        client.close()
+
+
+@app.command("list")
+def list_jobs(
+    limit: Annotated[int, typer.Option(help="Max jobs to return")] = 20,
+    offset: Annotated[int, typer.Option(help="Pagination offset")] = 0,
+    json_output: JsonOption = False,
+) -> None:
+    """List submitted jobs."""
+    client = _get_client()
+    try:
+        resp = client.get(f"/api/v1/jobs?limit={limit}&offset={offset}")
+        if resp.status_code != 200:
+            _handle_error(resp)
+
+        data = resp.json()
+
+        if json_output:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            jobs = data.get("jobs", [])
+            if not jobs:
+                typer.echo("No jobs found.")
+                return
+
+            headers = ["JOB ID", "STATUS", "NAME", "CREATED"]
+            rows = []
+            for j in jobs:
+                rows.append(
+                    [
+                        j.get("job_id", "-"),
+                        j.get("status", "-"),
+                        j.get("job_name", "-"),
+                        j.get("created_at", "-")[:19],
+                    ]
+                )
+
+            col_widths = [
+                max(len(headers[i]), *(len(r[i]) for r in rows)) for i in range(len(headers))
+            ]
+
+            header_line = "  ".join(h.ljust(w) for h, w in zip(headers, col_widths, strict=True))
+            typer.echo(header_line)
+
+            for row in rows:
+                line = "  ".join(v.ljust(w) for v, w in zip(row, col_widths, strict=True))
+                typer.echo(line)
+    finally:
+        client.close()
+
+
+@app.command()
+def cancel(
+    job_id: Annotated[str, typer.Argument(help="Job ID")],
+    json_output: JsonOption = False,
+) -> None:
+    """Cancel a running job."""
+    client = _get_client()
+    try:
+        resp = client.post(f"/api/v1/jobs/{job_id}/cancel")
+        if resp.status_code not in (200, 202):
+            _handle_error(resp)
+
+        data = resp.json()
+        if json_output:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            typer.echo(f"Job {job_id} cancelled")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,0 +1,326 @@
+"""CLI integration tests exercising ds01-submit commands against in-process FastAPI app.
+
+Uses a sync transport wrapper around httpx.ASGITransport to route DS01Client
+requests to the real FastAPI app, validating full request signing, auth, and
+database round-trips.
+"""
+
+import asyncio
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import bcrypt
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from ds01_jobs.app import create_app
+from ds01_jobs.database import SCHEMA_SQL
+from ds01_jobs.submit import app as submit_app
+
+pytestmark = pytest.mark.integration
+
+runner = CliRunner()
+
+
+class SyncASGITransport(httpx.BaseTransport):
+    """Sync transport that bridges to ASGITransport via asyncio.run().
+
+    Allows httpx.Client (sync) to make requests against an ASGI app.
+    Converts async response streams to sync byte streams.
+    """
+
+    def __init__(self, app: object) -> None:
+        self._async_transport = httpx.ASGITransport(app=app)  # type: ignore[arg-type]
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        """Handle a sync request by running the async transport in an event loop."""
+
+        async def _handle() -> tuple[int, list[tuple[bytes, bytes]], bytes]:
+            resp = await self._async_transport.handle_async_request(request)
+            # Read the full async stream body into bytes
+            body_parts = []
+            async for chunk in resp.stream:
+                body_parts.append(chunk)
+            await resp.stream.aclose()
+            body = b"".join(body_parts)
+            return resp.status_code, list(resp.headers.raw), body
+
+        loop = asyncio.new_event_loop()
+        try:
+            status_code, headers, body = loop.run_until_complete(_handle())
+        finally:
+            loop.close()
+
+        return httpx.Response(
+            status_code=status_code,
+            headers=headers,
+            content=body,
+        )
+
+    def close(self) -> None:
+        pass
+
+
+def _generate_test_key() -> tuple[str, str, str]:
+    """Generate a test API key and return (raw_key, key_id, bcrypt_hash)."""
+    import base64
+    import secrets
+
+    raw_bytes = secrets.token_bytes(32)
+    encoded = base64.urlsafe_b64encode(raw_bytes).rstrip(b"=").decode()
+    raw_key = f"ds01_{encoded}"
+    key_id = encoded[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt(rounds=4)).decode()
+    return raw_key, key_id, key_hash
+
+
+def _seed_api_key(db_path: Path) -> tuple[str, str]:
+    """Seed the database with a test API key. Returns (raw_key, username)."""
+    raw_key, key_id, key_hash = _generate_test_key()
+    username = "testuser"
+    now = datetime.now(UTC).isoformat()
+    expires = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (username, key_id, key_hash, now, expires),
+    )
+    conn.commit()
+    conn.close()
+    return raw_key, username
+
+
+def _seed_job(db_path: Path, username: str, status: str = "queued") -> str:
+    """Insert a test job and return its ID."""
+    import uuid
+
+    job_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
+        "status, created_at, updated_at, phase_timestamps) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            job_id,
+            username,
+            "https://github.com/test-org/test-repo",
+            "main",
+            1,
+            f"test-job-{job_id[:8]}",
+            status,
+            now,
+            now,
+            "{}",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return job_id
+
+
+@pytest.fixture()
+def integration_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Set up an in-process FastAPI app with a temp database and patched DS01Client.
+
+    Returns (raw_key, username, db_path, fastapi_app).
+    """
+    db_path = tmp_path / "test.db"
+
+    # Initialise database schema
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_SQL)
+    conn.commit()
+    conn.close()
+
+    # Seed API key
+    raw_key, username = _seed_api_key(db_path)
+
+    # Patch settings to use temp DB and skip resource-limits file
+    monkeypatch.setenv("DS01_JOBS_DB_PATH", str(db_path))
+    monkeypatch.setenv("DS01_JOBS_RESOURCE_LIMITS_PATH", str(tmp_path / "nonexistent.yaml"))
+    monkeypatch.setenv("DS01_JOBS_WORKSPACE_ROOT", str(tmp_path / "workspaces"))
+
+    # Clear lru_cache on settings/db path resolvers
+    from ds01_jobs.database import _get_db_path
+    from ds01_jobs.jobs import _get_settings
+
+    _get_db_path.cache_clear()
+    _get_settings.cache_clear()
+
+    # Create the FastAPI app
+    fastapi_app = create_app()
+
+    # Create sync ASGI transport for the test app
+    transport = SyncASGITransport(app=fastapi_app)
+    original_init = httpx.Client.__init__
+
+    def _patched_client_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs["transport"] = transport
+        # Ensure base_url is a valid HTTP URL for the transport
+        if "base_url" in kwargs:
+            base = kwargs["base_url"]
+            if not str(base).startswith("http"):
+                kwargs["base_url"] = f"http://testserver{base}"
+            elif "testserver" not in str(base):
+                kwargs["base_url"] = "http://testserver"
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", _patched_client_init)
+
+    # Set env vars for CLI credential resolution
+    monkeypatch.setenv("DS01_API_KEY", raw_key)
+    monkeypatch.setenv("DS01_API_URL", "http://testserver")
+
+    yield raw_key, username, db_path, fastapi_app
+
+    # Cleanup caches
+    _get_db_path.cache_clear()
+    _get_settings.cache_clear()
+
+
+def test_configure_valid_key(integration_env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """configure command with a valid key succeeds and writes credentials file."""
+    raw_key, username, db_path, _ = integration_env
+    creds_path = tmp_path / "creds" / "credentials"
+    monkeypatch.setattr("ds01_jobs.submit.CREDENTIALS_PATH", creds_path)
+
+    result = runner.invoke(submit_app, ["configure"], input=f"{raw_key}\n")
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    assert "Authenticated as" in result.output
+    assert creds_path.exists()
+    assert creds_path.read_text() == raw_key
+
+
+def test_configure_invalid_key(integration_env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """configure with invalid key prints error and exits 1."""
+    creds_path = tmp_path / "creds" / "credentials"
+    monkeypatch.setattr("ds01_jobs.submit.CREDENTIALS_PATH", creds_path)
+
+    result = runner.invoke(submit_app, ["configure"], input="invalid_key_abc\n")
+    assert result.exit_code == 1
+    assert not creds_path.exists()
+
+
+def test_run_submit_job(integration_env, monkeypatch: pytest.MonkeyPatch):
+    """run command submits a job and prints job ID only (one line)."""
+    raw_key, username, db_path, _ = integration_env
+    # Need allowed_github_orgs to be empty (allows any) and skip preflight
+    monkeypatch.setenv("DS01_JOBS_ALLOWED_GITHUB_ORGS", "[]")
+
+    from ds01_jobs.jobs import _get_settings
+
+    _get_settings.cache_clear()
+
+    # Patch verify_repo_accessible and check_ssrf to skip network calls
+    with (
+        patch("ds01_jobs.jobs.verify_repo_accessible", return_value=None),
+        patch("ds01_jobs.jobs.check_ssrf", return_value=None),
+    ):
+        result = runner.invoke(
+            submit_app,
+            ["run", "https://github.com/test-org/test-repo"],
+        )
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    # Default output is just the job ID (UUID format)
+    output = result.output.strip()
+    assert len(output) == 36  # UUID length
+    assert "-" in output
+
+
+def test_run_submit_json(integration_env, monkeypatch: pytest.MonkeyPatch):
+    """run with --json prints full JSON response."""
+    raw_key, username, db_path, _ = integration_env
+    monkeypatch.setenv("DS01_JOBS_ALLOWED_GITHUB_ORGS", "[]")
+
+    from ds01_jobs.jobs import _get_settings
+
+    _get_settings.cache_clear()
+
+    with (
+        patch("ds01_jobs.jobs.verify_repo_accessible", return_value=None),
+        patch("ds01_jobs.jobs.check_ssrf", return_value=None),
+    ):
+        result = runner.invoke(
+            submit_app,
+            ["run", "https://github.com/test-org/test-repo", "--json"],
+        )
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    data = json.loads(result.output)
+    assert "job_id" in data
+    assert data["status"] == "queued"
+
+
+def test_status_snapshot(integration_env):
+    """status command shows job details in human-readable format."""
+    raw_key, username, db_path, _ = integration_env
+    job_id = _seed_job(db_path, username, status="queued")
+
+    result = runner.invoke(submit_app, ["status", job_id])
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    assert f"Job:     {job_id}" in result.output
+    assert "Status:  queued" in result.output
+
+
+def test_status_json(integration_env):
+    """status --json prints raw JSON response."""
+    raw_key, username, db_path, _ = integration_env
+    job_id = _seed_job(db_path, username, status="queued")
+
+    result = runner.invoke(submit_app, ["status", job_id, "--json"])
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    data = json.loads(result.output)
+    assert data["job_id"] == job_id
+    assert data["status"] == "queued"
+
+
+def test_list_jobs(integration_env):
+    """list command shows columnar output."""
+    raw_key, username, db_path, _ = integration_env
+    _seed_job(db_path, username, status="queued")
+    _seed_job(db_path, username, status="succeeded")
+
+    result = runner.invoke(submit_app, ["list"])
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    assert "JOB ID" in result.output
+    assert "STATUS" in result.output
+
+
+def test_cancel_job(integration_env):
+    """cancel command succeeds on a queued job."""
+    raw_key, username, db_path, _ = integration_env
+    job_id = _seed_job(db_path, username, status="queued")
+
+    result = runner.invoke(submit_app, ["cancel", job_id])
+    assert result.exit_code == 0, f"stdout: {result.output}"
+    assert f"Job {job_id} cancelled" in result.output
+
+    # Verify status changed in DB
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT status FROM jobs WHERE id = ?", (job_id,))
+    row = cursor.fetchone()
+    conn.close()
+    assert row["status"] == "failed"
+
+
+def test_no_credentials_error(monkeypatch: pytest.MonkeyPatch):
+    """Commands without credentials print helpful error."""
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
+    # Ensure credentials file doesn't exist
+    monkeypatch.setattr(
+        "ds01_jobs.submit.CREDENTIALS_PATH",
+        Path("/nonexistent/path/credentials"),
+    )
+
+    result = runner.invoke(submit_app, ["status", "fake-job-id"])
+    assert result.exit_code == 1
+    assert "No API key found" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -208,7 +208,8 @@ def test_key_create_setup_instructions(tmp_db, mock_github_member):
     result = runner.invoke(app, ["key-create", "researcher1"])
     assert result.exit_code == 0
     assert "Setup instructions" in result.output
-    assert "mkdir -p ~/.config/ds01" in result.output
+    assert "pip install ds01-jobs" in result.output
+    assert "ds01-submit configure" in result.output
     assert "DS01_API_KEY=" in result.output
 
 

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -1,0 +1,405 @@
+"""Tests for ds01_jobs.submit module - ds01-submit CLI commands."""
+
+import io
+import json
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ds01_jobs.submit import app
+
+runner = CliRunner()
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def mock_api_key(monkeypatch):
+    """Set a fake API key in the environment."""
+    monkeypatch.setenv("DS01_API_KEY", "ds01_testkey123")
+    monkeypatch.setenv("DS01_API_URL", "http://localhost:8765")
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    """Build a mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import httpx
+
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message="error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+# --- configure tests ---
+
+
+@patch("ds01_jobs.submit.DS01Client")
+def test_configure_success(MockClient, tmp_path, monkeypatch):
+    """configure validates key and saves credentials."""
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
+    monkeypatch.setenv("DS01_API_URL", "http://localhost:8765")
+    creds_path = tmp_path / "credentials"
+    monkeypatch.setattr("ds01_jobs.submit.CREDENTIALS_PATH", creds_path)
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(
+        json_data={"username": "researcher1", "group": "lab-a"}
+    )
+    MockClient.return_value = mock_client
+
+    result = runner.invoke(app, ["configure"], input="ds01_mykey\n")
+    assert result.exit_code == 0
+    assert "Authenticated as researcher1" in result.output
+    assert "group: lab-a" in result.output
+    assert creds_path.read_text() == "ds01_mykey"
+
+
+@patch("ds01_jobs.submit.DS01Client")
+def test_configure_invalid_key(MockClient, monkeypatch):
+    """configure with invalid key prints error and exits 1."""
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
+    monkeypatch.setenv("DS01_API_URL", "http://localhost:8765")
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(status_code=401)
+    MockClient.return_value = mock_client
+
+    result = runner.invoke(app, ["configure"], input="bad_key\n")
+    assert result.exit_code == 1
+    assert "Invalid or expired API key" in result.output
+
+
+# --- run tests ---
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_run_prints_job_id_only(mock_get_client, mock_api_key):
+    """run prints only the job ID by default (pipeable)."""
+    mock_client = MagicMock()
+    mock_client.post.return_value = _mock_response(
+        status_code=202,
+        json_data={
+            "job_id": "job-abc123",
+            "status": "queued",
+            "status_url": "/api/v1/jobs/job-abc123",
+            "created_at": "2026-03-10T00:00:00Z",
+        },
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["run", "https://github.com/org/repo"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "job-abc123"
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_run_json_output(mock_get_client, mock_api_key):
+    """run --json prints full JSON response."""
+    response_data = {
+        "job_id": "job-abc123",
+        "status": "queued",
+        "status_url": "/api/v1/jobs/job-abc123",
+        "created_at": "2026-03-10T00:00:00Z",
+    }
+    mock_client = MagicMock()
+    mock_client.post.return_value = _mock_response(status_code=202, json_data=response_data)
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["run", "https://github.com/org/repo", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["job_id"] == "job-abc123"
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_run_with_options(mock_get_client, mock_api_key):
+    """run passes --gpus, --branch, --name to the API."""
+    mock_client = MagicMock()
+    mock_client.post.return_value = _mock_response(
+        status_code=202,
+        json_data={"job_id": "job-xyz", "status": "queued", "status_url": "/", "created_at": "now"},
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "https://github.com/org/repo",
+            "--gpus",
+            "4",
+            "--branch",
+            "dev",
+            "--name",
+            "test-job",
+        ],
+    )
+    assert result.exit_code == 0
+
+    call_kwargs = mock_client.post.call_args
+    body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    assert body["gpu_count"] == 4
+    assert body["branch"] == "dev"
+    assert body["job_name"] == "test-job"
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_run_api_error(mock_get_client, mock_api_key):
+    """run handles API error with structured message."""
+    mock_client = MagicMock()
+    mock_client.post.return_value = _mock_response(
+        status_code=422,
+        json_data={"error": {"type": "validation_error", "message": "Invalid repo URL"}},
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["run", "not-a-url"])
+    assert result.exit_code == 1
+
+
+# --- status tests ---
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_status_snapshot(mock_get_client, mock_api_key):
+    """status prints human-readable snapshot."""
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(
+        json_data={
+            "job_id": "job-abc123",
+            "status": "running",
+            "job_name": "my-job",
+            "repo_url": "https://github.com/org/repo",
+            "branch": "main",
+            "gpu_count": 2,
+            "submitted_by": "researcher1",
+            "created_at": "2026-03-10T00:00:00Z",
+            "started_at": "2026-03-10T00:01:00Z",
+            "completed_at": None,
+            "phases": {
+                "queued": {"started_at": "2026-03-10T00:00:00Z", "ended_at": "2026-03-10T00:01:00Z"}
+            },
+            "error": None,
+            "queue_position": None,
+        },
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["status", "job-abc123"])
+    assert result.exit_code == 0
+    assert "job-abc123" in result.output
+    assert "running" in result.output
+    assert "my-job" in result.output
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_status_json(mock_get_client, mock_api_key):
+    """status --json prints raw JSON."""
+    detail = {"job_id": "job-abc123", "status": "succeeded"}
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(json_data=detail)
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["status", "job-abc123", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["job_id"] == "job-abc123"
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_status_failed_exit_code_2(mock_get_client, mock_api_key):
+    """status of a failed job exits with code 2."""
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(
+        json_data={
+            "job_id": "job-fail",
+            "status": "failed",
+            "job_name": "broken",
+            "repo_url": "https://github.com/org/repo",
+            "branch": "main",
+            "gpu_count": 1,
+            "submitted_by": "researcher1",
+            "created_at": "2026-03-10T00:00:00Z",
+            "phases": {},
+            "error": {"phase": "build", "message": "Build failed", "exit_code": 1},
+        },
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["status", "job-fail"])
+    assert result.exit_code == 2
+
+
+# --- results tests ---
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_results_download_and_extract(mock_get_client, mock_api_key, tmp_path):
+    """results downloads tar.gz and extracts to output directory."""
+    # Create a tar.gz in memory
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+        data = b"hello results"
+        info = tarfile.TarInfo(name="results/output.txt")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    tar_bytes = tar_buffer.getvalue()
+
+    mock_client = MagicMock()
+    mock_stream_response = MagicMock()
+    mock_stream_response.status_code = 200
+    mock_stream_response.headers = {"content-length": str(len(tar_bytes))}
+    mock_stream_response.iter_bytes.return_value = [tar_bytes]
+    mock_stream_response.raise_for_status = MagicMock()
+    mock_stream_response.__enter__ = MagicMock(return_value=mock_stream_response)
+    mock_stream_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client.stream.return_value = mock_stream_response
+    mock_get_client.return_value = mock_client
+
+    output_dir = tmp_path / "output"
+    result = runner.invoke(app, ["results", "job-abc123", "-o", str(output_dir)])
+    assert result.exit_code == 0
+    assert "Results downloaded" in result.output
+    assert (output_dir / "results" / "output.txt").exists()
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_results_not_found(mock_get_client, mock_api_key):
+    """results handles 404 with clear error."""
+    mock_client = MagicMock()
+    mock_stream_response = MagicMock()
+    mock_stream_response.status_code = 404
+    mock_stream_response.__enter__ = MagicMock(return_value=mock_stream_response)
+    mock_stream_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client.stream.return_value = mock_stream_response
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["results", "job-nonexistent"])
+    assert result.exit_code == 1
+    assert "No results found" in result.output
+
+
+# --- list tests ---
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_list_columnar_output(mock_get_client, mock_api_key):
+    """list prints columnar output."""
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(
+        json_data={
+            "jobs": [
+                {
+                    "job_id": "job-001",
+                    "status": "succeeded",
+                    "job_name": "train-model",
+                    "repo_url": "https://github.com/org/repo",
+                    "created_at": "2026-03-10T00:00:00Z",
+                    "completed_at": "2026-03-10T01:00:00Z",
+                },
+                {
+                    "job_id": "job-002",
+                    "status": "running",
+                    "job_name": "eval-model",
+                    "repo_url": "https://github.com/org/repo",
+                    "created_at": "2026-03-10T02:00:00Z",
+                    "completed_at": None,
+                },
+            ],
+            "total": 2,
+            "limit": 20,
+            "offset": 0,
+        },
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "JOB ID" in result.output
+    assert "STATUS" in result.output
+    assert "job-001" in result.output
+    assert "job-002" in result.output
+    assert "train-model" in result.output
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_list_json(mock_get_client, mock_api_key):
+    """list --json prints raw JSON."""
+    list_data = {"jobs": [], "total": 0, "limit": 20, "offset": 0}
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(json_data=list_data)
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["total"] == 0
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_list_empty(mock_get_client, mock_api_key):
+    """list with no jobs prints message."""
+    mock_client = MagicMock()
+    mock_client.get.return_value = _mock_response(
+        json_data={"jobs": [], "total": 0, "limit": 20, "offset": 0}
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "No jobs found" in result.output
+
+
+# --- cancel tests ---
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_cancel_success(mock_get_client, mock_api_key):
+    """cancel prints confirmation."""
+    mock_client = MagicMock()
+    mock_client.post.return_value = _mock_response(
+        json_data={"job_id": "job-abc123", "status": "cancelled"}
+    )
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["cancel", "job-abc123"])
+    assert result.exit_code == 0
+    assert "cancelled" in result.output
+
+
+@patch("ds01_jobs.submit._get_client")
+def test_cancel_json(mock_get_client, mock_api_key):
+    """cancel --json prints JSON response."""
+    cancel_data = {"job_id": "job-abc123", "status": "cancelled"}
+    mock_client = MagicMock()
+    mock_client.post.return_value = _mock_response(json_data=cancel_data)
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(app, ["cancel", "job-abc123", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["status"] == "cancelled"
+
+
+# --- credential resolution failure ---
+
+
+def test_no_credentials_exits_with_message(monkeypatch, tmp_path):
+    """Commands exit with helpful message when no credentials found."""
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
+    monkeypatch.setattr("ds01_jobs.client.CREDENTIALS_PATH", tmp_path / "nonexistent")
+
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 1
+    assert "No API key found" in result.output


### PR DESCRIPTION
## Summary

- Add composite GitHub Action (`action/action.yml` + `action/entrypoint.py`) for CI-driven job submission
- Action handles submit → poll → download → commit-results or upload-artifact in a single step
- Outputs `job-id`, `status`, `results-path` for downstream workflow steps
- `entrypoint.py` uses argparse (lightweight, no Rich dependency for CI)
- 9 CLI integration tests exercise commands against in-process FastAPI app via `SyncASGITransport`

## Dependencies

Depends on #38 — merge that first.

## Test plan

- [ ] `action/action.yml` has valid composite structure with all inputs/outputs
- [ ] `pytest tests/integration/test_cli_integration.py -v -m integration` — all 9 tests pass
- [ ] `ruff check action/entrypoint.py tests/integration/test_cli_integration.py` passes
- [ ] CI passes