### PR TITLE
feat: executor sudo-u, resource limits, and runner propagation

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,180 @@
+# Roadmap: ds01-jobs — v0.1.0
+
+## Overview
+
+Seven phases take ds01-jobs from empty repository to a deployed GPU job submission service with usable clients (v0.1.0). Foundation establishes the package structure and CI pipelines that every subsequent phase depends on. Authentication and the job submission API are built as the API gateway. The job runner — the highest-risk component — gets its own phase with full operational hardening. Status and result retrieval complete the server-side workflow. A CLI client and GitHub Action make the API accessible to researchers (tested against a local dev server). Finally, production deployment wires the three systemd services and Cloudflare Tunnel into a live service.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [x] **Phase 1: Foundation** - Package layout, uv, pre-commit, CI pipelines (Tier 1 + Tier 2), config
+- [x] **Phase 2: Authentication** - HMAC auth, API key lifecycle, admin CLI, health endpoint, global rate limit
+- [x] **Phase 3: Job Submission** - Submission endpoint, Dockerfile scanning, per-user rate limiting
+- [x] **Phase 4: Job Runner** - Polling runner, job lifecycle execution, GPU slot management, operational hardening
+- [x] **Phase 5: Status and Results** - Job status polling, log retrieval, result download, quota endpoint
+- [x] **Phase 6: Clients** - ds01-submit CLI tool, GitHub Action in action/ subdirectory (tested against local dev server)
+- [ ] **Phase 7: Deployment** - deploy.sh, systemd units, Cloudflare Tunnel service, pre-deploy safety check
+
+## Phase Details
+
+### Phase 1: Foundation
+**Goal**: The project skeleton is fully operational — importable package, enforced code quality, and both CI tiers passing before any feature code is written
+**Depends on**: Nothing (first phase)
+**Requirements**: FOUND-01, FOUND-02, FOUND-03, FOUND-04, FOUND-05, FOUND-06, NET-01
+**Success Criteria** (what must be TRUE):
+  1. `import ds01_jobs` succeeds in a clean venv created by `uv sync`
+  2. `ruff check` and `mypy` pass with zero errors on an empty-but-typed package skeleton
+  3. A PR to main triggers Tier 1 CI (lint, type check, unit tests) on a GitHub-hosted runner and goes green
+  4. A push to main triggers Tier 2 CI (integration tests) on the self-hosted GPU runner and goes green
+  5. Configuration values (DB path, API host/port, resource-limits.yaml path) are readable from environment variables via Pydantic Settings
+**Plans**: 2 plans
+Plans:
+- [x] 01-01-PLAN.md — Package skeleton, pyproject.toml, Pydantic Settings, test suite
+- [x] 01-02-PLAN.md — Pre-commit verification, CI workflows (Tier 1 + Tier 2)
+
+### Phase 2: Authentication
+**Goal**: Users can authenticate via signed API keys, and admins can provision and revoke those keys via a CLI
+**Depends on**: Phase 1
+**Requirements**: AUTH-01, AUTH-02, AUTH-03, AUTH-04, AUTH-05, AUTH-06, AUTH-07, NET-03, RATE-05
+**Success Criteria** (what must be TRUE):
+  1. A signed request with a valid API key passes authentication; an unsigned or tampered request returns 401
+  2. A replayed request (duplicate nonce within 5 minutes) is rejected with 401
+  3. A request made with an API key within 14 days of expiry receives the `X-DS01-Key-Expiry-Warning` header
+  4. `ds01-job-admin key-create <username>` prints the raw key once and stores only the bcrypt hash
+  5. `ds01-job-admin key-revoke <username>` causes that key to be rejected on subsequent requests
+  6. `GET /health` returns `{status, version}` with no authentication required
+  7. The global rate limiter returns 429 after 60 requests per minute from the same API key
+**Plans**: 3 plans
+Plans:
+- [x] 02-01-PLAN.md — Database layer, response models, config extensions, dependency updates
+- [x] 02-02-PLAN.md — HMAC auth dependency, health endpoint, rate limiter, app factory
+- [x] 02-03-PLAN.md — Admin CLI (key-create, key-list, key-revoke, key-rotate)
+
+### Phase 3: Job Submission
+**Goal**: Authenticated users can submit GPU jobs, with Dockerfile scanning and rate limit enforcement before any job reaches the queue
+**Depends on**: Phase 2
+**Requirements**: JOB-01, JOB-02, JOB-03, JOB-04, JOB-05, SCAN-01, SCAN-02, SCAN-03, SCAN-04, SCAN-05, RATE-01, RATE-02, RATE-03, RATE-04
+**Success Criteria** (what must be TRUE):
+  1. `POST /api/v1/jobs` with a valid repo URL and Dockerfile returns `{job_id, status: "queued", status_url}` immediately
+  2. A submission with a non-GitHub URL (or a private IP) is rejected with a structured 422 before any network request is made
+  3. A Dockerfile containing a disallowed base image or `ENV LD_PRELOAD` is rejected with a structured error showing line number, directive, and reason
+  4. A user who has reached their concurrent job limit receives a 429 with `retry_after_seconds`, `limit_type`, `current_count`, and `max_allowed`
+  5. Rate limits for a user reflect their group membership as defined in `resource-limits.yaml`
+**Plans**: 2 plans
+Plans:
+- [x] 03-01-PLAN.md — Contracts, Dockerfile scanner, URL validation (models, config, schema, scanner.py, url_validation.py)
+- [x] 03-02-PLAN.md — Per-user rate limiter, jobs router, app wiring (rate_limit.py, jobs.py, endpoint tests)
+
+### Phase 4: Job Runner
+**Goal**: Queued jobs execute reliably through the full Docker lifecycle, with the runner surviving restarts and shutdowns without leaving orphaned containers or stuck job states
+**Depends on**: Phase 3
+**Requirements**: RUN-01, RUN-02, RUN-03, RUN-04, RUN-05, RUN-06, RUN-07, RUN-08, RUN-09, RUN-10, RUN-11
+**Success Criteria** (what must be TRUE):
+  1. A queued job progresses through `queued → cloning → building → running → succeeded` with each transition committed to SQLite before the corresponding subprocess starts
+  2. A job that exceeds its build timeout (15 min) or run timeout is killed via process group and transitions to `failed`
+  3. Killing and restarting the runner marks any in-progress jobs as `failed` rather than leaving them stuck in `running`
+  4. SIGTERM causes the runner to stop accepting new jobs and exit cleanly after draining
+  5. A `POST /api/v1/jobs/{id}/cancel` on a running job kills the process group and transitions status to `failed`
+  6. All docker commands are invoked via `/usr/local/bin/docker` (the DS01 wrapper), never the real Docker binary
+**Plans**: 3 plans
+Plans:
+- [x] 04-01-PLAN.md — Database schema extensions, runner config, GPU availability module
+- [x] 04-02-PLAN.md — Job executor (clone/build/run subprocess pipeline, timeouts, cleanup)
+- [x] 04-03-PLAN.md — Runner poll loop, signal handling, startup recovery, cancel endpoint
+
+### Phase 5: Status and Results
+**Goal**: Users can observe job progress, retrieve logs for debugging, download result files, and check their remaining quota
+**Depends on**: Phase 4
+**Requirements**: STAT-01, STAT-02, STAT-03, STAT-04
+**Success Criteria** (what must be TRUE):
+  1. `GET /api/v1/jobs/{id}` returns current status, per-phase timestamps, and a human-readable error message on failure
+  2. `GET /api/v1/jobs/{id}/logs` returns captured stdout/stderr for each completed phase (clone, build, run)
+  3. `GET /api/v1/jobs/{id}/results` delivers the job's output files as a downloadable artifact
+  4. `GET /api/v1/users/me/quota` returns the user's current concurrent job count, daily count, and configured limits
+**Plans**: 3 plans
+Plans:
+- [x] 05-01-PLAN.md — Schema extension, config, response models, helpers, executor phase timestamps
+- [x] 05-02-PLAN.md — Status, logs, listing, and quota endpoints
+- [x] 05-03-PLAN.md — Results download endpoint with tar.gz streaming
+
+### Phase 05.1: API integration tests (INSERTED)
+
+**Goal**: The server-side API surface is verified end-to-end via Tier 1 integration tests that exercise real wiring between auth, submission, status, logs, cancel, quota, and results — catching integration bugs before clients are built on top
+**Depends on**: Phase 5
+**Requirements**: INT-LIFECYCLE, INT-AUTH, INT-RATE, INT-CI
+**Success Criteria** (what must be TRUE):
+  1. Integration tests exercise the full API round-trip: create key → submit job → check status → list jobs → check quota → cancel, using the real FastAPI app and SQLite
+  2. Auth integration: signed requests succeed, unsigned/tampered/expired requests fail, nonce replay is rejected
+  3. Rate limiting integration: submitting past configured limits returns 429 with correct headers
+  4. All integration tests run in Tier 1 CI (no Docker/GPU required) and pass
+**Plans**: 1 plan
+Plans:
+- [x] 05.1-01-PLAN.md — Shared integration fixtures and API round-trip test suite
+
+### Phase 6: Clients
+**Goal**: Researchers can submit jobs, check status, and retrieve results without constructing HMAC-signed requests by hand — via either a CLI tool or a GitHub Action (tested against local dev server)
+**Depends on**: Phase 5.1
+**Requirements**: CLI-01, CLI-02, GHA-01, GHA-02
+**Success Criteria** (what must be TRUE):
+  1. `ds01-submit run https://github.com/user/repo --gpus 1` submits a job and prints the job ID and status URL
+  2. `ds01-submit status <job-id>` shows current job status and phase timestamps
+  3. `ds01-submit results <job-id> -o ./output/` downloads result files to the local directory
+  4. The CLI reads the API key from `~/.config/ds01/credentials` or `DS01_API_KEY` env var and handles all HMAC signing transparently
+  5. The GitHub Action (`uses: hertie-data-science-lab/ds01-jobs/action@v0.1.0`) submits a job from a CI workflow and commits results back to the triggering repo
+  6. Integration tests for CLI commands (submit, status, results) against a local dev server are added to the Tier 1 integration test suite
+**Plans**: 2 plans
+Plans:
+- [x] 06-01-PLAN.md — Signing HTTP client, ds01-submit CLI (configure, run, status, results, list, cancel), unit tests
+- [x] 06-02-PLAN.md — GitHub Action (composite action + entrypoint), CLI integration tests, admin CLI instruction update
+
+### Phase 06.1: ds01-infra container integration (INSERTED)
+
+**Goal**: Job containers launched by ds01-jobs are fully integrated with the ds01-infra ecosystem — using `sudo -u {unix_username}` so the Docker wrapper automatically handles labels, cgroup, GPU allocation, and event logging identically to containers launched via ds01-infra's own tools
+**Depends on**: Phase 6
+**Requirements**: INFRA-IDENTITY, INFRA-SUDO, INFRA-LIMITS, INFRA-EVENTS, INFRA-RATELIMIT-FIX
+**Success Criteria** (what must be TRUE):
+  1. API keys store both `github_username` (display/auth) and `unix_username` (server identity) as mandatory fields; `key-create` validates the Unix user exists on the server
+  2. All docker commands (build, run, rm) execute via `sudo -u {unix_username}` so the Docker wrapper sees the correct user identity
+  3. `docker inspect` on a ds01-jobs container shows correct `ds01.*` labels (`ds01.user={unix_username}`, `ds01.managed=true`, GPU labels) — all injected automatically by the wrapper
+  4. Per-container resource limits (`--memory`, `--shm-size`, `--pids-limit`) are read from `get_resource_limits.py {unix_username}` and passed to docker run
+  5. `container-owner-tracker` daemon correctly identifies ds01-jobs containers and attributes them to the submitting Unix user
+  6. Rate limiting group resolution delegates to `get_resource_limits.py` instead of the broken `users:` section lookup in resource-limits.yaml
+**Plans**: 2 plans
+
+Plans:
+- [ ] 06.1-01-PLAN.md — Database dual identity, auth, CLI key-create, rate limit fix, config (INFRA-IDENTITY, INFRA-RATELIMIT-FIX)
+- [ ] 06.1-02-PLAN.md — Executor sudo -u, resource limits, interface label, runner propagation (INFRA-SUDO, INFRA-LIMITS, INFRA-EVENTS)
+
+### Phase 7: Deployment
+**Goal**: The complete service — API server, job runner, and Cloudflare Tunnel — can be installed and upgraded on the production server with a single script and zero manual steps
+**Depends on**: Phase 6.1
+**Requirements**: DEP-01, DEP-02, DEP-03, DEP-04, DEP-05, NET-02
+**Success Criteria** (what must be TRUE):
+  1. Running `deploy.sh` on the server creates the venv, installs deps via `uv sync`, copies systemd units, and symlinks the admin CLI — with no manual steps after
+  2. `ds01-api.service`, `ds01-runner.service`, and `ds01-cloudflared.service` all start, pass health checks, and survive a server reboot
+  3. `ds01-cloudflared.service` lists `ds01-api.service` as a dependency and only starts after the API is healthy
+  4. Running `deploy.sh` while jobs are active prints a warning and requires confirmation before proceeding
+  5. The API is reachable from an off-campus network via the Cloudflare Tunnel URL without VPN
+  6. Tier 2 integration tests exercise full job lifecycle on the self-hosted GPU runner (submit → clone → build → run → succeed → download results) and are added to the existing integration test suite
+**Plans**: TBD
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 5.1 → 6 → 7
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Foundation | 2/2 | Complete | 2026-03-05 |
+| 2. Authentication | 3/3 | Complete | 2026-03-06 |
+| 3. Job Submission | 2/2 | Complete | 2026-03-06 |
+| 4. Job Runner | 3/3 | Complete | 2026-03-07 |
+| 5. Status and Results | 3/3 | Complete | 2026-03-07 |
+| 5.1 API Integration Tests | 1/1 | Complete | 2026-03-08 |
+| 6. Clients | 2/2 | Complete | 2026-03-10 |
+| 7. Deployment | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,124 @@
+---
+gsd_state_version: 1.0
+milestone: v0.1
+milestone_name: milestone
+status: executing
+last_updated: "2026-03-11T11:51:54Z"
+progress:
+  total_phases: 8
+  completed_phases: 6
+  total_plans: 17
+  completed_plans: 16
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-03-04)
+
+**Core value:** Researchers can submit GPU jobs remotely and get results back without direct server access.
+**Current focus:** Phase 06.1 — ds01-infra container integration
+
+## Current Position
+
+Phase: 06.1 (ds01-infra-container-integration) - IN PROGRESS
+Plan: 2 of 2 in current phase
+Status: Plan 01 complete, Plan 02 next
+Last activity: 2026-03-11 — Completed 06.1-01 (dual identity + rate limit fix)
+
+Progress: [████████░░] 94%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 15
+- Average duration: 3min
+- Total execution time: 51min
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| 01-foundation | 2 | 4min | 2min |
+| 02-authentication | 3 | 12min | 4min |
+| 03-job-submission | 1 | 4min | 4min |
+| 04-job-runner | 3 | 9min | 3min |
+| 05-status-and-results | 2 | 6min | 3min |
+| 05.1-api-integration-tests | 1 | 4min | 4min |
+| 06-clients | 2 | 7min | 3.5min |
+| 06.1-ds01-infra | 1/2 | 8min | 8min |
+
+**Recent Trend:**
+- Last 5 plans: 05.1-01 (4min), 06-01 (5min), 06-02 (2min), 06.1-01 (8min)
+- Trend: stable
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- mypy scoped to src/ds01_jobs/ — brownfield files at src/ level have pre-existing errors (out of scope)
+- Settings uses _env_file=None in tests for isolation from .env files
+- Ruff excludes brownfield src/ files — consistent with mypy scoping
+- CI mypy scoped to src/ds01_jobs/ — brownfield files out of scope
+- Tier 2 handles pytest exit code 5 (no tests collected) as success
+- Result delivery: server stores output files, serves via API endpoint. CLI and GitHub Action handle retrieval client-side.
+- Clients (Phase 6) before Deployment (Phase 7): build CLI + Action against local dev server, validate end-to-end before production deploy.
+- CLI client (`ds01-submit`) and GitHub Action both in v0.1.0 scope (Phase 6). CLI handles HMAC signing. Action lives in action/ subdirectory — extract to ds01-actions when org has 3+ actions.
+- Runner is separate systemd service with `KillMode=process` (not control-group) — preserves Docker containers for startup recovery.
+- GPU availability: runner checks real GPU state (nvidia-smi / allocator), not internal SUM query. Retries on rejection.
+- Auth: GitHub org membership (hertie-data-science-lab) verified at key creation time, not on every request. Admin roles deferred to v0.2.0+.
+- Phase 4 (runner) is highest-risk phase — needs its own phase-level research pass before implementation.
+- Database functions accept optional db_path param for testability, defaulting to Settings
+- Async/sync database split: aiosqlite for FastAPI handlers, sqlite3 for Typer CLI commands
+- Nonce cache is in-memory dict with monotonic clock TTL - cleared on restart
+- bcrypt.checkpw runs via asyncio.to_thread to avoid blocking event loop
+- All auth failures return generic 401 - specific reasons logged server-side
+- Rate limiter keyed by key_id from Bearer token, falls back to client IP
+- key-rotate uses UPDATE approach (overwrites existing row) for simplicity - single-key-per-user means no history needed
+- Added @contextmanager decorator to get_db_sync for proper with-statement usage
+- Non-greedy regex for repo name to correctly strip .git suffix in URL validation
+- Unresolved build args in FROM produce info-level violation, not error
+- [Phase 04-job-runner]: GPU idle threshold set at 100 MiB - GPUs below this are considered available
+- [Phase 04-job-runner]: nvidia-smi query uses asyncio.create_subprocess_exec - output is small so PIPE is fine
+- [Phase 04-job-runner]: Cancel endpoint uses DB status update only - runner detects on next poll cycle (up to 5s latency)
+- [Phase 04-job-runner]: Completed task cleanup happens synchronously in poll loop, not via task callbacks
+- [Phase 05-status-and-results]: queued phase started_at uses job created_at timestamp for accurate queue time measurement
+- [Phase 05-status-and-results]: Phase timestamps stored as JSON dict with started_at/ended_at per phase
+- [Phase 05-status-and-results]: Used unittest.mock.patch for _get_settings override in tests since it is called directly (not via Depends)
+- [Phase 05]: Used unittest.mock.patch for _get_settings in log tests since lru_cache prevents FastAPI dependency_overrides
+- [Phase 05.1]: Used pytest_asyncio.fixture for async fixtures - required for pytest-asyncio strict mode with pytest 9.x
+- [Phase 06-clients]: HMAC signing in client.py mirrors auth.py _build_canonical exactly - JSON body serialised to bytes before signing
+- [Phase 06-clients]: Exponential backoff for --follow polling: 2s, 4s, 8s, 16s, 30s cap
+- [Phase 06-clients]: Exit code 2 for failed jobs (0 for success, 1 for errors)
+- [Phase 06-clients]: sign_headers strips query params before signing - server uses request.url.path (path only)
+- [Phase 06-clients]: SyncASGITransport bridges sync httpx.Client to ASGI app for CLI integration tests
+- [Phase 06-clients]: GitHub Action entrypoint uses argparse (not Typer) - lightweight for CI
+- [Phase 06.1]: Dual identity model - github_username (display/auth) + unix_username (Docker execution) propagated from api_keys through auth, jobs, rate_limit
+- [Phase 06.1]: Rate limit group resolution via async subprocess to get_resource_limits.py --group (replaces broken users: YAML lookup)
+- [Phase 06.1]: check_rate_limits takes both unix_username (group resolution) and username (DB job count queries)
+
+### Roadmap Evolution
+
+- Phase 05.1 inserted after Phase 05: API integration tests (URGENT) — Tier 1 round-trip tests for complete server-side API surface before building clients
+- Phase 06.1 inserted after Phase 06: ds01-infra container integration (URGENT) — Docker labels, GPU allocator integration, cgroup placement, resource limits, event logging to align ds01-jobs containers with ds01-infra ecosystem
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- Max job duration per group: confirm whether resource-limits.yaml defines `max_duration_minutes` per group before runner implementation.
+- Shallow clone assumption: confirm whether `--recurse-submodules` is needed for primary users.
+- Docker wrapper path (`/usr/local/bin/docker`): confirm correct on production server before runner executor code.
+- GPU availability check mechanism: confirm whether nvidia-smi parsing or allocator state file is the better approach during Phase 4 research.
+
+## Session Continuity
+
+Last session: 2026-03-11
+Stopped at: Completed 06.1-01-PLAN.md
+Resume file: None

