### PR TITLE
feat: dual identity CLI, async rate limit fix, jobs propagation

### DIFF
--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -34,6 +34,7 @@ def _hash_key(raw_key: str) -> str:
 
 def _print_key_result(
     username: str,
+    unix_username: str | None,
     raw_key: str,
     key_id: str,
     expires_date: str,
@@ -42,23 +43,23 @@ def _print_key_result(
 ) -> None:
     """Display a key creation/rotation result."""
     if json_output:
-        typer.echo(
-            json.dumps(
-                {
-                    "username": username,
-                    "key": raw_key,
-                    "key_id": key_id,
-                    "expires_at": expires_date,
-                },
-                indent=2,
-            )
-        )
+        data: dict[str, str] = {
+            "username": username,
+            "key": raw_key,
+            "key_id": key_id,
+            "expires_at": expires_date,
+        }
+        if unix_username is not None:
+            data["unix_username"] = unix_username
+        typer.echo(json.dumps(data, indent=2))
     else:
         typer.echo(f"API Key {action} successfully")
         typer.echo("")
         typer.echo(f"Key:     {raw_key}")
         typer.echo("")
-        typer.echo(f"User:    {username}")
+        typer.echo(f"GitHub:  {username}")
+        if unix_username is not None:
+            typer.echo(f"Unix:    {unix_username}")
         typer.echo(f"Expires: {expires_date}")
         typer.echo("")
         typer.echo("Setup instructions (send to researcher):")
@@ -177,9 +178,22 @@ def _get_active_key(conn: sqlite3.Connection, username: str) -> sqlite3.Row | No
     return cursor.fetchone()  # type: ignore[no-any-return]
 
 
+def _validate_unix_user(unix_username: str) -> bool:
+    """Check that the Unix user exists on this server."""
+    result = subprocess.run(
+        ["id", unix_username],
+        capture_output=True,
+        timeout=5,
+    )
+    return result.returncode == 0
+
+
 @app.command("key-create")
 def key_create(
-    username: Annotated[str, typer.Argument(help="GitHub username (must be a member of the org)")],
+    github_username: Annotated[
+        str, typer.Argument(help="GitHub username (must be a member of the org)")
+    ],
+    unix_username: Annotated[str, typer.Argument(help="Unix username on the server")],
     expires: Annotated[
         str, typer.Option(help="Key validity duration (e.g. 90d, 30d, 180d)")
     ] = "90d",
@@ -187,14 +201,20 @@ def key_create(
 ) -> None:
     """Create a new API key for a researcher.
 
-    USERNAME must be the researcher's GitHub username. Org membership is
-    verified via the GitHub API (requires gh CLI or GITHUB_TOKEN).
+    GITHUB_USERNAME must be the researcher's GitHub username. Org membership
+    is verified via the GitHub API (requires gh CLI or GITHUB_TOKEN).
+    UNIX_USERNAME must exist on this server (validated via `id`).
     """
     settings = Settings(_env_file=None)
 
+    # Validate Unix user exists
+    if not _validate_unix_user(unix_username):
+        typer.echo(f"Error: Unix user {unix_username!r} does not exist on this server", err=True)
+        raise typer.Exit(code=1)
+
     # Check GitHub org membership
-    if not check_org_membership(username, settings.github_org):
-        typer.echo(f"Error: {username} is not a member of {settings.github_org}", err=True)
+    if not check_org_membership(github_username, settings.github_org):
+        typer.echo(f"Error: {github_username} is not a member of {settings.github_org}", err=True)
         raise typer.Exit(code=1)
 
     days = parse_duration(expires)
@@ -203,9 +223,9 @@ def key_create(
         _ensure_schema(conn)
 
         # Check for existing active key
-        if _get_active_key(conn, username):
+        if _get_active_key(conn, github_username):
             typer.echo(
-                f"Error: User {username} already has an active key. "
+                f"Error: User {github_username} already has an active key. "
                 "Use key-revoke or key-rotate first.",
                 err=True,
             )
@@ -219,14 +239,28 @@ def key_create(
         expires_dt = now + timedelta(days=days)
 
         conn.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, now.isoformat(), expires_dt.isoformat()),
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                github_username,
+                unix_username,
+                key_id,
+                key_hash,
+                now.isoformat(),
+                expires_dt.isoformat(),
+            ),
         )
         conn.commit()
 
     _print_key_result(
-        username, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "created", json_output
+        github_username,
+        unix_username,
+        raw_key,
+        key_id,
+        expires_dt.strftime("%Y-%m-%d"),
+        "created",
+        json_output,
     )
 
 
@@ -238,7 +272,7 @@ def key_list(
     with get_db_sync() as conn:
         _ensure_schema(conn)
         cursor = conn.execute(
-            "SELECT username, key_id, created_at, expires_at, revoked, last_used_at "
+            "SELECT username, unix_username, key_id, created_at, expires_at, revoked, last_used_at "
             "FROM api_keys ORDER BY created_at DESC"
         )
         rows = cursor.fetchall()
@@ -256,6 +290,7 @@ def key_list(
         keys.append(
             {
                 "username": row["username"],
+                "unix_username": row["unix_username"],
                 "status": status,
                 "created": row["created_at"][:10],
                 "expires": row["expires_at"][:10],
@@ -271,13 +306,14 @@ def key_list(
             return
 
         # Aligned columnar output
-        headers = ["USERNAME", "STATUS", "CREATED", "EXPIRES", "LAST USED"]
+        headers = ["USERNAME", "UNIX USER", "STATUS", "CREATED", "EXPIRES", "LAST USED"]
         col_widths = [
             max(len(headers[0]), *(len(k["username"]) for k in keys)),
-            max(len(headers[1]), *(len(k["status"]) for k in keys)),
-            max(len(headers[2]), *(len(k["created"]) for k in keys)),
-            max(len(headers[3]), *(len(k["expires"]) for k in keys)),
-            max(len(headers[4]), *(len(k["last_used"]) for k in keys)),
+            max(len(headers[1]), *(len(k["unix_username"]) for k in keys)),
+            max(len(headers[2]), *(len(k["status"]) for k in keys)),
+            max(len(headers[3]), *(len(k["created"]) for k in keys)),
+            max(len(headers[4]), *(len(k["expires"]) for k in keys)),
+            max(len(headers[5]), *(len(k["last_used"]) for k in keys)),
         ]
 
         header_line = "  ".join(h.ljust(w) for h, w in zip(headers, col_widths, strict=True))
@@ -286,6 +322,7 @@ def key_list(
         for key in keys:
             vals = [
                 key["username"],
+                key["unix_username"],
                 key["status"],
                 key["created"],
                 key["expires"],
@@ -370,5 +407,5 @@ def key_rotate(
         conn.commit()
 
     _print_key_result(
-        username, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "rotated", json_output
+        username, None, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "rotated", json_output
     )

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -96,6 +96,7 @@ async def submit_job(
     """Submit a new GPU job for execution."""
     settings = _get_settings()
     username = user["username"]
+    unix_username = user["unix_username"]
 
     # 1. URL format validation (cheap, no I/O)
     try:
@@ -120,7 +121,7 @@ async def submit_job(
 
     # 2. Rate limit check (raises 429 on failure)
     concurrent_count, concurrent_limit, daily_count, daily_limit = await check_rate_limits(
-        db, username, settings
+        db, unix_username, username, settings
     )
 
     # 3. SSRF check
@@ -195,12 +196,13 @@ async def submit_job(
     now_iso = datetime.now(UTC).isoformat()
     await db.execute(
         "INSERT INTO jobs "
-        "(id, username, repo_url, branch, gpu_count, job_name, "
+        "(id, username, unix_username, repo_url, branch, gpu_count, job_name, "
         "timeout_seconds, dockerfile_content, status, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             job_id,
             username,
+            unix_username,
             body.repo_url,
             body.branch,
             body.gpu_count,
@@ -403,8 +405,9 @@ async def get_quota(
 ) -> QuotaResponse:
     """Return quota usage and limits for the authenticated user."""
     settings = _get_settings()
-    group, concurrent_limit, daily_limit, max_result_size_mb = get_user_quota_info(
-        user["username"], settings
+    unix_username = user["unix_username"]
+    group, concurrent_limit, daily_limit, max_result_size_mb = await get_user_quota_info(
+        unix_username, settings
     )
     concurrent_used, daily_used = await get_user_job_counts(db, user["username"])
 
@@ -448,7 +451,7 @@ async def download_results(
         )
 
     # Size enforcement
-    _, _, _, max_result_size_mb = get_user_quota_info(user["username"], settings)
+    _, _, _, max_result_size_mb = await get_user_quota_info(user["unix_username"], settings)
     total_size = _get_results_dir_size(results_dir)
     max_size_bytes = max_result_size_mb * 1024 * 1024
     if total_size > max_size_bytes:

--- a/src/ds01_jobs/rate_limit.py
+++ b/src/ds01_jobs/rate_limit.py
@@ -2,8 +2,10 @@
 
 Enforces concurrent and daily job submission limits per user,
 with configurable per-group overrides from resource-limits.yaml.
+Group resolution delegates to get_resource_limits.py via subprocess.
 """
 
+import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -28,48 +30,68 @@ def load_resource_limits(path: Path) -> dict:  # type: ignore[type-arg]
     return data if isinstance(data, dict) else {}
 
 
-def get_user_limits(username: str, settings: Settings) -> tuple[int, int]:
-    """Return (concurrent_limit, daily_limit) for a user.
+async def _get_user_group(unix_username: str, bin_path: Path) -> str:
+    """Get user's resource group from get_resource_limits.py."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "python3",
+            str(bin_path),
+            unix_username,
+            "--group",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        if proc.returncode == 0:
+            return stdout.decode().strip()
+        logger.warning(
+            "get_resource_limits.py --group failed for %s: %s",
+            unix_username,
+            stderr.decode().strip(),
+        )
+    except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
+        logger.warning("get_resource_limits.py --group error for %s: %s", unix_username, exc)
+    return "default"
+
+
+async def get_user_limits(unix_username: str, settings: Settings) -> tuple[int, int]:
+    """Return (concurrent_limit, daily_limit) for a user based on their group.
 
     Precedence (lowest to highest):
     1. Settings defaults
-    2. resource-limits.yaml group limits
+    2. resource-limits.yaml group limits (group resolved via subprocess)
     """
     concurrent = settings.default_concurrent_limit
     daily = settings.default_daily_limit
 
+    group = await _get_user_group(unix_username, settings.get_resource_limits_bin)
+
     data = load_resource_limits(settings.resource_limits_path)
     groups = data.get("groups", {})
-    users = data.get("users", {})
-
-    group_name = users.get(username)
-    if group_name and group_name in groups:
-        group_cfg = groups[group_name]
+    if group in groups:
+        group_cfg = groups[group]
         concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
         daily = group_cfg.get("max_daily_submissions", daily)
 
     return concurrent, daily
 
 
-def get_user_quota_info(username: str, settings: Settings) -> tuple[str, int, int, int]:
+async def get_user_quota_info(unix_username: str, settings: Settings) -> tuple[str, int, int, int]:
     """Return (group_name, concurrent_limit, daily_limit, max_result_size_mb) for a user.
 
-    Reads group membership and limits from resource-limits.yaml,
-    falling back to settings defaults for unmapped users.
+    Group resolution delegates to get_resource_limits.py via subprocess,
+    falling back to 'default' on failure.
     """
     concurrent = settings.default_concurrent_limit
     daily = settings.default_daily_limit
     max_result_mb = settings.default_max_result_size_mb
-    group = "default"
+
+    group = await _get_user_group(unix_username, settings.get_resource_limits_bin)
 
     data = load_resource_limits(settings.resource_limits_path)
     groups = data.get("groups", {})
-    users = data.get("users", {})
-
-    group_name = users.get(username)
-    if group_name and group_name in groups:
-        group = group_name
-        group_cfg = groups[group_name]
+    if group in groups:
+        group_cfg = groups[group]
         concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
         daily = group_cfg.get("max_daily_submissions", daily)
         max_result_mb = group_cfg.get("max_result_size_mb", max_result_mb)
@@ -101,13 +123,19 @@ async def get_user_job_counts(db: aiosqlite.Connection, username: str) -> tuple[
 
 
 async def check_rate_limits(
-    db: aiosqlite.Connection, username: str, settings: Settings
+    db: aiosqlite.Connection, unix_username: str, username: str, settings: Settings
 ) -> tuple[int, int, int, int]:
     """Check both rate limits and raise HTTPException(429) if exceeded.
 
+    Args:
+        db: Database connection.
+        unix_username: Unix username for group resolution.
+        username: GitHub username for DB job count queries.
+        settings: Application settings.
+
     Returns (concurrent_count, concurrent_limit, daily_count, daily_limit) on success.
     """
-    concurrent_limit, daily_limit = get_user_limits(username, settings)
+    concurrent_limit, daily_limit = await get_user_limits(unix_username, settings)
     concurrent_count, daily_count = await get_user_job_counts(db, username)
 
     # Check concurrent limit first

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -61,6 +61,18 @@ def mock_github_non_member(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ds01_jobs.cli.check_org_membership", lambda u, o: False)
 
 
+@pytest.fixture()
+def mock_unix_user_valid(monkeypatch: pytest.MonkeyPatch):
+    """Mock _validate_unix_user to return True."""
+    monkeypatch.setattr("ds01_jobs.cli._validate_unix_user", lambda u: True)
+
+
+@pytest.fixture()
+def mock_unix_user_invalid(monkeypatch: pytest.MonkeyPatch):
+    """Mock _validate_unix_user to return False."""
+    monkeypatch.setattr("ds01_jobs.cli._validate_unix_user", lambda u: False)
+
+
 # --- Token resolution tests ---
 
 
@@ -125,9 +137,9 @@ def test_parse_duration_invalid():
 # --- key-create tests ---
 
 
-def test_key_create_success(tmp_db, mock_github_member):
+def test_key_create_success(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create produces output with ds01_ key, username, and expiry."""
-    result = runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result.exit_code == 0
     assert "ds01_" in result.output
     assert "researcher1" in result.output
@@ -135,48 +147,67 @@ def test_key_create_success(tmp_db, mock_github_member):
     assert "API Key created successfully" in result.output
 
 
-def test_key_create_json(tmp_db, mock_github_member):
-    """key-create --json produces valid JSON with key field."""
-    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+def test_key_create_shows_both_usernames(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-create output shows both GitHub and Unix usernames."""
+    result = runner.invoke(app, ["key-create", "ghuser", "unixuser"])
+    assert result.exit_code == 0
+    assert "GitHub:  ghuser" in result.output
+    assert "Unix:    unixuser" in result.output
+
+
+def test_key_create_json(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-create --json produces valid JSON with key and unix_username fields."""
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert data["key"].startswith("ds01_")
     assert data["username"] == "researcher1"
+    assert data["unix_username"] == "researcher1_unix"
     assert "key_id" in data
     assert "expires_at" in data
 
 
-def test_key_create_non_member(tmp_db, mock_github_non_member):
+def test_key_create_non_member(tmp_db, mock_github_non_member, mock_unix_user_valid):
     """key-create for non-member exits with error."""
-    result = runner.invoke(app, ["key-create", "outsider"])
+    result = runner.invoke(app, ["key-create", "outsider", "outsider_unix"])
     assert result.exit_code == 1
 
 
-def test_key_create_duplicate_active_key(tmp_db, mock_github_member):
+def test_key_create_invalid_unix_user(tmp_db, mock_unix_user_invalid):
+    """key-create with invalid Unix user exits with error code 1."""
+    result = runner.invoke(app, ["key-create", "researcher1", "nonexistent_unix"])
+    assert result.exit_code == 1
+    assert "does not exist" in result.output
+
+
+def test_key_create_duplicate_active_key(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create for user with existing active key exits with error."""
     # Create first key
-    result1 = runner.invoke(app, ["key-create", "researcher1"])
+    result1 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result1.exit_code == 0
 
     # Try to create second key
-    result2 = runner.invoke(app, ["key-create", "researcher1"])
+    result2 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result2.exit_code == 1
 
 
-def test_key_create_after_revoke(tmp_db, mock_github_member):
+def test_key_create_after_revoke(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create succeeds after the previous key is revoked."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
 
-    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert data["username"] == "researcher1"
 
 
-def test_key_create_custom_expires(tmp_db, mock_github_member):
+def test_key_create_custom_expires(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create with --expires 30d sets expiry ~30 days from now."""
-    result = runner.invoke(app, ["key-create", "researcher1", "--expires", "30d", "--json"])
+    result = runner.invoke(
+        app,
+        ["key-create", "researcher1", "researcher1_unix", "--expires", "30d", "--json"],
+    )
     assert result.exit_code == 0
     data = json.loads(result.output)
 
@@ -184,9 +215,9 @@ def test_key_create_custom_expires(tmp_db, mock_github_member):
     assert data["expires_at"] == expected_date
 
 
-def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member):
+def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member, mock_unix_user_valid):
     """Created key hash is valid bcrypt - bcrypt.checkpw returns True."""
-    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     raw_key = data["key"]
@@ -203,9 +234,24 @@ def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member):
     assert bcrypt.checkpw(raw_key.encode(), stored_hash.encode())
 
 
-def test_key_create_setup_instructions(tmp_db, mock_github_member):
+def test_key_create_stores_unix_username(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-create stores unix_username in the database."""
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
+    assert result.exit_code == 0
+
+    conn = sqlite3.connect(tmp_db)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT unix_username FROM api_keys WHERE username = 'researcher1'")
+    row = cursor.fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row["unix_username"] == "researcher1_unix"
+
+
+def test_key_create_setup_instructions(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create output includes setup instructions block."""
-    result = runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result.exit_code == 0
     assert "Setup instructions" in result.output
     assert "pip install ds01-jobs" in result.output
@@ -223,12 +269,13 @@ def test_key_list_empty(tmp_db):
     assert "No API keys found" in result.output
 
 
-def test_key_list_with_keys(tmp_db, mock_github_member):
-    """key-list shows correct columns."""
-    runner.invoke(app, ["key-create", "researcher1"])
+def test_key_list_with_keys(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-list shows correct columns including UNIX USER."""
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-list"])
     assert result.exit_code == 0
     assert "USERNAME" in result.output
+    assert "UNIX USER" in result.output
     assert "STATUS" in result.output
     assert "CREATED" in result.output
     assert "EXPIRES" in result.output
@@ -237,22 +284,23 @@ def test_key_list_with_keys(tmp_db, mock_github_member):
     assert "active" in result.output
 
 
-def test_key_list_json(tmp_db, mock_github_member):
-    """key-list --json produces valid JSON array."""
-    runner.invoke(app, ["key-create", "researcher1"])
+def test_key_list_json(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-list --json produces valid JSON array with unix_username."""
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-list", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["username"] == "researcher1"
+    assert data[0]["unix_username"] == "researcher1_unix"
     assert data[0]["status"] == "active"
 
 
-def test_key_list_shows_status(tmp_db, mock_github_member):
+def test_key_list_shows_status(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-list shows correct status for active, revoked, expired keys."""
     # Create and revoke a key to test revoked status
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
 
     result = runner.invoke(app, ["key-list", "--json"])
@@ -260,10 +308,10 @@ def test_key_list_shows_status(tmp_db, mock_github_member):
     assert data[0]["status"] == "revoked"
 
 
-def test_key_list_shows_expired_status(tmp_db, mock_github_member):
+def test_key_list_shows_expired_status(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-list shows 'expired' for keys past their expiry date."""
     # Create key then manually backdate its expiry
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     conn = sqlite3.connect(tmp_db)
     past_date = (datetime.now(UTC) - timedelta(days=1)).isoformat()
     conn.execute("UPDATE api_keys SET expires_at = ? WHERE username = 'researcher1'", (past_date,))
@@ -278,9 +326,9 @@ def test_key_list_shows_expired_status(tmp_db, mock_github_member):
 # --- key-revoke tests ---
 
 
-def test_key_revoke_with_yes(tmp_db, mock_github_member):
+def test_key_revoke_with_yes(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-revoke --yes revokes without prompt."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
     assert result.exit_code == 0
     assert "Key revoked" in result.output
@@ -292,18 +340,18 @@ def test_key_revoke_nonexistent_user(tmp_db):
     assert result.exit_code == 1
 
 
-def test_revoked_key_shows_in_list(tmp_db, mock_github_member):
+def test_revoked_key_shows_in_list(tmp_db, mock_github_member, mock_unix_user_valid):
     """Revoked key shows as 'revoked' in key-list."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
     result = runner.invoke(app, ["key-list", "--json"])
     data = json.loads(result.output)
     assert data[0]["status"] == "revoked"
 
 
-def test_key_revoke_json(tmp_db, mock_github_member):
+def test_key_revoke_json(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-revoke --json produces valid JSON output."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-revoke", "researcher1", "--yes", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -314,9 +362,9 @@ def test_key_revoke_json(tmp_db, mock_github_member):
 # --- key-rotate tests ---
 
 
-def test_key_rotate_with_yes(tmp_db, mock_github_member):
+def test_key_rotate_with_yes(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-rotate --yes produces a new key."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-rotate", "researcher1", "--yes"])
     assert result.exit_code == 0
     assert "ds01_" in result.output
@@ -329,9 +377,9 @@ def test_key_rotate_no_active_key(tmp_db):
     assert result.exit_code == 1
 
 
-def test_key_rotate_produces_different_key(tmp_db, mock_github_member):
+def test_key_rotate_produces_different_key(tmp_db, mock_github_member, mock_unix_user_valid):
     """Rotated key is different from the original."""
-    result1 = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result1 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     original_key = json.loads(result1.output)["key"]
 
     result2 = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
@@ -341,9 +389,9 @@ def test_key_rotate_produces_different_key(tmp_db, mock_github_member):
     assert new_key.startswith("ds01_")
 
 
-def test_key_rotate_json(tmp_db, mock_github_member):
+def test_key_rotate_json(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-rotate --json produces valid JSON with new key."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -351,9 +399,9 @@ def test_key_rotate_json(tmp_db, mock_github_member):
     assert data["username"] == "researcher1"
 
 
-def test_key_rotate_old_hash_changes(tmp_db, mock_github_member):
+def test_key_rotate_old_hash_changes(tmp_db, mock_github_member, mock_unix_user_valid):
     """After rotation, the stored hash corresponds to the new key."""
-    result1 = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result1 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     original_key = json.loads(result1.output)["key"]
 
     result2 = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -53,6 +53,7 @@ async def _seed_key(
     key_id: str,
     key_hash: str,
     username: str = "testuser",
+    unix_username: str = "testuser_unix",
     expires_at: str | None = None,
 ) -> None:
     """Insert a test API key into the database."""
@@ -66,7 +67,7 @@ async def _seed_key(
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 username,
-                f"{username}_unix",
+                unix_username,
                 key_id,
                 key_hash,
                 datetime.now(UTC).isoformat(),
@@ -87,11 +88,12 @@ async def _insert_job(
     now = created_at or datetime.now(UTC).isoformat()
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
-            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 str(uuid.uuid4()),
                 username,
+                "testuser_unix",
                 "https://github.com/test/repo",
                 "main",
                 1,
@@ -137,10 +139,11 @@ def _build_headers(raw_key: str, body_dict: dict) -> dict[str, str]:  # type: ig
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_success(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Valid auth + valid repo_url returns 202 with job record in DB."""
     db_path = tmp_path / "test.db"
@@ -199,10 +202,11 @@ async def test_submit_job_invalid_url(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_with_dockerfile_scan_error(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Dockerfile with blocked base image returns 422 with dockerfile_scan_error."""
     db_path = tmp_path / "test.db"
@@ -230,10 +234,11 @@ async def test_submit_job_with_dockerfile_scan_error(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_with_clean_dockerfile(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Valid Dockerfile returns 202 (scan passes)."""
     db_path = tmp_path / "test.db"
@@ -257,10 +262,11 @@ async def test_submit_job_with_clean_dockerfile(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_concurrent_limit_exceeded(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """User at concurrent limit gets 429 with limit_type='concurrent'."""
     db_path = tmp_path / "test.db"
@@ -287,10 +293,11 @@ async def test_submit_job_concurrent_limit_exceeded(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_daily_limit_exceeded(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """User at daily limit gets 429 with limit_type='daily'."""
     db_path = tmp_path / "test.db"
@@ -317,10 +324,11 @@ async def test_submit_job_daily_limit_exceeded(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_rate_limit_headers_on_success(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Successful 202 includes X-RateLimit-* headers."""
     db_path = tmp_path / "test.db"
@@ -346,10 +354,11 @@ async def test_submit_job_rate_limit_headers_on_success(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_auto_generated_job_name(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Omitting job_name auto-generates from repo name + short ID."""
     db_path = tmp_path / "test.db"
@@ -399,8 +408,11 @@ async def test_submit_job_unauthenticated(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
-async def test_submit_job_repo_not_found(mock_ssrf: AsyncMock, tmp_path: Path) -> None:
+async def test_submit_job_repo_not_found(
+    mock_ssrf: AsyncMock, mock_group: AsyncMock, tmp_path: Path
+) -> None:
     """verify_repo_accessible raising ValueError returns 422 with repo_not_found."""
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import aiosqlite
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from ds01_jobs.config import Settings
 from ds01_jobs.database import init_db
 from ds01_jobs.rate_limit import (
+    _get_user_group,
     check_rate_limits,
     get_user_job_counts,
     get_user_limits,
@@ -32,11 +34,12 @@ async def _insert_job(
 
     now = created_at or datetime.now(UTC).isoformat()
     await db.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
-        "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, job_name, "
+        "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             str(uuid.uuid4()),
             username,
+            "testuser_unix",
             "https://github.com/test/repo",
             "main",
             1,
@@ -53,14 +56,17 @@ async def _insert_job(
 async def test_get_user_limits_defaults() -> None:
     """No resource-limits.yaml returns settings defaults (3, 10)."""
     settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
-    concurrent, daily = get_user_limits("someuser", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+    ):
+        concurrent, daily = await get_user_limits("someuser", settings)
     assert concurrent == 3
     assert daily == 10
 
 
 @pytest.mark.asyncio
-async def test_get_user_limits_from_yaml(tmp_path: Path) -> None:
-    """User mapped to student group gets group limits (2, 5)."""
+async def test_get_user_limits_from_group(tmp_path: Path) -> None:
+    """User resolved to student group gets group limits (2, 5)."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
         "groups:\n"
@@ -70,36 +76,74 @@ async def test_get_user_limits_from_yaml(tmp_path: Path) -> None:
         "  researcher:\n"
         "    max_concurrent_jobs: 5\n"
         "    max_daily_submissions: 20\n"
-        "users:\n"
-        "  alice: researcher\n"
-        "  bob: student\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    concurrent, daily = get_user_limits("bob", settings)
+
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="student"
+    ):
+        concurrent, daily = await get_user_limits("bob_unix", settings)
     assert concurrent == 2
     assert daily == 5
 
-    concurrent, daily = get_user_limits("alice", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="researcher"
+    ):
+        concurrent, daily = await get_user_limits("alice_unix", settings)
     assert concurrent == 5
     assert daily == 20
 
 
 @pytest.mark.asyncio
-async def test_get_user_limits_user_not_in_yaml(tmp_path: Path) -> None:
-    """User not listed in YAML users section falls back to defaults."""
+async def test_get_user_limits_unknown_group(tmp_path: Path) -> None:
+    """User with group not in YAML falls back to defaults."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
-        "groups:\n"
-        "  student:\n"
-        "    max_concurrent_jobs: 2\n"
-        "    max_daily_submissions: 5\n"
-        "users:\n"
-        "  bob: student\n"
+        "groups:\n  student:\n    max_concurrent_jobs: 2\n    max_daily_submissions: 5\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    concurrent, daily = get_user_limits("unknown_user", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+    ):
+        concurrent, daily = await get_user_limits("unknown_unix", settings)
     assert concurrent == 3
     assert daily == 10
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_success() -> None:
+    """_get_user_group returns group from subprocess stdout."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (b"student\n", b"")
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+        group = await _get_user_group("testuser", Path("/some/bin.py"))
+    assert group == "student"
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_fallback_on_failure() -> None:
+    """_get_user_group returns 'default' when subprocess fails."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (b"", b"error\n")
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+        group = await _get_user_group("testuser", Path("/some/bin.py"))
+    assert group == "default"
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_fallback_on_file_not_found() -> None:
+    """_get_user_group returns 'default' when binary not found."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        side_effect=FileNotFoundError("no such file"),
+    ):
+        group = await _get_user_group("testuser", Path("/nonexistent/bin.py"))
+    assert group == "default"
 
 
 @pytest.mark.asyncio
@@ -167,7 +211,10 @@ async def test_check_rate_limits_passes(tmp_path: Path) -> None:
 
     async with aiosqlite.connect(db_path) as db:
         await _insert_job(db, status="queued")
-        result = await check_rate_limits(db, "testuser", settings)
+        with patch(
+            "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+        ):
+            result = await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     concurrent_count, concurrent_limit, daily_count, daily_limit = result
     assert concurrent_count == 1
@@ -192,7 +239,12 @@ async def test_check_rate_limits_concurrent_exceeded(tmp_path: Path) -> None:
         await _insert_job(db, status="running")
 
         with pytest.raises(Exception) as exc_info:
-            await check_rate_limits(db, "testuser", settings)
+            with patch(
+                "ds01_jobs.rate_limit._get_user_group",
+                new_callable=AsyncMock,
+                return_value="default",
+            ):
+                await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     exc = exc_info.value
     assert exc.status_code == 429  # type: ignore[union-attr]
@@ -220,7 +272,12 @@ async def test_check_rate_limits_daily_exceeded(tmp_path: Path) -> None:
         await _insert_job(db, status="succeeded")
 
         with pytest.raises(Exception) as exc_info:
-            await check_rate_limits(db, "testuser", settings)
+            with patch(
+                "ds01_jobs.rate_limit._get_user_group",
+                new_callable=AsyncMock,
+                return_value="default",
+            ):
+                await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     exc = exc_info.value
     assert exc.status_code == 429  # type: ignore[union-attr]
@@ -247,7 +304,12 @@ async def test_rate_limit_429_body_structure(tmp_path: Path) -> None:
         await _insert_job(db, status="queued")
 
         with pytest.raises(Exception) as exc_info:
-            await check_rate_limits(db, "testuser", settings)
+            with patch(
+                "ds01_jobs.rate_limit._get_user_group",
+                new_callable=AsyncMock,
+                return_value="default",
+            ):
+                await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     exc = exc_info.value
     body = exc.detail  # type: ignore[union-attr]
@@ -266,18 +328,23 @@ async def test_rate_limit_429_body_structure(tmp_path: Path) -> None:
 # --- get_user_quota_info tests ---
 
 
-def test_get_user_quota_info_defaults() -> None:
+@pytest.mark.asyncio
+async def test_get_user_quota_info_defaults() -> None:
     """No YAML file returns default group and settings defaults."""
     settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
-    group, concurrent, daily, max_result_mb = get_user_quota_info("someuser", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+    ):
+        group, concurrent, daily, max_result_mb = await get_user_quota_info("someuser", settings)
     assert group == "default"
     assert concurrent == 3
     assert daily == 10
     assert max_result_mb == 1024
 
 
-def test_get_user_quota_info_from_yaml(tmp_path: Path) -> None:
-    """User mapped to student group with max_result_size_mb returns group values."""
+@pytest.mark.asyncio
+async def test_get_user_quota_info_from_group(tmp_path: Path) -> None:
+    """User resolved to student group with max_result_size_mb returns group values."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
         "groups:\n"
@@ -285,30 +352,30 @@ def test_get_user_quota_info_from_yaml(tmp_path: Path) -> None:
         "    max_concurrent_jobs: 2\n"
         "    max_daily_submissions: 5\n"
         "    max_result_size_mb: 512\n"
-        "users:\n"
-        "  bob: student\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    group, concurrent, daily, max_result_mb = get_user_quota_info("bob", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="student"
+    ):
+        group, concurrent, daily, max_result_mb = await get_user_quota_info("bob_unix", settings)
     assert group == "student"
     assert concurrent == 2
     assert daily == 5
     assert max_result_mb == 512
 
 
-def test_get_user_quota_info_no_result_size_in_yaml(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_get_user_quota_info_no_result_size_in_yaml(tmp_path: Path) -> None:
     """Group without max_result_size_mb falls back to settings default."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
-        "groups:\n"
-        "  researcher:\n"
-        "    max_concurrent_jobs: 5\n"
-        "    max_daily_submissions: 20\n"
-        "users:\n"
-        "  alice: researcher\n"
+        "groups:\n  researcher:\n    max_concurrent_jobs: 5\n    max_daily_submissions: 20\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    group, concurrent, daily, max_result_mb = get_user_quota_info("alice", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="researcher"
+    ):
+        group, concurrent, daily, max_result_mb = await get_user_quota_info("alice_unix", settings)
     assert group == "researcher"
     assert concurrent == 5
     assert daily == 20

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import aiosqlite
 import bcrypt
@@ -555,7 +555,8 @@ async def test_list_jobs_empty(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_quota_defaults(tmp_path: Path) -> None:
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
+async def test_get_quota_defaults(mock_group: AsyncMock, tmp_path: Path) -> None:
     """Without resource-limits.yaml, quota returns defaults."""
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
@@ -581,7 +582,8 @@ async def test_get_quota_defaults(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_quota_with_active_jobs(tmp_path: Path) -> None:
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
+async def test_get_quota_with_active_jobs(mock_group: AsyncMock, tmp_path: Path) -> None:
     """Active jobs are reflected in concurrent.used."""
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
@@ -606,7 +608,8 @@ async def test_get_quota_with_active_jobs(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_quota_other_user_isolation(tmp_path: Path) -> None:
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
+async def test_get_quota_other_user_isolation(mock_group: AsyncMock, tmp_path: Path) -> None:
     """Other user's jobs do not affect testuser's quota."""
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)


### PR DESCRIPTION
## Summary
- `key-create` takes both `github_username` and `unix_username` as mandatory args; validates Unix user exists via `id`
- Rate limiter group resolution delegates to `get_resource_limits.py --group` via async subprocess (fixes broken `users:` YAML lookup)
- `jobs.py` stores `unix_username` at submission time; rate limiting uses `unix_username` for group resolution

**Part 2 of 3** for ds01-infra container integration. Stacked on #42.

## Context
The rate limiter was looking up groups from a nonexistent `users:` section in resource-limits.yaml — all users fell through to defaults. Now delegates to ds01-infra's `get_resource_limits.py` parser for correct group resolution.

## Test plan
- [ ] `key-create` requires both positional args, rejects invalid Unix users
- [ ] Rate limit tests mock subprocess and verify group resolution
- [ ] Jobs tests verify `unix_username` stored and used for rate limiting
- [ ] CI passes