### PR TITLE
feat: implement deploy.sh and add lifecycle integration test

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,355 @@
 #!/usr/bin/env bash
-# deploy.sh -- ds01-jobs deployment script
-# Stub for Phase 1. Full implementation in Phase 7 (DEP-01 through DEP-05).
-echo "deploy.sh: not yet implemented (Phase 7)"
-exit 1
+# deploy.sh - ds01-jobs deployment script
+#
+# Single entry point for installing and upgrading ds01-jobs on the production
+# server. Run as root: sudo ./deploy.sh
+#
+# Idempotent - safe to run repeatedly. Handles both first-time setup and
+# upgrades. Requires a clean git working tree.
+#
+# Usage:
+#   sudo ./deploy.sh              # Interactive deployment
+#   sudo ./deploy.sh --yes        # Skip confirmations (for CI)
+#   sudo ./deploy.sh --dry-run    # Preview only, no changes
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="/opt/ds01-jobs"
+ENV_FILE="/etc/ds01-jobs/env"
+DB_PATH="$INSTALL_DIR/data/jobs.db"
+LOG_FILE="/tmp/ds01-jobs-deploy-$(date '+%Y%m%d-%H%M%S').log"
+SERVICES=(ds01-api ds01-runner ds01-cloudflared)
+UV_BIN=""
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+YES=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --yes)    YES=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        -h|--help)
+            echo "Usage: sudo ./deploy.sh [--yes] [--dry-run]"
+            echo ""
+            echo "Options:"
+            echo "  --yes       Skip all confirmation prompts"
+            echo "  --dry-run   Preview steps without making changes"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: sudo ./deploy.sh [--yes] [--dry-run]"
+            exit 1
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+fail() {
+    log "FAIL: $*"
+    exit 1
+}
+
+confirm() {
+    $YES && return 0
+    local prompt="$1"
+    read -rp "$prompt [y/N] " answer
+    [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+step() {
+    local name="$1"; shift
+    log "STEP: $name"
+    if $DRY_RUN; then
+        log "  (dry-run: skipped)"
+        return 0
+    fi
+    if "$@"; then
+        log "  PASS: $name"
+    else
+        log "  FAIL: $name"
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-deploy checks (always run, even in dry-run)
+# ---------------------------------------------------------------------------
+check_root() {
+    [[ $EUID -eq 0 ]] || fail "Must run as root (sudo ./deploy.sh)"
+}
+
+check_git_clean() {
+    git -C "$SCRIPT_DIR" diff --quiet && git -C "$SCRIPT_DIR" diff --cached --quiet \
+        || fail "Uncommitted changes detected. Commit or stash before deploying."
+}
+
+check_uv() {
+    # Check PATH first
+    if command -v uv &>/dev/null; then
+        UV_BIN="$(command -v uv)"
+        log "Found uv at $UV_BIN"
+        return 0
+    fi
+
+    # Check common locations
+    local candidates=(
+        /usr/local/bin/uv
+        /usr/bin/uv
+    )
+
+    # Check user-local locations
+    for user_home in /home/datasciencelab ~datasciencelab; do
+        if [[ -d "$user_home" ]]; then
+            candidates+=(
+                "$user_home/.local/bin/uv"
+                "$user_home/.cargo/bin/uv"
+                "$user_home/anaconda3/bin/uv"
+            )
+        fi
+    done
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -x "$candidate" ]]; then
+            UV_BIN="$candidate"
+            log "Found uv at $UV_BIN"
+            return 0
+        fi
+    done
+
+    fail "uv not found. Checked PATH and common locations."
+}
+
+check_active_jobs() {
+    if [[ -f "$DB_PATH" ]]; then
+        local count
+        count=$(sqlite3 "$DB_PATH" \
+            "SELECT COUNT(*) FROM jobs WHERE status IN ('cloning','building','running')" \
+            2>/dev/null || echo "0")
+        if [[ "$count" -gt 0 ]]; then
+            log "WARNING: $count active job(s) running:"
+            sqlite3 -column -header "$DB_PATH" \
+                "SELECT id, status, repo_url, created_at FROM jobs WHERE status IN ('cloning','building','running')" \
+                2>/dev/null || true
+            confirm "Continue deployment? Active jobs will be interrupted." || {
+                log "Deployment cancelled by user."
+                exit 0
+            }
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Deployment steps
+# ---------------------------------------------------------------------------
+setup_system_user() {
+    if id ds01 &>/dev/null; then
+        log "  User ds01 already exists"
+    else
+        useradd --system --shell /usr/sbin/nologin --home-dir /opt/ds01-jobs ds01
+        log "  Created system user ds01"
+    fi
+    usermod -aG docker ds01 2>/dev/null || true
+    log "  Ensured ds01 is in docker group"
+}
+
+setup_directories() {
+    mkdir -p /etc/ds01-jobs
+    chmod 0755 /etc/ds01-jobs
+
+    mkdir -p /opt/ds01-jobs/data
+    chown ds01:ds01 /opt/ds01-jobs/data
+
+    mkdir -p /var/lib/ds01-jobs/workspaces
+    chown ds01:ds01 /var/lib/ds01-jobs
+    chown ds01:ds01 /var/lib/ds01-jobs/workspaces
+
+    mkdir -p /var/log/ds01
+    touch /var/log/ds01/events.jsonl
+    chown ds01:ds01 /var/log/ds01/events.jsonl
+
+    log "  Directories and permissions configured"
+}
+
+setup_env_file() {
+    if [[ ! -f "$ENV_FILE" ]]; then
+        cp "$SCRIPT_DIR/config/env.example" "$ENV_FILE"
+        log "  Created $ENV_FILE from template"
+    else
+        log "  $ENV_FILE already exists (preserved)"
+    fi
+
+    # Check if TUNNEL_TOKEN is empty
+    if grep -q '^TUNNEL_TOKEN=$' "$ENV_FILE" 2>/dev/null; then
+        if $YES; then
+            log "  WARNING: TUNNEL_TOKEN is empty in $ENV_FILE - set it manually"
+        elif ! $DRY_RUN; then
+            echo ""
+            echo "Cloudflare Tunnel token is not set."
+            echo "Get it from the Cloudflare Zero Trust dashboard -> Networks -> Tunnels."
+            read -rsp "Enter tunnel token (input hidden): " token
+            echo ""
+            if [[ -n "$token" ]]; then
+                sed -i "s|^TUNNEL_TOKEN=$|TUNNEL_TOKEN=$token|" "$ENV_FILE"
+                log "  Tunnel token written to $ENV_FILE"
+            else
+                log "  WARNING: No token entered - TUNNEL_TOKEN remains empty"
+            fi
+        fi
+    fi
+
+    chmod 0600 "$ENV_FILE"
+    chown root:root "$ENV_FILE"
+    log "  $ENV_FILE permissions set to 0600 root:root"
+}
+
+install_cloudflared() {
+    if command -v cloudflared &>/dev/null; then
+        log "  cloudflared already installed ($(cloudflared --version 2>&1 | head -1))"
+        return 0
+    fi
+
+    log "  Installing cloudflared from apt repository..."
+    mkdir -p --mode=0755 /usr/share/keyrings
+    curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+        | tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+    echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main' \
+        | tee /etc/apt/sources.list.d/cloudflared.list >/dev/null
+    apt-get update -qq
+    apt-get install -y cloudflared
+    log "  cloudflared installed ($(cloudflared --version 2>&1 | head -1))"
+}
+
+setup_python_env() {
+    log "  Running uv sync --locked..."
+    cd "$INSTALL_DIR"
+    "$UV_BIN" sync --locked
+    cd - >/dev/null
+
+    # Verify entrypoints
+    local entrypoints=(ds01-job-admin ds01-job-runner ds01-submit)
+    for ep in "${entrypoints[@]}"; do
+        if [[ ! -x "$INSTALL_DIR/.venv/bin/$ep" ]]; then
+            fail "Entrypoint $ep not found in .venv/bin/"
+        fi
+    done
+    log "  Python environment ready, all entrypoints verified"
+}
+
+install_sudoers() {
+    cp "$SCRIPT_DIR/config/sudoers.d/ds01-jobs" /etc/sudoers.d/ds01-jobs
+    chmod 0440 /etc/sudoers.d/ds01-jobs
+    visudo -cf /etc/sudoers.d/ds01-jobs || fail "Sudoers file validation failed"
+    log "  Sudoers drop-in installed and validated"
+}
+
+install_systemd_units() {
+    cp "$SCRIPT_DIR/systemd/ds01-api.service" /etc/systemd/system/
+    cp "$SCRIPT_DIR/systemd/ds01-runner.service" /etc/systemd/system/
+    cp "$SCRIPT_DIR/systemd/ds01-cloudflared.service" /etc/systemd/system/
+    log "  Systemd unit files copied"
+
+    systemctl daemon-reload
+    log "  systemctl daemon-reload complete"
+
+    systemctl enable ds01-api ds01-runner ds01-cloudflared
+    log "  Services enabled"
+
+    systemctl restart ds01-api ds01-runner ds01-cloudflared
+    log "  Services restarted"
+}
+
+verify_health() {
+    log "Verifying deployment..."
+
+    # Check all services are active
+    local all_active=true
+    for svc in "${SERVICES[@]}"; do
+        if systemctl is-active --quiet "$svc"; then
+            log "  $svc: active"
+        else
+            log "  $svc: INACTIVE"
+            journalctl -u "$svc" --no-pager -n 10 2>/dev/null || true
+            all_active=false
+        fi
+    done
+
+    if ! $all_active; then
+        fail "One or more services failed to start"
+    fi
+
+    # Wait for API health endpoint
+    local health=""
+    for i in $(seq 1 10); do
+        health=$(curl -sf http://127.0.0.1:8765/health 2>/dev/null) && break
+        sleep 1
+    done
+
+    if echo "$health" | grep -q '"status":"ok"'; then
+        log "  /health: ok"
+    else
+        fail "API health check failed: ${health:-no response}"
+    fi
+
+    log "Deployment verified successfully"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    log "=== ds01-jobs deployment started ==="
+    log "Script directory: $SCRIPT_DIR"
+    log "Install directory: $INSTALL_DIR"
+    log "Flags: --yes=$YES --dry-run=$DRY_RUN"
+
+    # Pre-deploy checks (always run)
+    log "--- Pre-deploy checks ---"
+    check_root
+    log "  Root check: PASS"
+    check_git_clean
+    log "  Git clean check: PASS"
+    check_uv
+    check_active_jobs
+
+    if $DRY_RUN; then
+        log ""
+        log "--- Dry-run preview ---"
+        log "The following steps would be executed:"
+    fi
+
+    # Deployment steps
+    step "Create system user"       setup_system_user
+    step "Setup directories"        setup_directories
+    step "Setup environment file"   setup_env_file
+    step "Install cloudflared"      install_cloudflared
+    step "Setup Python environment" setup_python_env
+    step "Install sudoers drop-in"  install_sudoers
+    step "Install systemd units"    install_systemd_units
+
+    if ! $DRY_RUN; then
+        verify_health
+    else
+        log ""
+        log "STEP: Verify deployment health"
+        log "  (dry-run: skipped)"
+    fi
+
+    log ""
+    log "=== Deployment complete ==="
+    log "Deploy log: $LOG_FILE"
+}
+
+main

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -1,0 +1,137 @@
+"""Full job lifecycle integration test - requires GPU runner (Tier 2).
+
+Exercises the complete pipeline on the self-hosted GPU runner:
+    key-create -> submit -> poll -> verify succeeded -> download results
+
+Prerequisites:
+    - ds01-jobs API running at http://127.0.0.1:8765
+    - ds01-job-runner active and connected
+    - Docker available with GPU access
+    - Test repo https://github.com/hertie-data-science-lab/ds01-test-job must exist
+      with a Dockerfile that runs ``nvidia-smi > /output/gpu.txt``
+
+If the test repo does not exist yet, the test will fail with a clear clone
+error. Creating the repo is a separate manual step.
+
+Marked ``@pytest.mark.integration`` so it only runs on the self-hosted GPU
+runner via Tier 2 CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+# Known minimal test repo - Dockerfile runs nvidia-smi and writes to /output/
+TEST_REPO_URL = "https://github.com/hertie-data-science-lab/ds01-test-job"
+
+API_BASE_URL = "http://127.0.0.1:8765"
+
+# Maximum time to wait for a job to reach a terminal state (seconds)
+POLL_TIMEOUT = 300
+
+# Backoff parameters for polling (seconds)
+INITIAL_BACKOFF = 2
+MAX_BACKOFF = 30
+
+
+def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess with merged environment and return the result."""
+    merged_env = {**os.environ, **(env or {})}
+    return subprocess.run(args, capture_output=True, text=True, env=merged_env)
+
+
+@pytest.fixture()
+def api_key() -> str:
+    """Create a temporary API key for the lifecycle test.
+
+    Uses ``ds01-job-admin key-create`` to create a key for a test user.
+    Tears down by revoking the key after the test.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    test_username = f"test-lifecycle-{suffix}"
+
+    # Create a key using --json for reliable parsing
+    result = _run(["ds01-job-admin", "key-create", test_username, "--json"])
+    assert result.returncode == 0, f"key-create failed: {result.stderr}"
+
+    data = json.loads(result.stdout)
+    raw_key = data["key"]
+
+    yield raw_key
+
+    # Teardown: revoke the key
+    _run(["ds01-job-admin", "key-revoke", test_username, "--yes"])
+
+
+@pytest.fixture()
+def api_base_url() -> str:
+    """Return the local API base URL."""
+    return API_BASE_URL
+
+
+def test_full_job_lifecycle(
+    api_key: str,
+    api_base_url: str,
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """Submit a job, wait for completion, verify success, download results."""
+    env = {
+        "DS01_API_KEY": api_key,
+        "DS01_API_URL": api_base_url,
+    }
+
+    # 1. Submit a job via ds01-submit run
+    result = _run(["ds01-submit", "run", TEST_REPO_URL, "--json"], env=env)
+    assert result.returncode == 0, f"Job submission failed: {result.stderr}"
+
+    submit_data = json.loads(result.stdout)
+    job_id = submit_data["job_id"]
+    assert job_id, "No job_id returned from submission"
+
+    # 2. Poll status until terminal state (max 5 minutes)
+    backoff = INITIAL_BACKOFF
+    deadline = time.monotonic() + POLL_TIMEOUT
+    final_status = None
+
+    while time.monotonic() < deadline:
+        result = _run(["ds01-submit", "status", job_id, "--json"], env=env)
+        assert result.returncode in (0, 2), f"Status check failed: {result.stderr}"
+
+        status_data = json.loads(result.stdout)
+        current_status = status_data["status"]
+
+        if current_status in ("succeeded", "failed"):
+            final_status = current_status
+            break
+
+        time.sleep(backoff)
+        backoff = min(backoff * 2, MAX_BACKOFF)
+    else:
+        pytest.fail(f"Job {job_id} did not reach terminal state within {POLL_TIMEOUT}s")
+
+    # 3. Assert the job succeeded
+    assert final_status == "succeeded", (
+        f"Job {job_id} ended with status '{final_status}', expected 'succeeded'. "
+        f"Status data: {json.dumps(status_data, indent=2)}"
+    )
+
+    # 4. Download results
+    output_dir = tmp_path / "results"
+    result = _run(
+        ["ds01-submit", "results", job_id, "-o", str(output_dir)],
+        env=env,
+    )
+    assert result.returncode == 0, f"Results download failed: {result.stderr}"
+
+    # 5. Verify output directory is not empty
+    assert output_dir.exists(), f"Output directory {output_dir} does not exist"
+    result_files = list(output_dir.rglob("*"))
+    assert len(result_files) > 0, f"Output directory {output_dir} is empty"


### PR DESCRIPTION
## Summary

- Replace deploy.sh stub with full 355-line idempotent deployment script covering: pre-deploy safety checks (root, clean git, uv, active jobs), system user/directory setup, env file management with tunnel token prompt, cloudflared apt installation, uv sync, sudoers with visudo validation, systemd unit installation, and post-deploy health verification
- Add Tier 2 lifecycle integration test exercising the full job pipeline (key-create -> submit -> poll -> verify -> results) via real CLI subprocesses with exponential backoff polling

**Depends on:** #46 (systemd units and config artefacts that deploy.sh copies to the server)

## Files

| File | Purpose |
|------|---------|
| `deploy.sh` | Idempotent deployment script (--yes, --dry-run) |
| `tests/integration/test_lifecycle.py` | Full pipeline integration test for GPU runner |

## Test plan

- [ ] `bash -n deploy.sh` passes (valid syntax)
- [ ] `deploy.sh --dry-run` previews all steps without mutations
- [ ] Review deploy.sh handles all edge cases (no uv, active jobs, missing token)
- [ ] `python -c "import ast; ast.parse(open('tests/integration/test_lifecycle.py').read())"` passes
- [ ] Lifecycle test runs on Tier 2 GPU runner (post-merge)