### PR TITLE
feat: add systemd units, sudoers drop-in, and env template

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -1,0 +1,24 @@
+# /etc/ds01-jobs/env - Environment configuration for ds01-jobs services
+# Permissions: 0600 root:root (systemd reads before dropping privileges)
+
+# Database
+DS01_JOBS_DB_PATH=/opt/ds01-jobs/data/jobs.db
+
+# API server
+DS01_JOBS_API_HOST=127.0.0.1
+DS01_JOBS_API_PORT=8765
+
+# Workspace for job working directories
+DS01_JOBS_WORKSPACE_ROOT=/var/lib/ds01-jobs/workspaces
+
+# ds01-infra resource limits config
+DS01_JOBS_RESOURCE_LIMITS_PATH=/opt/ds01-infra/config/runtime/resource-limits.yaml
+
+# ds01-infra resource limits query script
+DS01_JOBS_GET_RESOURCE_LIMITS_BIN=/opt/ds01-infra/scripts/docker/get_resource_limits.py
+
+# Docker binary (ds01-infra wrapper)
+DS01_JOBS_DOCKER_BIN=/usr/local/bin/docker
+
+# Cloudflare Tunnel token (set on first deploy)
+TUNNEL_TOKEN=

--- a/config/sudoers.d/ds01-jobs
+++ b/config/sudoers.d/ds01-jobs
@@ -1,0 +1,5 @@
+# /etc/sudoers.d/ds01-jobs
+# Allow ds01 service user to run Docker wrapper as any user
+# Required for: sudo -u {unix_username} /usr/local/bin/docker ...
+# Deployed by: /opt/ds01-jobs/deploy.sh
+ds01 ALL=(ALL) NOPASSWD: /usr/local/bin/docker

--- a/systemd/ds01-api.service
+++ b/systemd/ds01-api.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=DS01 Job Submission API
+Documentation=file:///opt/ds01-jobs/README.md
+After=network.target
+
+[Service]
+Type=simple
+User=ds01
+Group=ds01
+WorkingDirectory=/opt/ds01-jobs
+ExecStart=/opt/ds01-jobs/.venv/bin/uvicorn ds01_jobs.app:app --host 127.0.0.1 --port 8765
+Restart=always
+RestartSec=5
+EnvironmentFile=/etc/ds01-jobs/env
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ds01-api
+
+# Hardening
+ProtectSystem=full
+ReadWritePaths=/opt/ds01-jobs/data /var/log/ds01 /var/lib/ds01-jobs
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ds01-cloudflared.service
+++ b/systemd/ds01-cloudflared.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=DS01 Cloudflare Tunnel
+After=network.target ds01-api.service
+Requires=ds01-api.service
+
+[Service]
+Type=simple
+User=ds01
+Group=ds01
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0; sleep 1; done; echo "API not ready after 30s"; exit 1'
+ExecStart=/usr/bin/cloudflared --no-autoupdate tunnel run
+Restart=always
+RestartSec=5
+EnvironmentFile=/etc/ds01-jobs/env
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ds01-cloudflared
+
+# Hardening
+ProtectSystem=strict
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ds01-runner.service
+++ b/systemd/ds01-runner.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=DS01 Job Runner
+Documentation=file:///opt/ds01-jobs/README.md
+After=network.target docker.service
+Wants=docker.service
+
+[Service]
+Type=simple
+User=ds01
+Group=ds01
+WorkingDirectory=/opt/ds01-jobs
+ExecStart=/opt/ds01-jobs/.venv/bin/ds01-job-runner
+Restart=always
+RestartSec=5
+KillMode=process
+EnvironmentFile=/etc/ds01-jobs/env
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ds01-runner
+
+# Hardening (relaxed - needs Docker/sudo access)
+ProtectSystem=full
+ReadWritePaths=/opt/ds01-jobs/data /var/log/ds01 /var/lib/ds01-jobs
+PrivateTmp=true
+NoNewPrivileges=false
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Add three systemd service units (`ds01-api`, `ds01-runner`, `ds01-cloudflared`) following ds01-infra conventions (journal logging, SyslogIdentifier, Restart=always)
- Cloudflared unit gates on API health via ExecStartPre 30s check loop
- Runner unit uses KillMode=process and NoNewPrivileges=false for sudo -u Docker execution
- Sudoers drop-in grants ds01 user NOPASSWD access to Docker wrapper
- Environment file template documents all DS01_JOBS_ variables plus TUNNEL_TOKEN

## Files

| File | Purpose |
|------|---------|
| `systemd/ds01-api.service` | FastAPI/uvicorn on 127.0.0.1:8765 |
| `systemd/ds01-runner.service` | Job runner with Docker container preservation |
| `systemd/ds01-cloudflared.service` | Cloudflare Tunnel with API dependency |
| `config/sudoers.d/ds01-jobs` | Passwordless Docker wrapper for ds01 user |
| `config/env.example` | Template for /etc/ds01-jobs/env |

## Test plan

- [ ] Review unit file directives against ds01-infra conventions
- [ ] Verify cloudflared ExecStartPre health check logic
- [ ] Confirm sudoers syntax (no tabs, trailing newline)
- [ ] Check env.example covers all Settings fields