### PR TITLE
feat: add dual identity model (github_username + unix_username)

### DIFF
--- a/src/ds01_jobs/auth.py
+++ b/src/ds01_jobs/auth.py
@@ -161,4 +161,4 @@ async def get_current_user(
     if expires_at - now <= timedelta(days=KEY_EXPIRY_WARNING_DAYS):
         response.headers["X-DS01-Key-Expiry-Warning"] = expires_at.date().isoformat()
 
-    return {"username": username}
+    return {"username": username, "unix_username": row["unix_username"]}

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
 
     # External config
     resource_limits_path: Path = Path("/opt/ds01-infra/config/runtime/resource-limits.yaml")
+    get_resource_limits_bin: Path = Path("/opt/ds01-infra/scripts/docker/get_resource_limits.py")
 
     # Authentication
     github_org: str = "hertie-data-science-lab"

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -18,7 +18,7 @@ SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS api_keys (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL,
-    unix_username TEXT NOT NULL,
+    unix_username TEXT NOT NULL DEFAULT '',
     key_id TEXT NOT NULL UNIQUE,
     key_hash TEXT NOT NULL,
     created_at TEXT NOT NULL,

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -18,6 +18,7 @@ SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS api_keys (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL,
+    unix_username TEXT NOT NULL,
     key_id TEXT NOT NULL UNIQUE,
     key_hash TEXT NOT NULL,
     created_at TEXT NOT NULL,
@@ -30,6 +31,7 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_key_id ON api_keys(key_id);
 CREATE TABLE IF NOT EXISTS jobs (
     id TEXT PRIMARY KEY,
     username TEXT NOT NULL,
+    unix_username TEXT NOT NULL DEFAULT '',
     repo_url TEXT NOT NULL,
     branch TEXT NOT NULL DEFAULT 'main',
     gpu_count INTEGER NOT NULL DEFAULT 1,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,7 +98,8 @@ async def seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 username,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,9 +98,17 @@ async def seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                f"{username}_unix",
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                0,
+            ),
         )
         await db.commit()
 

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -88,9 +88,9 @@ def _seed_api_key(db_path: Path) -> tuple[str, str]:
     conn = sqlite3.connect(db_path)
     conn.executescript(SCHEMA_SQL)
     conn.execute(
-        "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (username, key_id, key_hash, now, expires),
+        "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (username, f"{username}_unix", key_id, key_hash, now, expires),
     )
     conn.commit()
     conn.close()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -55,6 +55,7 @@ async def _seed_key(
     key_id: str,
     key_hash: str,
     username: str = "testuser",
+    unix_username: str = "testuser_unix",
     expires_at: str | None = None,
     revoked: int = 0,
 ) -> None:
@@ -66,9 +67,18 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, revoked),
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                unix_username,
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                revoked,
+            ),
         )
         await db.commit()
 
@@ -323,3 +333,26 @@ async def test_last_used_at_updated_after_successful_auth(tmp_path: Path):
         row = await cursor.fetchone()
         assert row is not None
         assert row[0] is not None  # last_used_at should be set
+
+
+@pytest.mark.asyncio
+async def test_auth_returns_unix_username(tmp_path: Path):
+    """Successful auth returns both username and unix_username."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 200
+    user = resp.json()["user"]
+    assert user["username"] == "ghuser"
+    assert user["unix_username"] == "unixuser"

--- a/tests/unit/test_cancel.py
+++ b/tests/unit/test_cancel.py
@@ -59,9 +59,17 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                f"{username}_unix",
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                0,
+            ),
         )
         await db.commit()
 

--- a/tests/unit/test_cancel.py
+++ b/tests/unit/test_cancel.py
@@ -59,7 +59,8 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 username,

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -24,6 +24,7 @@ async def test_init_db_creates_api_keys_table(tmp_path: Path):
     expected = {
         "id",
         "username",
+        "unix_username",
         "key_id",
         "key_hash",
         "created_at",

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -61,9 +61,17 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                f"{username}_unix",
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                0,
+            ),
         )
         await db.commit()
 

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -61,7 +61,8 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 username,

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -62,9 +62,17 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                f"{username}_unix",
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                0,
+            ),
         )
         await db.commit()
 

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -62,7 +62,8 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 username,

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -62,9 +62,17 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                f"{username}_unix",
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                0,
+            ),
         )
         await db.commit()
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -62,7 +62,8 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 username,


### PR DESCRIPTION
## Summary
- Add `unix_username` column to `api_keys` and `jobs` tables for server-side user identity
- Add `get_resource_limits_bin` config setting pointing to ds01-infra's resource limits parser
- `auth.get_current_user` now returns both `username` (GitHub) and `unix_username` (Unix)
- Fix all test fixtures and seed helpers to include `unix_username` in INSERT statements
- Add explicit test for `unix_username` returned from auth

**Part 1 of 3** for ds01-infra container integration. Schema foundation for dual identity model.

## Context
ds01-jobs stores GitHub usernames for API auth/display, but Docker execution needs Unix usernames (LDAP format) for the ds01-infra wrapper to correctly apply cgroup placement, GPU quotas, and labels.

## Test plan
- [ ] Auth tests verify `unix_username` returned alongside `username`
- [ ] Schema includes `unix_username NOT NULL` in both tables
- [ ] Config exposes `get_resource_limits_bin` setting
- [ ] All test fixtures updated with `unix_username` column
- [ ] CI passes