--- a/.planning/phases/06.1-ds01-infra-container-integration/06.1-01-SUMMARY.md
+++ b/.planning/phases/06.1-ds01-infra-container-integration/06.1-01-SUMMARY.md
@@ -1,0 +1,146 @@
+---
+phase: 06.1-ds01-infra-container-integration
+plan: 01
+subsystem: auth, database, api, cli
+tags: [sqlite, asyncio, subprocess, dual-identity, rate-limiting]
+
+requires:
+  - phase: 05-api-rate-limiting
+    provides: rate_limit.py with check_rate_limits and get_user_limits
+provides:
+  - unix_username column in api_keys and jobs tables
+  - auth returns both username and unix_username
+  - key-create takes github_username + unix_username with Unix user validation
+  - async rate limit group resolution via get_resource_limits.py subprocess
+  - jobs table stores unix_username at creation time
+affects: [06.1-02-executor-sudo, runner, executor]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Async subprocess for external tool delegation (get_resource_limits.py)"
+    - "Dual identity model: github_username (display/auth) + unix_username (execution)"
+
+key-files:
+  created: []
+  modified:
+    - src/ds01_jobs/database.py
+    - src/ds01_jobs/config.py
+    - src/ds01_jobs/auth.py
+    - src/ds01_jobs/cli.py
+    - src/ds01_jobs/jobs.py
+    - src/ds01_jobs/rate_limit.py
+    - tests/unit/test_auth.py
+    - tests/unit/test_cli.py
+    - tests/unit/test_jobs.py
+    - tests/unit/test_rate_limit.py
+
+key-decisions:
+  - "get_user_limits and get_user_quota_info made async to support subprocess group resolution"
+  - "check_rate_limits takes both unix_username (for group) and username (for DB queries)"
+  - "_print_key_result accepts optional unix_username for backward compat with key-rotate"
+  - "Default group is 'default' (not 'student') when subprocess fails"
+
+patterns-established:
+  - "Async subprocess delegation: _get_user_group calls get_resource_limits.py via asyncio.create_subprocess_exec with 5s timeout"
+  - "Dual identity propagation: api_keys -> auth -> jobs -> rate_limit"
+
+requirements-completed: [INFRA-IDENTITY, INFRA-RATELIMIT-FIX]
+
+duration: 8min
+completed: 2026-03-11
+---
+
+# Phase 06.1 Plan 01: Dual Identity and Rate Limit Fix Summary
+
+**Dual identity model (github_username + unix_username) across database, auth, CLI, and jobs layers; async subprocess-based rate limit group resolution replacing broken YAML users: lookup**
+
+## Performance
+
+- **Duration:** 8 min
+- **Started:** 2026-03-11T11:43:43Z
+- **Completed:** 2026-03-11T11:51:54Z
+- **Tasks:** 2
+- **Files modified:** 10
+
+## Accomplishments
+
+- Added unix_username column to api_keys (NOT NULL) and jobs (NOT NULL DEFAULT '') tables
+- Auth dependency returns both username and unix_username from API key record
+- key-create now takes two positional args (github_username, unix_username) and validates Unix user exists via `id` command
+- Replaced broken `data.get("users", {})` YAML lookup with async subprocess call to `get_resource_limits.py --group`
+- Jobs table stores unix_username from auth context at creation time
+- All rate limit and quota functions now use unix_username for group resolution
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Database schema, config, and auth layer changes** - `ec50f83` (feat)
+2. **Task 2: CLI key-create, rate limit fix, and jobs propagation** - `0300617` (feat)
+
+## Files Created/Modified
+
+- `src/ds01_jobs/database.py` - Added unix_username to api_keys and jobs schema
+- `src/ds01_jobs/config.py` - Added get_resource_limits_bin setting
+- `src/ds01_jobs/auth.py` - Returns unix_username in get_current_user dict
+- `src/ds01_jobs/cli.py` - Dual identity key-create, Unix user validation, updated key-list
+- `src/ds01_jobs/jobs.py` - Stores unix_username in jobs, passes to rate limit functions
+- `src/ds01_jobs/rate_limit.py` - Async group resolution via subprocess, removed broken users: lookup
+- `tests/unit/test_auth.py` - Updated seed helper, added test_auth_returns_unix_username
+- `tests/unit/test_cli.py` - Dual identity tests, unix_user fixtures, new validation tests
+- `tests/unit/test_jobs.py` - Updated seed/insert helpers, added _get_user_group mocks
+- `tests/unit/test_rate_limit.py` - Async tests with subprocess mocks, group resolution tests
+
+## Decisions Made
+
+- Made get_user_limits and get_user_quota_info async to support subprocess group resolution
+- check_rate_limits signature now takes both unix_username (for group lookup) and username (for DB job counts)
+- _print_key_result accepts optional unix_username to support key-rotate (which doesn't change usernames)
+- Default group fallback is "default" (not "student") when get_resource_limits.py fails or is missing
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Installed pytest-asyncio for test execution**
+- **Found during:** Task 1 verification
+- **Issue:** pytest-asyncio was a dev dependency but not installed in the current environment
+- **Fix:** `pip install pytest-asyncio`
+- **Verification:** All async tests run successfully
+- **Committed in:** Not committed (runtime dependency, not source change)
+
+**2. [Rule 1 - Bug] Updated test_jobs.py seed helpers and added group mocks**
+- **Found during:** Task 2
+- **Issue:** test_jobs.py insert helpers lacked unix_username column; tests hit real subprocess calls
+- **Fix:** Added unix_username to _seed_key and _insert_job helpers; added @patch for _get_user_group on all tests that exercise rate limiting
+- **Files modified:** tests/unit/test_jobs.py
+- **Verification:** All 10 jobs tests pass
+- **Committed in:** 0300617 (Task 2 commit)
+
+---
+
+**Total deviations:** 2 auto-fixed (1 blocking, 1 bug)
+**Impact on plan:** Both fixes necessary for correctness. No scope creep.
+
+## Issues Encountered
+
+None - all planned work executed as specified.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Dual identity data model established and propagated through all layers
+- Rate limit group resolution working via async subprocess delegation
+- Ready for Plan 02 (executor sudo-u integration, resource limits, runner unix_username propagation)
+
+## Self-Check: PASSED
+
+All files verified on disk. All commit hashes found in git log.
+
+---
+*Phase: 06.1-ds01-infra-container-integration*
+*Completed: 2026-03-11*

--- a/src/ds01_jobs/auth.py
+++ b/src/ds01_jobs/auth.py
@@ -161,4 +161,4 @@ async def get_current_user(
     if expires_at - now <= timedelta(days=KEY_EXPIRY_WARNING_DAYS):
         response.headers["X-DS01-Key-Expiry-Warning"] = expires_at.date().isoformat()
 
-    return {"username": username}
+    return {"username": username, "unix_username": row["unix_username"]}

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -34,6 +34,7 @@ def _hash_key(raw_key: str) -> str:
 
 def _print_key_result(
     username: str,
+    unix_username: str | None,
     raw_key: str,
     key_id: str,
     expires_date: str,
@@ -42,23 +43,23 @@ def _print_key_result(
 ) -> None:
     """Display a key creation/rotation result."""
     if json_output:
-        typer.echo(
-            json.dumps(
-                {
-                    "username": username,
-                    "key": raw_key,
-                    "key_id": key_id,
-                    "expires_at": expires_date,
-                },
-                indent=2,
-            )
-        )
+        data: dict[str, str] = {
+            "username": username,
+            "key": raw_key,
+            "key_id": key_id,
+            "expires_at": expires_date,
+        }
+        if unix_username is not None:
+            data["unix_username"] = unix_username
+        typer.echo(json.dumps(data, indent=2))
     else:
         typer.echo(f"API Key {action} successfully")
         typer.echo("")
         typer.echo(f"Key:     {raw_key}")
         typer.echo("")
-        typer.echo(f"User:    {username}")
+        typer.echo(f"GitHub:  {username}")
+        if unix_username is not None:
+            typer.echo(f"Unix:    {unix_username}")
         typer.echo(f"Expires: {expires_date}")
         typer.echo("")
         typer.echo("Setup instructions (send to researcher):")
@@ -177,9 +178,22 @@ def _get_active_key(conn: sqlite3.Connection, username: str) -> sqlite3.Row | No
     return cursor.fetchone()  # type: ignore[no-any-return]
 
 
+def _validate_unix_user(unix_username: str) -> bool:
+    """Check that the Unix user exists on this server."""
+    result = subprocess.run(
+        ["id", unix_username],
+        capture_output=True,
+        timeout=5,
+    )
+    return result.returncode == 0
+
+
 @app.command("key-create")
 def key_create(
-    username: Annotated[str, typer.Argument(help="GitHub username (must be a member of the org)")],
+    github_username: Annotated[
+        str, typer.Argument(help="GitHub username (must be a member of the org)")
+    ],
+    unix_username: Annotated[str, typer.Argument(help="Unix username on the server")],
     expires: Annotated[
         str, typer.Option(help="Key validity duration (e.g. 90d, 30d, 180d)")
     ] = "90d",
@@ -187,14 +201,20 @@ def key_create(
 ) -> None:
     """Create a new API key for a researcher.
 
-    USERNAME must be the researcher's GitHub username. Org membership is
-    verified via the GitHub API (requires gh CLI or GITHUB_TOKEN).
+    GITHUB_USERNAME must be the researcher's GitHub username. Org membership
+    is verified via the GitHub API (requires gh CLI or GITHUB_TOKEN).
+    UNIX_USERNAME must exist on this server (validated via `id`).
     """
     settings = Settings(_env_file=None)
 
+    # Validate Unix user exists
+    if not _validate_unix_user(unix_username):
+        typer.echo(f"Error: Unix user {unix_username!r} does not exist on this server", err=True)
+        raise typer.Exit(code=1)
+
     # Check GitHub org membership
-    if not check_org_membership(username, settings.github_org):
-        typer.echo(f"Error: {username} is not a member of {settings.github_org}", err=True)
+    if not check_org_membership(github_username, settings.github_org):
+        typer.echo(f"Error: {github_username} is not a member of {settings.github_org}", err=True)
         raise typer.Exit(code=1)
 
     days = parse_duration(expires)
@@ -203,9 +223,9 @@ def key_create(
         _ensure_schema(conn)
 
         # Check for existing active key
-        if _get_active_key(conn, username):
+        if _get_active_key(conn, github_username):
             typer.echo(
-                f"Error: User {username} already has an active key. "
+                f"Error: User {github_username} already has an active key. "
                 "Use key-revoke or key-rotate first.",
                 err=True,
             )
@@ -219,14 +239,28 @@ def key_create(
         expires_dt = now + timedelta(days=days)
 
         conn.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, now.isoformat(), expires_dt.isoformat()),
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                github_username,
+                unix_username,
+                key_id,
+                key_hash,
+                now.isoformat(),
+                expires_dt.isoformat(),
+            ),
         )
         conn.commit()
 
     _print_key_result(
-        username, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "created", json_output
+        github_username,
+        unix_username,
+        raw_key,
+        key_id,
+        expires_dt.strftime("%Y-%m-%d"),
+        "created",
+        json_output,
     )
 
 
@@ -238,7 +272,7 @@ def key_list(
     with get_db_sync() as conn:
         _ensure_schema(conn)
         cursor = conn.execute(
-            "SELECT username, key_id, created_at, expires_at, revoked, last_used_at "
+            "SELECT username, unix_username, key_id, created_at, expires_at, revoked, last_used_at "
             "FROM api_keys ORDER BY created_at DESC"
         )
         rows = cursor.fetchall()
@@ -256,6 +290,7 @@ def key_list(
         keys.append(
             {
                 "username": row["username"],
+                "unix_username": row["unix_username"],
                 "status": status,
                 "created": row["created_at"][:10],
                 "expires": row["expires_at"][:10],
@@ -271,13 +306,14 @@ def key_list(
             return
 
         # Aligned columnar output
-        headers = ["USERNAME", "STATUS", "CREATED", "EXPIRES", "LAST USED"]
+        headers = ["USERNAME", "UNIX USER", "STATUS", "CREATED", "EXPIRES", "LAST USED"]
         col_widths = [
             max(len(headers[0]), *(len(k["username"]) for k in keys)),
-            max(len(headers[1]), *(len(k["status"]) for k in keys)),
-            max(len(headers[2]), *(len(k["created"]) for k in keys)),
-            max(len(headers[3]), *(len(k["expires"]) for k in keys)),
-            max(len(headers[4]), *(len(k["last_used"]) for k in keys)),
+            max(len(headers[1]), *(len(k["unix_username"]) for k in keys)),
+            max(len(headers[2]), *(len(k["status"]) for k in keys)),
+            max(len(headers[3]), *(len(k["created"]) for k in keys)),
+            max(len(headers[4]), *(len(k["expires"]) for k in keys)),
+            max(len(headers[5]), *(len(k["last_used"]) for k in keys)),
         ]
 
         header_line = "  ".join(h.ljust(w) for h, w in zip(headers, col_widths, strict=True))
@@ -286,6 +322,7 @@ def key_list(
         for key in keys:
             vals = [
                 key["username"],
+                key["unix_username"],
                 key["status"],
                 key["created"],
                 key["expires"],
@@ -370,5 +407,5 @@ def key_rotate(
         conn.commit()
 
     _print_key_result(
-        username, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "rotated", json_output
+        username, None, raw_key, key_id, expires_dt.strftime("%Y-%m-%d"), "rotated", json_output
     )

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
 
     # External config
     resource_limits_path: Path = Path("/opt/ds01-infra/config/runtime/resource-limits.yaml")
+    get_resource_limits_bin: Path = Path("/opt/ds01-infra/scripts/docker/get_resource_limits.py")
 
     # Authentication
     github_org: str = "hertie-data-science-lab"

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -18,6 +18,7 @@ SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS api_keys (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL,
+    unix_username TEXT NOT NULL,
     key_id TEXT NOT NULL UNIQUE,
     key_hash TEXT NOT NULL,
     created_at TEXT NOT NULL,
@@ -30,6 +31,7 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_key_id ON api_keys(key_id);
 CREATE TABLE IF NOT EXISTS jobs (
     id TEXT PRIMARY KEY,
     username TEXT NOT NULL,
+    unix_username TEXT NOT NULL DEFAULT '',
     repo_url TEXT NOT NULL,
     branch TEXT NOT NULL DEFAULT 'main',
     gpu_count INTEGER NOT NULL DEFAULT 1,

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -39,6 +39,41 @@ class JobExecutor:
     def __init__(self, settings: Settings) -> None:
         self.settings = settings
         self._current_process: asyncio.subprocess.Process | None = None
+        self._unix_username: str = ""
+
+    def _sudo_docker(self, unix_username: str) -> list[str]:
+        """Return the sudo -u {unix_username} docker prefix."""
+        return ["sudo", "-u", unix_username, str(self.settings.docker_bin)]
+
+    async def _get_resource_limits(self, unix_username: str) -> list[str]:
+        """Get Docker resource limit args from get_resource_limits.py.
+
+        Returns a list of Docker CLI args (e.g. ['--memory=32g', '--shm-size=16g']).
+        Strips --cgroup-parent since the Docker wrapper injects it automatically.
+        Returns empty list on failure (job runs with wrapper defaults).
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "python3",
+                str(self.settings.get_resource_limits_bin),
+                unix_username,
+                "--docker-args",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+            if proc.returncode != 0:
+                logger.warning(
+                    "get_resource_limits.py failed for %s: %s",
+                    unix_username,
+                    stderr.decode().strip(),
+                )
+                return []
+            args = stdout.decode().strip().split()
+            return [a for a in args if not a.startswith("--cgroup-parent=")]
+        except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
+            logger.warning("get_resource_limits.py error for %s: %s", unix_username, exc)
+            return []
 
     async def execute(
         self,
@@ -48,6 +83,7 @@ class JobExecutor:
         gpu_count: int,
         timeout_seconds: int | None,
         db_path: Path,
+        unix_username: str = "",
     ) -> None:
         """Run a job through the full execution pipeline.
 
@@ -58,7 +94,9 @@ class JobExecutor:
             gpu_count: Number of GPUs requested.
             timeout_seconds: Job run timeout (None = use default).
             db_path: Path to the SQLite database.
+            unix_username: Unix user for sudo -u Docker execution.
         """
+        self._unix_username = unix_username
         workspace = self.settings.workspace_root / job_id
         workspace.mkdir(parents=True, exist_ok=True)
 
@@ -78,8 +116,10 @@ class JobExecutor:
                 await db.commit()
 
             await self._clone(job_id, repo_url, branch, workspace, db_path)
-            await self._build(job_id, workspace, db_path)
-            await self._run_container(job_id, workspace, gpu_count, timeout_seconds, db_path)
+            await self._build(job_id, workspace, db_path, unix_username)
+            await self._run_container(
+                job_id, workspace, gpu_count, timeout_seconds, db_path, unix_username
+            )
             await self._collect_results(job_id, workspace)
 
             # Success
@@ -106,6 +146,7 @@ class JobExecutor:
             )
         finally:
             await self._cleanup(job_id)
+            self._unix_username = ""
 
     async def _update_status(
         self,
@@ -256,7 +297,7 @@ class JobExecutor:
             if exit_code != 0:
                 raise PhaseError("clone", exit_code, "Clone failed after retry")
 
-    async def _build(self, job_id: str, workspace: Path, db_path: Path) -> None:
+    async def _build(self, job_id: str, workspace: Path, db_path: Path, unix_username: str) -> None:
         """Build Docker image from the repo Dockerfile."""
         if await self._check_cancelled(db_path, job_id):
             raise PhaseError("build", -1, "Job cancelled before build")
@@ -265,7 +306,7 @@ class JobExecutor:
 
         image_tag = f"ds01-job-{job_id}"
         cmd = [
-            str(self.settings.docker_bin),
+            *self._sudo_docker(unix_username),
             "build",
             "-t",
             image_tag,
@@ -292,6 +333,7 @@ class JobExecutor:
         gpu_count: int,
         timeout_seconds: int | None,
         db_path: Path,
+        unix_username: str,
     ) -> None:
         """Run the Docker container with GPU access."""
         if await self._check_cancelled(db_path, job_id):
@@ -310,11 +352,17 @@ class JobExecutor:
         )
         resolved_timeout = min(resolved_timeout, self.settings.max_job_timeout_seconds)
 
+        # Get per-user resource limits
+        resource_args = await self._get_resource_limits(unix_username)
+
         cmd = [
-            str(self.settings.docker_bin),
+            *self._sudo_docker(unix_username),
             "run",
             "--name",
             container_name,
+            "--label",
+            "ds01.interface=api",
+            *resource_args,
             "--gpus",
             "all",
             image_tag,
@@ -335,8 +383,9 @@ class JobExecutor:
         results_dir = workspace / "results"
         results_dir.mkdir(exist_ok=True)
 
+        unix_username = self._unix_username
         proc = await asyncio.create_subprocess_exec(
-            str(self.settings.docker_bin),
+            *self._sudo_docker(unix_username),
             "cp",
             f"{container_name}:/output/.",
             str(results_dir),
@@ -350,12 +399,13 @@ class JobExecutor:
 
     async def _cleanup(self, job_id: str) -> None:
         """Remove container, image, and prune build cache."""
-        docker = str(self.settings.docker_bin)
+        unix_username = self._unix_username
+        docker_prefix = self._sudo_docker(unix_username)
 
         # Remove container
         try:
             proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "rm",
                 "-f",
                 f"ds01-job-{job_id}",
@@ -369,7 +419,7 @@ class JobExecutor:
         # Remove image
         try:
             proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "image",
                 "rm",
                 "-f",
@@ -384,7 +434,7 @@ class JobExecutor:
         # Prune build cache
         try:
             proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "builder",
                 "prune",
                 "--force",
@@ -411,10 +461,13 @@ class JobExecutor:
             await proc.wait()
 
         # Also force-remove any Docker container (survives process group kill)
-        docker = str(self.settings.docker_bin)
+        unix_username = self._unix_username
+        docker_prefix = (
+            self._sudo_docker(unix_username) if unix_username else [str(self.settings.docker_bin)]
+        )
         try:
             rm_proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "rm",
                 "-f",
                 f"ds01-job-{job_id}",

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -96,6 +96,7 @@ async def submit_job(
     """Submit a new GPU job for execution."""
     settings = _get_settings()
     username = user["username"]
+    unix_username = user["unix_username"]
 
     # 1. URL format validation (cheap, no I/O)
     try:
@@ -120,7 +121,7 @@ async def submit_job(
 
     # 2. Rate limit check (raises 429 on failure)
     concurrent_count, concurrent_limit, daily_count, daily_limit = await check_rate_limits(
-        db, username, settings
+        db, unix_username, username, settings
     )
 
     # 3. SSRF check
@@ -195,12 +196,13 @@ async def submit_job(
     now_iso = datetime.now(UTC).isoformat()
     await db.execute(
         "INSERT INTO jobs "
-        "(id, username, repo_url, branch, gpu_count, job_name, "
+        "(id, username, unix_username, repo_url, branch, gpu_count, job_name, "
         "timeout_seconds, dockerfile_content, status, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             job_id,
             username,
+            unix_username,
             body.repo_url,
             body.branch,
             body.gpu_count,
@@ -403,8 +405,9 @@ async def get_quota(
 ) -> QuotaResponse:
     """Return quota usage and limits for the authenticated user."""
     settings = _get_settings()
-    group, concurrent_limit, daily_limit, max_result_size_mb = get_user_quota_info(
-        user["username"], settings
+    unix_username = user["unix_username"]
+    group, concurrent_limit, daily_limit, max_result_size_mb = await get_user_quota_info(
+        unix_username, settings
     )
     concurrent_used, daily_used = await get_user_job_counts(db, user["username"])
 
@@ -448,7 +451,7 @@ async def download_results(
         )
 
     # Size enforcement
-    _, _, _, max_result_size_mb = get_user_quota_info(user["username"], settings)
+    _, _, _, max_result_size_mb = await get_user_quota_info(user["unix_username"], settings)
     total_size = _get_results_dir_size(results_dir)
     max_size_bytes = max_result_size_mb * 1024 * 1024
     if total_size > max_size_bytes:

--- a/src/ds01_jobs/rate_limit.py
+++ b/src/ds01_jobs/rate_limit.py
@@ -2,8 +2,10 @@
 
 Enforces concurrent and daily job submission limits per user,
 with configurable per-group overrides from resource-limits.yaml.
+Group resolution delegates to get_resource_limits.py via subprocess.
 """
 
+import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -28,48 +30,68 @@ def load_resource_limits(path: Path) -> dict:  # type: ignore[type-arg]
     return data if isinstance(data, dict) else {}
 
 
-def get_user_limits(username: str, settings: Settings) -> tuple[int, int]:
-    """Return (concurrent_limit, daily_limit) for a user.
+async def _get_user_group(unix_username: str, bin_path: Path) -> str:
+    """Get user's resource group from get_resource_limits.py."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "python3",
+            str(bin_path),
+            unix_username,
+            "--group",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        if proc.returncode == 0:
+            return stdout.decode().strip()
+        logger.warning(
+            "get_resource_limits.py --group failed for %s: %s",
+            unix_username,
+            stderr.decode().strip(),
+        )
+    except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
+        logger.warning("get_resource_limits.py --group error for %s: %s", unix_username, exc)
+    return "default"
+
+
+async def get_user_limits(unix_username: str, settings: Settings) -> tuple[int, int]:
+    """Return (concurrent_limit, daily_limit) for a user based on their group.
 
     Precedence (lowest to highest):
     1. Settings defaults
-    2. resource-limits.yaml group limits
+    2. resource-limits.yaml group limits (group resolved via subprocess)
     """
     concurrent = settings.default_concurrent_limit
     daily = settings.default_daily_limit
 
+    group = await _get_user_group(unix_username, settings.get_resource_limits_bin)
+
     data = load_resource_limits(settings.resource_limits_path)
     groups = data.get("groups", {})
-    users = data.get("users", {})
-
-    group_name = users.get(username)
-    if group_name and group_name in groups:
-        group_cfg = groups[group_name]
+    if group in groups:
+        group_cfg = groups[group]
         concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
         daily = group_cfg.get("max_daily_submissions", daily)
 
     return concurrent, daily
 
 
-def get_user_quota_info(username: str, settings: Settings) -> tuple[str, int, int, int]:
+async def get_user_quota_info(unix_username: str, settings: Settings) -> tuple[str, int, int, int]:
     """Return (group_name, concurrent_limit, daily_limit, max_result_size_mb) for a user.
 
-    Reads group membership and limits from resource-limits.yaml,
-    falling back to settings defaults for unmapped users.
+    Group resolution delegates to get_resource_limits.py via subprocess,
+    falling back to 'default' on failure.
     """
     concurrent = settings.default_concurrent_limit
     daily = settings.default_daily_limit
     max_result_mb = settings.default_max_result_size_mb
-    group = "default"
+
+    group = await _get_user_group(unix_username, settings.get_resource_limits_bin)
 
     data = load_resource_limits(settings.resource_limits_path)
     groups = data.get("groups", {})
-    users = data.get("users", {})
-
-    group_name = users.get(username)
-    if group_name and group_name in groups:
-        group = group_name
-        group_cfg = groups[group_name]
+    if group in groups:
+        group_cfg = groups[group]
         concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
         daily = group_cfg.get("max_daily_submissions", daily)
         max_result_mb = group_cfg.get("max_result_size_mb", max_result_mb)
@@ -101,13 +123,19 @@ async def get_user_job_counts(db: aiosqlite.Connection, username: str) -> tuple[
 
 
 async def check_rate_limits(
-    db: aiosqlite.Connection, username: str, settings: Settings
+    db: aiosqlite.Connection, unix_username: str, username: str, settings: Settings
 ) -> tuple[int, int, int, int]:
     """Check both rate limits and raise HTTPException(429) if exceeded.
 
+    Args:
+        db: Database connection.
+        unix_username: Unix username for group resolution.
+        username: GitHub username for DB job count queries.
+        settings: Application settings.
+
     Returns (concurrent_count, concurrent_limit, daily_count, daily_limit) on success.
     """
-    concurrent_limit, daily_limit = get_user_limits(username, settings)
+    concurrent_limit, daily_limit = await get_user_limits(unix_username, settings)
     concurrent_count, daily_count = await get_user_job_counts(db, username)
 
     # Check concurrent limit first

--- a/src/ds01_jobs/runner.py
+++ b/src/ds01_jobs/runner.py
@@ -91,7 +91,7 @@ class JobRunner:
         async with aiosqlite.connect(self.settings.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "SELECT id, username, repo_url, branch, gpu_count, timeout_seconds "
+                "SELECT id, username, unix_username, repo_url, branch, gpu_count, timeout_seconds "
                 "FROM jobs WHERE status='queued' ORDER BY created_at ASC"
             )
             rows = await cursor.fetchall()
@@ -115,6 +115,7 @@ class JobRunner:
                     gpu_count,
                     row["timeout_seconds"],
                     self.settings.db_path,
+                    unix_username=row["unix_username"],
                 )
             )
             self.active_jobs[job_id] = task

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -55,6 +55,7 @@ async def _seed_key(
     key_id: str,
     key_hash: str,
     username: str = "testuser",
+    unix_username: str = "testuser_unix",
     expires_at: str | None = None,
     revoked: int = 0,
 ) -> None:
@@ -66,9 +67,18 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, revoked),
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                unix_username,
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                revoked,
+            ),
         )
         await db.commit()
 
@@ -323,3 +333,26 @@ async def test_last_used_at_updated_after_successful_auth(tmp_path: Path):
         row = await cursor.fetchone()
         assert row is not None
         assert row[0] is not None  # last_used_at should be set
+
+
+@pytest.mark.asyncio
+async def test_auth_returns_unix_username(tmp_path: Path):
+    """Successful auth returns both username and unix_username."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
+
+    app = _make_app(db_path)
+    headers = _sign_request(raw_key, "GET", "/protected")
+    headers["Authorization"] = f"Bearer {raw_key}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/protected", headers=headers)
+
+    assert resp.status_code == 200
+    user = resp.json()["user"]
+    assert user["username"] == "ghuser"
+    assert user["unix_username"] == "unixuser"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -61,6 +61,18 @@ def mock_github_non_member(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ds01_jobs.cli.check_org_membership", lambda u, o: False)
 
 
+@pytest.fixture()
+def mock_unix_user_valid(monkeypatch: pytest.MonkeyPatch):
+    """Mock _validate_unix_user to return True."""
+    monkeypatch.setattr("ds01_jobs.cli._validate_unix_user", lambda u: True)
+
+
+@pytest.fixture()
+def mock_unix_user_invalid(monkeypatch: pytest.MonkeyPatch):
+    """Mock _validate_unix_user to return False."""
+    monkeypatch.setattr("ds01_jobs.cli._validate_unix_user", lambda u: False)
+
+
 # --- Token resolution tests ---
 
 
@@ -125,9 +137,9 @@ def test_parse_duration_invalid():
 # --- key-create tests ---
 
 
-def test_key_create_success(tmp_db, mock_github_member):
+def test_key_create_success(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create produces output with ds01_ key, username, and expiry."""
-    result = runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result.exit_code == 0
     assert "ds01_" in result.output
     assert "researcher1" in result.output
@@ -135,48 +147,67 @@ def test_key_create_success(tmp_db, mock_github_member):
     assert "API Key created successfully" in result.output
 
 
-def test_key_create_json(tmp_db, mock_github_member):
-    """key-create --json produces valid JSON with key field."""
-    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+def test_key_create_shows_both_usernames(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-create output shows both GitHub and Unix usernames."""
+    result = runner.invoke(app, ["key-create", "ghuser", "unixuser"])
+    assert result.exit_code == 0
+    assert "GitHub:  ghuser" in result.output
+    assert "Unix:    unixuser" in result.output
+
+
+def test_key_create_json(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-create --json produces valid JSON with key and unix_username fields."""
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert data["key"].startswith("ds01_")
     assert data["username"] == "researcher1"
+    assert data["unix_username"] == "researcher1_unix"
     assert "key_id" in data
     assert "expires_at" in data
 
 
-def test_key_create_non_member(tmp_db, mock_github_non_member):
+def test_key_create_non_member(tmp_db, mock_github_non_member, mock_unix_user_valid):
     """key-create for non-member exits with error."""
-    result = runner.invoke(app, ["key-create", "outsider"])
+    result = runner.invoke(app, ["key-create", "outsider", "outsider_unix"])
     assert result.exit_code == 1
 
 
-def test_key_create_duplicate_active_key(tmp_db, mock_github_member):
+def test_key_create_invalid_unix_user(tmp_db, mock_unix_user_invalid):
+    """key-create with invalid Unix user exits with error code 1."""
+    result = runner.invoke(app, ["key-create", "researcher1", "nonexistent_unix"])
+    assert result.exit_code == 1
+    assert "does not exist" in result.output
+
+
+def test_key_create_duplicate_active_key(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create for user with existing active key exits with error."""
     # Create first key
-    result1 = runner.invoke(app, ["key-create", "researcher1"])
+    result1 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result1.exit_code == 0
 
     # Try to create second key
-    result2 = runner.invoke(app, ["key-create", "researcher1"])
+    result2 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result2.exit_code == 1
 
 
-def test_key_create_after_revoke(tmp_db, mock_github_member):
+def test_key_create_after_revoke(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create succeeds after the previous key is revoked."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
 
-    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert data["username"] == "researcher1"
 
 
-def test_key_create_custom_expires(tmp_db, mock_github_member):
+def test_key_create_custom_expires(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create with --expires 30d sets expiry ~30 days from now."""
-    result = runner.invoke(app, ["key-create", "researcher1", "--expires", "30d", "--json"])
+    result = runner.invoke(
+        app,
+        ["key-create", "researcher1", "researcher1_unix", "--expires", "30d", "--json"],
+    )
     assert result.exit_code == 0
     data = json.loads(result.output)
 
@@ -184,9 +215,9 @@ def test_key_create_custom_expires(tmp_db, mock_github_member):
     assert data["expires_at"] == expected_date
 
 
-def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member):
+def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member, mock_unix_user_valid):
     """Created key hash is valid bcrypt - bcrypt.checkpw returns True."""
-    result = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     raw_key = data["key"]
@@ -203,9 +234,24 @@ def test_key_create_stores_bcrypt_hash(tmp_db, mock_github_member):
     assert bcrypt.checkpw(raw_key.encode(), stored_hash.encode())
 
 
-def test_key_create_setup_instructions(tmp_db, mock_github_member):
+def test_key_create_stores_unix_username(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-create stores unix_username in the database."""
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
+    assert result.exit_code == 0
+
+    conn = sqlite3.connect(tmp_db)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT unix_username FROM api_keys WHERE username = 'researcher1'")
+    row = cursor.fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row["unix_username"] == "researcher1_unix"
+
+
+def test_key_create_setup_instructions(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-create output includes setup instructions block."""
-    result = runner.invoke(app, ["key-create", "researcher1"])
+    result = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     assert result.exit_code == 0
     assert "Setup instructions" in result.output
     assert "pip install ds01-jobs" in result.output
@@ -223,12 +269,13 @@ def test_key_list_empty(tmp_db):
     assert "No API keys found" in result.output
 
 
-def test_key_list_with_keys(tmp_db, mock_github_member):
-    """key-list shows correct columns."""
-    runner.invoke(app, ["key-create", "researcher1"])
+def test_key_list_with_keys(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-list shows correct columns including UNIX USER."""
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-list"])
     assert result.exit_code == 0
     assert "USERNAME" in result.output
+    assert "UNIX USER" in result.output
     assert "STATUS" in result.output
     assert "CREATED" in result.output
     assert "EXPIRES" in result.output
@@ -237,22 +284,23 @@ def test_key_list_with_keys(tmp_db, mock_github_member):
     assert "active" in result.output
 
 
-def test_key_list_json(tmp_db, mock_github_member):
-    """key-list --json produces valid JSON array."""
-    runner.invoke(app, ["key-create", "researcher1"])
+def test_key_list_json(tmp_db, mock_github_member, mock_unix_user_valid):
+    """key-list --json produces valid JSON array with unix_username."""
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-list", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["username"] == "researcher1"
+    assert data[0]["unix_username"] == "researcher1_unix"
     assert data[0]["status"] == "active"
 
 
-def test_key_list_shows_status(tmp_db, mock_github_member):
+def test_key_list_shows_status(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-list shows correct status for active, revoked, expired keys."""
     # Create and revoke a key to test revoked status
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
 
     result = runner.invoke(app, ["key-list", "--json"])
@@ -260,10 +308,10 @@ def test_key_list_shows_status(tmp_db, mock_github_member):
     assert data[0]["status"] == "revoked"
 
 
-def test_key_list_shows_expired_status(tmp_db, mock_github_member):
+def test_key_list_shows_expired_status(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-list shows 'expired' for keys past their expiry date."""
     # Create key then manually backdate its expiry
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     conn = sqlite3.connect(tmp_db)
     past_date = (datetime.now(UTC) - timedelta(days=1)).isoformat()
     conn.execute("UPDATE api_keys SET expires_at = ? WHERE username = 'researcher1'", (past_date,))
@@ -278,9 +326,9 @@ def test_key_list_shows_expired_status(tmp_db, mock_github_member):
 # --- key-revoke tests ---
 
 
-def test_key_revoke_with_yes(tmp_db, mock_github_member):
+def test_key_revoke_with_yes(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-revoke --yes revokes without prompt."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
     assert result.exit_code == 0
     assert "Key revoked" in result.output
@@ -292,18 +340,18 @@ def test_key_revoke_nonexistent_user(tmp_db):
     assert result.exit_code == 1
 
 
-def test_revoked_key_shows_in_list(tmp_db, mock_github_member):
+def test_revoked_key_shows_in_list(tmp_db, mock_github_member, mock_unix_user_valid):
     """Revoked key shows as 'revoked' in key-list."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     runner.invoke(app, ["key-revoke", "researcher1", "--yes"])
     result = runner.invoke(app, ["key-list", "--json"])
     data = json.loads(result.output)
     assert data[0]["status"] == "revoked"
 
 
-def test_key_revoke_json(tmp_db, mock_github_member):
+def test_key_revoke_json(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-revoke --json produces valid JSON output."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-revoke", "researcher1", "--yes", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -314,9 +362,9 @@ def test_key_revoke_json(tmp_db, mock_github_member):
 # --- key-rotate tests ---
 
 
-def test_key_rotate_with_yes(tmp_db, mock_github_member):
+def test_key_rotate_with_yes(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-rotate --yes produces a new key."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-rotate", "researcher1", "--yes"])
     assert result.exit_code == 0
     assert "ds01_" in result.output
@@ -329,9 +377,9 @@ def test_key_rotate_no_active_key(tmp_db):
     assert result.exit_code == 1
 
 
-def test_key_rotate_produces_different_key(tmp_db, mock_github_member):
+def test_key_rotate_produces_different_key(tmp_db, mock_github_member, mock_unix_user_valid):
     """Rotated key is different from the original."""
-    result1 = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result1 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     original_key = json.loads(result1.output)["key"]
 
     result2 = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
@@ -341,9 +389,9 @@ def test_key_rotate_produces_different_key(tmp_db, mock_github_member):
     assert new_key.startswith("ds01_")
 
 
-def test_key_rotate_json(tmp_db, mock_github_member):
+def test_key_rotate_json(tmp_db, mock_github_member, mock_unix_user_valid):
     """key-rotate --json produces valid JSON with new key."""
-    runner.invoke(app, ["key-create", "researcher1"])
+    runner.invoke(app, ["key-create", "researcher1", "researcher1_unix"])
     result = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -351,9 +399,9 @@ def test_key_rotate_json(tmp_db, mock_github_member):
     assert data["username"] == "researcher1"
 
 
-def test_key_rotate_old_hash_changes(tmp_db, mock_github_member):
+def test_key_rotate_old_hash_changes(tmp_db, mock_github_member, mock_unix_user_valid):
     """After rotation, the stored hash corresponds to the new key."""
-    result1 = runner.invoke(app, ["key-create", "researcher1", "--json"])
+    result1 = runner.invoke(app, ["key-create", "researcher1", "researcher1_unix", "--json"])
     original_key = json.loads(result1.output)["key"]
 
     result2 = runner.invoke(app, ["key-rotate", "researcher1", "--yes", "--json"])

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -20,6 +20,7 @@ from ds01_jobs.executor import JobExecutor
 JOB_ID = "test-job-001"
 REPO_URL = "https://github.com/example/repo.git"
 BRANCH = "main"
+UNIX_USER = "testuser"
 
 
 @pytest.fixture
@@ -47,11 +48,12 @@ def db_path(tmp_path: Path) -> Path:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.executescript(SCHEMA_SQL)
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             JOB_ID,
             "testuser",
+            UNIX_USER,
             REPO_URL,
             BRANCH,
             1,
@@ -93,7 +95,13 @@ async def test_execute_success(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -120,13 +128,29 @@ async def test_execute_clone_failure_retries(
 ) -> None:
     """Clone retries once on failure and succeeds on second attempt."""
     # First clone call fails, second succeeds, rest succeed
+    # clone fail, clone retry ok, build ok, get_resource_limits ok, run ok, cp ok, cleanup x3
     fail_proc = _mock_process(128)
     ok_proc = _mock_process(0)
-    mock_exec.side_effect = [fail_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc]
+    mock_exec.side_effect = [
+        fail_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+    ]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -157,7 +181,13 @@ async def test_execute_clone_failure_after_retry(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -184,7 +214,13 @@ async def test_execute_build_failure(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -209,12 +245,18 @@ async def test_execute_run_failure(
     """Run failure sets status=failed with failed_phase=run."""
     ok_proc = _mock_process(0)
     fail_proc = _mock_process(1)
-    # clone ok, build ok, run fails, cleanup procs
-    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+    # clone ok, build ok, get_resource_limits ok, run fails, cleanup procs
+    mock_exec.side_effect = [ok_proc, ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -266,7 +308,13 @@ async def test_execute_build_timeout(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -306,7 +354,13 @@ async def test_status_transitions_order(
     executor._update_status = tracking_update  # type: ignore[assignment]
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     assert statuses == ["cloning", "building", "running", "succeeded"]
@@ -328,20 +382,26 @@ async def test_cleanup_called_on_failure(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     # Check cleanup calls were made (the last 3 create_subprocess_exec calls)
     calls = mock_exec.call_args_list
     docker = str(executor_settings.docker_bin)
 
-    # Find cleanup calls - they use docker rm, docker image rm, docker builder prune
+    # Find cleanup calls - they use sudo -u ... docker rm/image/builder
     cleanup_cmds = []
     for c in calls:
         args = c[0] if c[0] else ()
-        if args and args[0] == docker:
-            if len(args) > 1 and args[1] in ("rm", "image", "builder"):
-                cleanup_cmds.append(args[1])
+        # With sudo prefix, docker bin is at index 3, subcommand at index 4
+        if len(args) >= 5 and args[3] == docker:
+            cleanup_cmds.append(args[4])
 
     assert "rm" in cleanup_cmds
     assert "image" in cleanup_cmds
@@ -355,23 +415,29 @@ async def test_docker_bin_path_used(
     executor_settings: Settings,
     db_path: Path,
 ) -> None:
-    """All docker subprocess calls use settings.docker_bin, not a hardcoded path."""
+    """All docker subprocess calls use settings.docker_bin via sudo -u prefix."""
     mock_exec.return_value = _mock_process(0)
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     docker = str(executor_settings.docker_bin)
     for c in mock_exec.call_args_list:
         args = c[0] if c[0] else ()
-        # Skip the git clone call
-        if args and args[0] == "git":
+        # Skip the git clone call and get_resource_limits call
+        if args and args[0] in ("git", "python3"):
             continue
-        # All other calls should use the docker wrapper path
+        # All docker calls should have docker_bin at index 3 (after sudo -u user)
         if args:
-            assert args[0] == docker, f"Expected {docker} but got {args[0]} in call {args}"
+            assert docker in args, f"Expected {docker} in call {args}"
 
 
 @pytest.mark.asyncio
@@ -386,7 +452,13 @@ async def test_log_files_created(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     workspace = executor_settings.workspace_root / JOB_ID
@@ -431,13 +503,22 @@ async def test_cancel_check_stops_execution(
     executor._check_cancelled = cancel_after_clone  # type: ignore[assignment]
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     # Verify build was never started - no docker build call should exist
     calls = mock_exec.call_args_list
-    docker_cmds = [c[0] for c in calls if c[0] and c[0][0] == str(executor_settings.docker_bin)]
-    build_calls = [c for c in docker_cmds if len(c) > 1 and c[1] == "build"]
+    build_calls = [
+        c[0]
+        for c in calls
+        if c[0] and "build" in c[0] and str(executor_settings.docker_bin) in c[0]
+    ]
     assert len(build_calls) == 0, "Build should not have been called after cancel"
 
 
@@ -453,7 +534,13 @@ async def test_phase_timestamps_recorded(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -471,3 +558,254 @@ async def test_phase_timestamps_recorded(
     # Completed phases should have ended_at set
     for phase in ("queued", "cloning", "building", "running"):
         assert timestamps[phase]["ended_at"] is not None, f"{phase} missing ended_at"
+
+
+# ---------------------------------------------------------------------------
+# New tests for sudo -u, resource limits, and interface label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_build_uses_sudo_prefix(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Docker build command starts with sudo -u {unix_username} {docker_bin}."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the build call - it has "build" in args
+    build_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if "build" in args and docker in args:
+            build_call = args
+            break
+
+    assert build_call is not None, "No docker build call found"
+    assert build_call[:4] == ("sudo", "-u", UNIX_USER, docker)
+    assert build_call[4] == "build"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_run_uses_sudo_with_interface_label(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Docker run includes sudo -u prefix and --label ds01.interface=api."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the run call
+    run_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if "run" in args and docker in args:
+            run_call = args
+            break
+
+    assert run_call is not None, "No docker run call found"
+    # Verify sudo prefix
+    assert run_call[:4] == ("sudo", "-u", UNIX_USER, docker)
+    assert run_call[4] == "run"
+    # Verify interface label
+    assert "--label" in run_call
+    label_idx = run_call.index("--label")
+    assert run_call[label_idx + 1] == "ds01.interface=api"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_run_includes_resource_limits(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Docker run includes resource limit args from _get_resource_limits."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    # Mock _get_resource_limits to return specific args
+    with patch.object(
+        executor,
+        "_get_resource_limits",
+        new_callable=AsyncMock,
+        return_value=["--memory=32g", "--shm-size=16g"],
+    ):
+        await executor.execute(
+            JOB_ID,
+            REPO_URL,
+            BRANCH,
+            gpu_count=1,
+            timeout_seconds=None,
+            db_path=db_path,
+            unix_username=UNIX_USER,
+        )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the run call
+    run_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if "run" in args and docker in args:
+            run_call = args
+            break
+
+    assert run_call is not None, "No docker run call found"
+    assert "--memory=32g" in run_call
+    assert "--shm-size=16g" in run_call
+
+
+async def _passthrough_wait_for(coro: object, **_kwargs: object) -> object:
+    """Await and return the coroutine (bypass real timeout)."""
+    return await coro  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_get_resource_limits_strips_cgroup_parent(
+    executor_settings: Settings,
+) -> None:
+    """_get_resource_limits strips --cgroup-parent from output."""
+    executor = JobExecutor(executor_settings)
+
+    # Mock the subprocess to return output with --cgroup-parent
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (
+        b"--cpus=32 --memory=32g --cgroup-parent=ds01-student-testuser.slice --shm-size=16g",
+        b"",
+    )
+    mock_proc.returncode = 0
+
+    with patch("ds01_jobs.executor.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("ds01_jobs.executor.asyncio.wait_for", side_effect=_passthrough_wait_for):
+            result = await executor._get_resource_limits(UNIX_USER)
+
+    assert "--cpus=32" in result
+    assert "--memory=32g" in result
+    assert "--shm-size=16g" in result
+    # cgroup-parent should be stripped
+    assert not any(a.startswith("--cgroup-parent=") for a in result)
+
+
+@pytest.mark.asyncio
+async def test_get_resource_limits_fallback_on_failure(
+    executor_settings: Settings,
+) -> None:
+    """_get_resource_limits returns empty list when subprocess fails."""
+    executor = JobExecutor(executor_settings)
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (b"", b"error message")
+    mock_proc.returncode = 1
+
+    with patch("ds01_jobs.executor.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("ds01_jobs.executor.asyncio.wait_for", side_effect=_passthrough_wait_for):
+            result = await executor._get_resource_limits(UNIX_USER)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_cleanup_uses_sudo(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Cleanup commands (rm, image rm, builder prune) all use sudo -u prefix."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    cleanup_proc = _mock_process(0)
+    # clone ok, build fails, then 3 cleanup calls
+    mock_exec.side_effect = [ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    calls = mock_exec.call_args_list
+
+    # Get only cleanup calls (after git clone and docker build)
+    # Cleanup calls are docker rm, docker image rm, docker builder prune
+    cleanup_calls = []
+    for c in calls:
+        args = c[0] if c[0] else ()
+        if len(args) >= 5 and args[0] == "sudo" and args[3] == docker:
+            subcmd = args[4]
+            if subcmd in ("rm", "image", "builder"):
+                cleanup_calls.append(args)
+
+    assert len(cleanup_calls) == 3, f"Expected 3 cleanup calls, got {len(cleanup_calls)}"
+
+    for call_args in cleanup_calls:
+        assert call_args[:4] == ("sudo", "-u", UNIX_USER, docker), (
+            f"Cleanup call missing sudo prefix: {call_args}"
+        )
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_collect_results_uses_sudo(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """docker cp for results collection uses sudo -u prefix."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the cp call
+    cp_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if "cp" in args and docker in args:
+            cp_call = args
+            break
+
+    assert cp_call is not None, "No docker cp call found"
+    assert cp_call[:4] == ("sudo", "-u", UNIX_USER, docker)

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -53,6 +53,7 @@ async def _seed_key(
     key_id: str,
     key_hash: str,
     username: str = "testuser",
+    unix_username: str = "testuser_unix",
     expires_at: str | None = None,
 ) -> None:
     """Insert a test API key into the database."""
@@ -61,9 +62,18 @@ async def _seed_key(
 
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO api_keys (username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (username, key_id, key_hash, datetime.now(UTC).isoformat(), expires_at, 0),
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                unix_username,
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                0,
+            ),
         )
         await db.commit()
 
@@ -78,11 +88,12 @@ async def _insert_job(
     now = created_at or datetime.now(UTC).isoformat()
     async with aiosqlite.connect(db_path) as db:
         await db.execute(
-            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
-            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, job_name, "
+            "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 str(uuid.uuid4()),
                 username,
+                "testuser_unix",
                 "https://github.com/test/repo",
                 "main",
                 1,
@@ -128,10 +139,11 @@ def _build_headers(raw_key: str, body_dict: dict) -> dict[str, str]:  # type: ig
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_success(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Valid auth + valid repo_url returns 202 with job record in DB."""
     db_path = tmp_path / "test.db"
@@ -190,10 +202,11 @@ async def test_submit_job_invalid_url(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_with_dockerfile_scan_error(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Dockerfile with blocked base image returns 422 with dockerfile_scan_error."""
     db_path = tmp_path / "test.db"
@@ -221,10 +234,11 @@ async def test_submit_job_with_dockerfile_scan_error(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_with_clean_dockerfile(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Valid Dockerfile returns 202 (scan passes)."""
     db_path = tmp_path / "test.db"
@@ -248,10 +262,11 @@ async def test_submit_job_with_clean_dockerfile(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_concurrent_limit_exceeded(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """User at concurrent limit gets 429 with limit_type='concurrent'."""
     db_path = tmp_path / "test.db"
@@ -278,10 +293,11 @@ async def test_submit_job_concurrent_limit_exceeded(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_daily_limit_exceeded(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """User at daily limit gets 429 with limit_type='daily'."""
     db_path = tmp_path / "test.db"
@@ -308,10 +324,11 @@ async def test_submit_job_daily_limit_exceeded(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_rate_limit_headers_on_success(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Successful 202 includes X-RateLimit-* headers."""
     db_path = tmp_path / "test.db"
@@ -337,10 +354,11 @@ async def test_submit_job_rate_limit_headers_on_success(
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_submit_job_auto_generated_job_name(
-    mock_ssrf: AsyncMock, mock_verify: AsyncMock, tmp_path: Path
+    mock_ssrf: AsyncMock, mock_verify: AsyncMock, mock_group: AsyncMock, tmp_path: Path
 ) -> None:
     """Omitting job_name auto-generates from repo name + short ID."""
     db_path = tmp_path / "test.db"
@@ -390,8 +408,11 @@ async def test_submit_job_unauthenticated(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
-async def test_submit_job_repo_not_found(mock_ssrf: AsyncMock, tmp_path: Path) -> None:
+async def test_submit_job_repo_not_found(
+    mock_ssrf: AsyncMock, mock_group: AsyncMock, tmp_path: Path
+) -> None:
     """verify_repo_accessible raising ValueError returns 422 with repo_not_found."""
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import aiosqlite
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from ds01_jobs.config import Settings
 from ds01_jobs.database import init_db
 from ds01_jobs.rate_limit import (
+    _get_user_group,
     check_rate_limits,
     get_user_job_counts,
     get_user_limits,
@@ -32,11 +34,12 @@ async def _insert_job(
 
     now = created_at or datetime.now(UTC).isoformat()
     await db.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, job_name, "
-        "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, job_name, "
+        "status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             str(uuid.uuid4()),
             username,
+            "testuser_unix",
             "https://github.com/test/repo",
             "main",
             1,
@@ -53,14 +56,17 @@ async def _insert_job(
 async def test_get_user_limits_defaults() -> None:
     """No resource-limits.yaml returns settings defaults (3, 10)."""
     settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
-    concurrent, daily = get_user_limits("someuser", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+    ):
+        concurrent, daily = await get_user_limits("someuser", settings)
     assert concurrent == 3
     assert daily == 10
 
 
 @pytest.mark.asyncio
-async def test_get_user_limits_from_yaml(tmp_path: Path) -> None:
-    """User mapped to student group gets group limits (2, 5)."""
+async def test_get_user_limits_from_group(tmp_path: Path) -> None:
+    """User resolved to student group gets group limits (2, 5)."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
         "groups:\n"
@@ -70,36 +76,74 @@ async def test_get_user_limits_from_yaml(tmp_path: Path) -> None:
         "  researcher:\n"
         "    max_concurrent_jobs: 5\n"
         "    max_daily_submissions: 20\n"
-        "users:\n"
-        "  alice: researcher\n"
-        "  bob: student\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    concurrent, daily = get_user_limits("bob", settings)
+
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="student"
+    ):
+        concurrent, daily = await get_user_limits("bob_unix", settings)
     assert concurrent == 2
     assert daily == 5
 
-    concurrent, daily = get_user_limits("alice", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="researcher"
+    ):
+        concurrent, daily = await get_user_limits("alice_unix", settings)
     assert concurrent == 5
     assert daily == 20
 
 
 @pytest.mark.asyncio
-async def test_get_user_limits_user_not_in_yaml(tmp_path: Path) -> None:
-    """User not listed in YAML users section falls back to defaults."""
+async def test_get_user_limits_unknown_group(tmp_path: Path) -> None:
+    """User with group not in YAML falls back to defaults."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
-        "groups:\n"
-        "  student:\n"
-        "    max_concurrent_jobs: 2\n"
-        "    max_daily_submissions: 5\n"
-        "users:\n"
-        "  bob: student\n"
+        "groups:\n  student:\n    max_concurrent_jobs: 2\n    max_daily_submissions: 5\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    concurrent, daily = get_user_limits("unknown_user", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+    ):
+        concurrent, daily = await get_user_limits("unknown_unix", settings)
     assert concurrent == 3
     assert daily == 10
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_success() -> None:
+    """_get_user_group returns group from subprocess stdout."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (b"student\n", b"")
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+        group = await _get_user_group("testuser", Path("/some/bin.py"))
+    assert group == "student"
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_fallback_on_failure() -> None:
+    """_get_user_group returns 'default' when subprocess fails."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (b"", b"error\n")
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+        group = await _get_user_group("testuser", Path("/some/bin.py"))
+    assert group == "default"
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_fallback_on_file_not_found() -> None:
+    """_get_user_group returns 'default' when binary not found."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        side_effect=FileNotFoundError("no such file"),
+    ):
+        group = await _get_user_group("testuser", Path("/nonexistent/bin.py"))
+    assert group == "default"
 
 
 @pytest.mark.asyncio
@@ -167,7 +211,10 @@ async def test_check_rate_limits_passes(tmp_path: Path) -> None:
 
     async with aiosqlite.connect(db_path) as db:
         await _insert_job(db, status="queued")
-        result = await check_rate_limits(db, "testuser", settings)
+        with patch(
+            "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+        ):
+            result = await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     concurrent_count, concurrent_limit, daily_count, daily_limit = result
     assert concurrent_count == 1
@@ -192,7 +239,12 @@ async def test_check_rate_limits_concurrent_exceeded(tmp_path: Path) -> None:
         await _insert_job(db, status="running")
 
         with pytest.raises(Exception) as exc_info:
-            await check_rate_limits(db, "testuser", settings)
+            with patch(
+                "ds01_jobs.rate_limit._get_user_group",
+                new_callable=AsyncMock,
+                return_value="default",
+            ):
+                await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     exc = exc_info.value
     assert exc.status_code == 429  # type: ignore[union-attr]
@@ -220,7 +272,12 @@ async def test_check_rate_limits_daily_exceeded(tmp_path: Path) -> None:
         await _insert_job(db, status="succeeded")
 
         with pytest.raises(Exception) as exc_info:
-            await check_rate_limits(db, "testuser", settings)
+            with patch(
+                "ds01_jobs.rate_limit._get_user_group",
+                new_callable=AsyncMock,
+                return_value="default",
+            ):
+                await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     exc = exc_info.value
     assert exc.status_code == 429  # type: ignore[union-attr]
@@ -247,7 +304,12 @@ async def test_rate_limit_429_body_structure(tmp_path: Path) -> None:
         await _insert_job(db, status="queued")
 
         with pytest.raises(Exception) as exc_info:
-            await check_rate_limits(db, "testuser", settings)
+            with patch(
+                "ds01_jobs.rate_limit._get_user_group",
+                new_callable=AsyncMock,
+                return_value="default",
+            ):
+                await check_rate_limits(db, "testuser_unix", "testuser", settings)
 
     exc = exc_info.value
     body = exc.detail  # type: ignore[union-attr]
@@ -266,18 +328,23 @@ async def test_rate_limit_429_body_structure(tmp_path: Path) -> None:
 # --- get_user_quota_info tests ---
 
 
-def test_get_user_quota_info_defaults() -> None:
+@pytest.mark.asyncio
+async def test_get_user_quota_info_defaults() -> None:
     """No YAML file returns default group and settings defaults."""
     settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
-    group, concurrent, daily, max_result_mb = get_user_quota_info("someuser", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
+    ):
+        group, concurrent, daily, max_result_mb = await get_user_quota_info("someuser", settings)
     assert group == "default"
     assert concurrent == 3
     assert daily == 10
     assert max_result_mb == 1024
 
 
-def test_get_user_quota_info_from_yaml(tmp_path: Path) -> None:
-    """User mapped to student group with max_result_size_mb returns group values."""
+@pytest.mark.asyncio
+async def test_get_user_quota_info_from_group(tmp_path: Path) -> None:
+    """User resolved to student group with max_result_size_mb returns group values."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
         "groups:\n"
@@ -285,30 +352,30 @@ def test_get_user_quota_info_from_yaml(tmp_path: Path) -> None:
         "    max_concurrent_jobs: 2\n"
         "    max_daily_submissions: 5\n"
         "    max_result_size_mb: 512\n"
-        "users:\n"
-        "  bob: student\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    group, concurrent, daily, max_result_mb = get_user_quota_info("bob", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="student"
+    ):
+        group, concurrent, daily, max_result_mb = await get_user_quota_info("bob_unix", settings)
     assert group == "student"
     assert concurrent == 2
     assert daily == 5
     assert max_result_mb == 512
 
 
-def test_get_user_quota_info_no_result_size_in_yaml(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_get_user_quota_info_no_result_size_in_yaml(tmp_path: Path) -> None:
     """Group without max_result_size_mb falls back to settings default."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
-        "groups:\n"
-        "  researcher:\n"
-        "    max_concurrent_jobs: 5\n"
-        "    max_daily_submissions: 20\n"
-        "users:\n"
-        "  alice: researcher\n"
+        "groups:\n  researcher:\n    max_concurrent_jobs: 5\n    max_daily_submissions: 20\n"
     )
     settings = _test_settings(resource_limits_path=yaml_path)
-    group, concurrent, daily, max_result_mb = get_user_quota_info("alice", settings)
+    with patch(
+        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="researcher"
+    ):
+        group, concurrent, daily, max_result_mb = await get_user_quota_info("alice_unix", settings)
     assert group == "researcher"
     assert concurrent == 5
     assert daily == 20

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -35,11 +35,12 @@ def populated_db(tmp_path: Path) -> Path:
     conn.executescript(SCHEMA_SQL)
     for i in range(2):
         conn.execute(
-            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 f"job-{i}",
                 "testuser",
+                "testuser_unix",
                 "https://github.com/test/repo.git",
                 "main",
                 1,
@@ -73,11 +74,12 @@ async def test_recover_orphaned_jobs(runner_settings: Settings) -> None:
     conn = sqlite3.connect(db_path)
     for status in ("running", "building", "cloning"):
         conn.execute(
-            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 f"orphan-{status}",
                 "testuser",
+                "testuser_unix",
                 "https://github.com/test/repo.git",
                 "main",
                 1,
@@ -89,11 +91,12 @@ async def test_recover_orphaned_jobs(runner_settings: Settings) -> None:
         )
     # Also add a queued job that should NOT be affected
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             "queued-job",
             "testuser",
+            "testuser_unix",
             "https://github.com/test/repo.git",
             "main",
             1,
@@ -179,11 +182,12 @@ async def test_poll_skips_oversized_jobs(
     conn = sqlite3.connect(db_path)
     # Job needing 2 GPUs
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             "big-job",
             "testuser",
+            "testuser_unix",
             "https://github.com/test/repo.git",
             "main",
             2,
@@ -195,11 +199,12 @@ async def test_poll_skips_oversized_jobs(
     )
     # Job needing 1 GPU
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             "small-job",
             "testuser",
+            "testuser_unix",
             "https://github.com/test/repo.git",
             "main",
             1,
@@ -281,3 +286,55 @@ async def test_completed_tasks_cleaned_up(
 
     assert "done-job" not in runner.active_jobs
     assert "done-job" not in runner.active_executors
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+@patch("ds01_jobs.runner.JobExecutor")
+async def test_poll_passes_unix_username_to_executor(
+    mock_executor_cls: AsyncMock,
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Runner passes unix_username from DB to executor.execute()."""
+    db_path = tmp_path / "test.db"
+    runner_settings.db_path = db_path
+    _init_db_sync(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "unix-test-job",
+            "ghuser",
+            "alice_unix",
+            "https://github.com/test/repo.git",
+            "main",
+            1,
+            "unix-test",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    mock_gpu.return_value = 4
+
+    mock_executor = AsyncMock()
+    mock_executor.execute = AsyncMock()
+    mock_executor_cls.return_value = mock_executor
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    # Verify executor.execute was called with unix_username
+    assert mock_executor.execute.call_count == 1
+    call_kwargs = mock_executor.execute.call_args
+    # unix_username should be passed as keyword argument
+    assert call_kwargs.kwargs.get("unix_username") == "alice_unix" or (
+        len(call_kwargs.args) >= 7 and call_kwargs.args[6] == "alice_unix"
+    )


### PR DESCRIPTION
## Summary
- All Docker commands (build, run, rm, cp, image rm, builder prune) execute via `sudo -u {unix_username}`
- `docker run` includes `--label ds01.interface=api` for container type identification
- Per-container resource limits (`--memory`, `--shm-size`, `--pids-limit`, `--cpus`) read from `get_resource_limits.py --docker-args` (strips `--cgroup-parent` to avoid double injection)
- Runner queries `unix_username` from jobs table and passes to executor

**Part 3 of 3** for ds01-infra container integration. Stacked on #43.

## Context
By running Docker as the submitting Unix user via `sudo -u`, the ds01-infra Docker wrapper automatically handles labels, cgroup placement, GPU allocation, and event logging — zero ds01-infra changes needed.

## Test plan
- [ ] All Docker commands prefixed with `sudo -u {unix_username}`
- [ ] Resource limits from `get_resource_limits.py` appear in `docker run` (minus `--cgroup-parent`)
- [ ] `--label ds01.interface=api` on `docker run` only (not build)
- [ ] Runner passes `unix_username` to executor
- [ ] Full unit test suite passes
- [ ] CI passes