### PR TITLE
feat: wire sudo -u and resource limits into executor

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,29 @@
+# Project State
+
+## Current Phase
+
+Phase 07.1 - Documentation (pending start)
+
+## Decisions
+
+- unix_username stored as executor instance state (_unix_username) for cleanup/collect methods
+- Graceful fallback when unix_username is empty - docker commands run without sudo prefix
+- Resource limits subprocess has 5s timeout with empty-list fallback on failure
+- --label ds01.interface=api only on docker run, not docker build
+
+## Roadmap Evolution
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-12 | Inserted phase 07.1-documentation after phase 07-deployment | Update README and project docs to reflect the complete v1.0 feature set: architecture overview, deployment instructions (deploy.sh), submit CLI (ds01-submit), API endpoints, configuration reference, and env setup |
+
+## Last Session
+
+- **Stopped at:** Completed 06.1-02-PLAN.md (executor sudo-u, resource limits, interface label, runner unix_username propagation)
+- **Timestamp:** 2026-03-12T13:18:46Z
+
+## Performance Metrics
+
+| Phase | Plan | Duration | Tasks | Files |
+|-------|------|----------|-------|-------|
+| 06.1 | 02 | 7min | 2 | 4 |

--- a/.planning/phases/06.1-ds01-infra-container-integration/06.1-02-SUMMARY.md
+++ b/.planning/phases/06.1-ds01-infra-container-integration/06.1-02-SUMMARY.md
@@ -1,0 +1,131 @@
+---
+phase: 06.1-ds01-infra-container-integration
+plan: 02
+subsystem: infra
+tags: [docker, sudo, resource-limits, subprocess, container-lifecycle]
+
+# Dependency graph
+requires:
+  - phase: 06.1-01
+    provides: "dual identity model (github_username + unix_username in DB), get_resource_limits_bin setting"
+provides:
+  - "sudo -u Docker execution for all commands (build, run, rm, cp, image rm, prune)"
+  - "per-container resource limits from get_resource_limits.py"
+  - "--label ds01.interface=api on docker run"
+  - "unix_username propagation from runner to executor"
+affects: [07-deployment, rate-limiting]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: ["sudo -u subprocess prefix for Docker", "resource limits via external script subprocess", "cgroup-parent stripping"]
+
+key-files:
+  created: []
+  modified:
+    - src/ds01_jobs/executor.py
+    - src/ds01_jobs/runner.py
+    - tests/unit/test_executor.py
+    - tests/unit/test_runner.py
+
+key-decisions:
+  - "unix_username stored as instance state (_unix_username) for use by _cleanup and _collect_results"
+  - "Graceful fallback when unix_username is empty - uses docker_bin directly without sudo"
+  - "Resource limits fetch has 5s timeout with empty-list fallback on any failure"
+  - "--label ds01.interface=api only on docker run, not docker build (per wrapper behaviour)"
+
+patterns-established:
+  - "_sudo_docker helper returns ['sudo', '-u', unix_username, docker_bin] prefix for all Docker commands"
+  - "_get_resource_limits async subprocess call with cgroup-parent stripping"
+
+requirements-completed: [INFRA-SUDO, INFRA-LIMITS, INFRA-EVENTS]
+
+# Metrics
+duration: 7min
+completed: 2026-03-12
+---
+
+# Phase 06.1 Plan 02: Executor sudo-u, Resource Limits, and Interface Label Summary
+
+**sudo -u Docker execution with per-user resource limits from get_resource_limits.py and ds01.interface=api label for container type identification**
+
+## Performance
+
+- **Duration:** 7 min
+- **Started:** 2026-03-12T13:11:51Z
+- **Completed:** 2026-03-12T13:18:46Z
+- **Tasks:** 2
+- **Files modified:** 4
+
+## Accomplishments
+- All Docker commands (build, run, rm, cp, image rm, builder prune) execute via sudo -u {unix_username}
+- docker run includes --label ds01.interface=api and per-user resource limits from get_resource_limits.py
+- Runner queries unix_username from jobs table and passes to executor, completing the data flow: api_keys -> jobs -> runner -> executor -> sudo -u docker
+- 19 executor tests and 8 runner tests all pass, including 7 new tests for sudo prefix, interface label, resource limits, cgroup-parent stripping, and unix_username propagation
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Executor sudo -u, resource limits, and interface label** - `b1f8ce3` (feat)
+2. **Task 2: Runner unix_username propagation and integration** - `47e5096` (feat)
+
+## Files Created/Modified
+- `src/ds01_jobs/executor.py` - Added _sudo_docker helper, _get_resource_limits async method, unix_username parameter to execute/build/run, sudo -u prefix on all Docker commands, --label ds01.interface=api on run, resource limits with cgroup-parent stripping
+- `src/ds01_jobs/runner.py` - SQL query includes unix_username, executor.execute() called with unix_username=row["unix_username"]
+- `tests/unit/test_executor.py` - Updated existing tests with unix_username, added tests for sudo prefix, interface label, resource limits, cgroup-parent stripping, failure fallback, cleanup sudo, collect results sudo
+- `tests/unit/test_runner.py` - Updated fixture inserts with unix_username, added test_poll_passes_unix_username_to_executor
+
+## Decisions Made
+- Used instance state `self._unix_username` for methods that don't receive unix_username as a parameter (_cleanup, _collect_results, kill_current_process). Cleared in the finally block of execute().
+- Graceful fallback when unix_username is empty string - uses docker_bin directly without sudo prefix. This keeps backward compatibility with any code that doesn't pass unix_username.
+- Resource limits subprocess call wrapped in asyncio.wait_for with 5s timeout, returns empty list on any failure (TimeoutError, FileNotFoundError, OSError, non-zero exit).
+- Catches Python 3.11+ TimeoutError (which subsumes asyncio.TimeoutError) in _get_resource_limits exception handler.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed test side_effect sequences for _get_resource_limits subprocess call**
+- **Found during:** Task 1 (test execution)
+- **Issue:** With unix_username provided, _run_container now calls _get_resource_limits which is an additional create_subprocess_exec call. Tests using side_effect lists had incorrect process counts, causing the wrong mock to be consumed by the wrong call.
+- **Fix:** Added resource_limits process to side_effect lists for tests that proceed past the build phase (test_execute_run_failure, test_execute_clone_failure_retries).
+- **Files modified:** tests/unit/test_executor.py
+- **Verification:** All 19 executor tests pass
+- **Committed in:** b1f8ce3 (Task 1 commit)
+
+**2. [Rule 1 - Bug] Fixed test_docker_bin_path_used for python3 subprocess call**
+- **Found during:** Task 1 (test execution)
+- **Issue:** The _get_resource_limits method calls create_subprocess_exec with "python3" as the first arg, which doesn't contain docker_bin. The test assertion expected all non-git calls to contain docker_bin.
+- **Fix:** Added "python3" to the skip list alongside "git" in test_docker_bin_path_used.
+- **Files modified:** tests/unit/test_executor.py
+- **Verification:** Test passes
+- **Committed in:** b1f8ce3 (Task 1 commit)
+
+**3. [Rule 1 - Bug] Fixed async mock for _get_resource_limits tests**
+- **Found during:** Task 1 (test execution)
+- **Issue:** Tests for _get_resource_limits used a synchronous lambda to mock asyncio.wait_for, causing TypeError when the coroutine was returned without being awaited.
+- **Fix:** Replaced lambda with async passthrough_wait_for function that properly awaits the coroutine.
+- **Files modified:** tests/unit/test_executor.py
+- **Verification:** Both resource limits tests pass
+- **Committed in:** b1f8ce3 (Task 1 commit)
+
+---
+
+**Total deviations:** 3 auto-fixed (3 bugs in test mocking)
+**Impact on plan:** All auto-fixes necessary for test correctness. No scope creep.
+
+## Issues Encountered
+None beyond the test mock adjustments documented above.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Executor and runner fully wired for ds01-infra container integration
+- Sudoers entry (`ds01 ALL=(ALL) NOPASSWD: /usr/local/bin/docker`) needed on deployment (Phase 07)
+- Rate limiting fix (get_resource_limits.py --group) is a separate plan concern
+
+---
+*Phase: 06.1-ds01-infra-container-integration*
+*Completed: 2026-03-12*

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -19,7 +19,7 @@ import httpx
 import typer
 
 from ds01_jobs.config import Settings
-from ds01_jobs.database import SCHEMA_SQL, get_db_sync
+from ds01_jobs.database import _MIGRATIONS, SCHEMA_SQL, get_db_sync
 
 app = typer.Typer(
     name="ds01-job-admin",
@@ -164,8 +164,14 @@ def check_org_membership(username: str, org: str) -> bool:
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
-    """Ensure the api_keys table exists."""
+    """Ensure the api_keys table exists and apply any pending migrations."""
     conn.executescript(SCHEMA_SQL)
+    for stmt in _MIGRATIONS:
+        try:
+            conn.execute(stmt)
+        except sqlite3.OperationalError:
+            pass  # column already exists
+    conn.commit()
 
 
 def _get_active_key(conn: sqlite3.Connection, username: str) -> sqlite3.Row | None:

--- a/src/ds01_jobs/database.py
+++ b/src/ds01_jobs/database.py
@@ -53,8 +53,13 @@ CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
 CREATE INDEX IF NOT EXISTS idx_jobs_username_status ON jobs(username, status);
 CREATE INDEX IF NOT EXISTS idx_jobs_username_created ON jobs(username, created_at);
 """
-# Note: Schema uses CREATE TABLE IF NOT EXISTS. For pre-v1 development,
-# drop and recreate the DB if columns are missing after schema changes.
+
+# Migrations for columns added after initial schema. ALTER TABLE ADD COLUMN
+# is a no-op if the column already exists (we catch the OperationalError).
+_MIGRATIONS = [
+    "ALTER TABLE api_keys ADD COLUMN unix_username TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE jobs ADD COLUMN unix_username TEXT NOT NULL DEFAULT ''",
+]
 
 
 @lru_cache(maxsize=1)
@@ -75,6 +80,11 @@ async def init_db(db_path: Path | None = None) -> None:
     async with aiosqlite.connect(path) as db:
         await db.execute("PRAGMA journal_mode=WAL")
         await db.executescript(SCHEMA_SQL)
+        for stmt in _MIGRATIONS:
+            try:
+                await db.execute(stmt)
+            except aiosqlite.OperationalError:
+                pass  # column already exists
         await db.commit()
 
 

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -39,6 +39,41 @@ class JobExecutor:
     def __init__(self, settings: Settings) -> None:
         self.settings = settings
         self._current_process: asyncio.subprocess.Process | None = None
+        self._unix_username: str = ""
+
+    def _sudo_docker(self, unix_username: str) -> list[str]:
+        """Return the sudo -u {unix_username} docker prefix."""
+        return ["sudo", "-u", unix_username, str(self.settings.docker_bin)]
+
+    async def _get_resource_limits(self, unix_username: str) -> list[str]:
+        """Get Docker resource limit args from get_resource_limits.py.
+
+        Returns a list of Docker CLI args (e.g. ['--memory=32g', '--shm-size=16g']).
+        Strips --cgroup-parent since the Docker wrapper injects it automatically.
+        Returns empty list on failure (job runs with wrapper defaults).
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "python3",
+                str(self.settings.get_resource_limits_bin),
+                unix_username,
+                "--docker-args",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+            if proc.returncode != 0:
+                logger.warning(
+                    "get_resource_limits.py failed for %s: %s",
+                    unix_username,
+                    stderr.decode().strip(),
+                )
+                return []
+            args = stdout.decode().strip().split()
+            return [a for a in args if not a.startswith("--cgroup-parent=")]
+        except (TimeoutError, FileNotFoundError, OSError) as exc:
+            logger.warning("get_resource_limits.py error for %s: %s", unix_username, exc)
+            return []
 
     async def execute(
         self,
@@ -48,6 +83,7 @@ class JobExecutor:
         gpu_count: int,
         timeout_seconds: int | None,
         db_path: Path,
+        unix_username: str = "",
     ) -> None:
         """Run a job through the full execution pipeline.
 
@@ -58,7 +94,9 @@ class JobExecutor:
             gpu_count: Number of GPUs requested.
             timeout_seconds: Job run timeout (None = use default).
             db_path: Path to the SQLite database.
+            unix_username: Unix username for sudo -u Docker execution.
         """
+        self._unix_username = unix_username
         workspace = self.settings.workspace_root / job_id
         workspace.mkdir(parents=True, exist_ok=True)
 
@@ -78,8 +116,10 @@ class JobExecutor:
                 await db.commit()
 
             await self._clone(job_id, repo_url, branch, workspace, db_path)
-            await self._build(job_id, workspace, db_path)
-            await self._run_container(job_id, workspace, gpu_count, timeout_seconds, db_path)
+            await self._build(job_id, workspace, db_path, unix_username)
+            await self._run_container(
+                job_id, workspace, gpu_count, timeout_seconds, db_path, unix_username
+            )
             await self._collect_results(job_id, workspace)
 
             # Success
@@ -106,6 +146,7 @@ class JobExecutor:
             )
         finally:
             await self._cleanup(job_id)
+            self._unix_username = ""
 
     async def _update_status(
         self,
@@ -256,7 +297,9 @@ class JobExecutor:
             if exit_code != 0:
                 raise PhaseError("clone", exit_code, "Clone failed after retry")
 
-    async def _build(self, job_id: str, workspace: Path, db_path: Path) -> None:
+    async def _build(
+        self, job_id: str, workspace: Path, db_path: Path, unix_username: str = ""
+    ) -> None:
         """Build Docker image from the repo Dockerfile."""
         if await self._check_cancelled(db_path, job_id):
             raise PhaseError("build", -1, "Job cancelled before build")
@@ -264,8 +307,12 @@ class JobExecutor:
         await self._update_status(db_path, job_id, "building")
 
         image_tag = f"ds01-job-{job_id}"
+        if unix_username:
+            docker_prefix = self._sudo_docker(unix_username)
+        else:
+            docker_prefix = [str(self.settings.docker_bin)]
         cmd = [
-            str(self.settings.docker_bin),
+            *docker_prefix,
             "build",
             "-t",
             image_tag,
@@ -292,6 +339,7 @@ class JobExecutor:
         gpu_count: int,
         timeout_seconds: int | None,
         db_path: Path,
+        unix_username: str = "",
     ) -> None:
         """Run the Docker container with GPU access."""
         if await self._check_cancelled(db_path, job_id):
@@ -310,11 +358,22 @@ class JobExecutor:
         )
         resolved_timeout = min(resolved_timeout, self.settings.max_job_timeout_seconds)
 
+        # Get per-user resource limits
+        resource_args: list[str] = []
+        if unix_username:
+            resource_args = await self._get_resource_limits(unix_username)
+            docker_prefix = self._sudo_docker(unix_username)
+        else:
+            docker_prefix = [str(self.settings.docker_bin)]
+
         cmd = [
-            str(self.settings.docker_bin),
+            *docker_prefix,
             "run",
             "--name",
             container_name,
+            "--label",
+            "ds01.interface=api",
+            *resource_args,
             "--gpus",
             "all",
             image_tag,
@@ -335,8 +394,14 @@ class JobExecutor:
         results_dir = workspace / "results"
         results_dir.mkdir(exist_ok=True)
 
+        unix_username = self._unix_username
+        if unix_username:
+            docker_prefix = self._sudo_docker(unix_username)
+        else:
+            docker_prefix = [str(self.settings.docker_bin)]
+
         proc = await asyncio.create_subprocess_exec(
-            str(self.settings.docker_bin),
+            *docker_prefix,
             "cp",
             f"{container_name}:/output/.",
             str(results_dir),
@@ -350,12 +415,16 @@ class JobExecutor:
 
     async def _cleanup(self, job_id: str) -> None:
         """Remove container, image, and prune build cache."""
-        docker = str(self.settings.docker_bin)
+        unix_username = self._unix_username
+        if unix_username:
+            docker_prefix = self._sudo_docker(unix_username)
+        else:
+            docker_prefix = [str(self.settings.docker_bin)]
 
         # Remove container
         try:
             proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "rm",
                 "-f",
                 f"ds01-job-{job_id}",
@@ -369,7 +438,7 @@ class JobExecutor:
         # Remove image
         try:
             proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "image",
                 "rm",
                 "-f",
@@ -384,7 +453,7 @@ class JobExecutor:
         # Prune build cache
         try:
             proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "builder",
                 "prune",
                 "--force",
@@ -411,10 +480,14 @@ class JobExecutor:
             await proc.wait()
 
         # Also force-remove any Docker container (survives process group kill)
-        docker = str(self.settings.docker_bin)
+        unix_username = self._unix_username
+        if unix_username:
+            docker_prefix = self._sudo_docker(unix_username)
+        else:
+            docker_prefix = [str(self.settings.docker_bin)]
         try:
             rm_proc = await asyncio.create_subprocess_exec(
-                docker,
+                *docker_prefix,
                 "rm",
                 "-f",
                 f"ds01-job-{job_id}",

--- a/src/ds01_jobs/runner.py
+++ b/src/ds01_jobs/runner.py
@@ -91,8 +91,8 @@ class JobRunner:
         async with aiosqlite.connect(self.settings.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "SELECT id, username, repo_url, branch, gpu_count, timeout_seconds "
-                "FROM jobs WHERE status='queued' ORDER BY created_at ASC"
+                "SELECT id, username, unix_username, repo_url, branch, gpu_count, "
+                "timeout_seconds FROM jobs WHERE status='queued' ORDER BY created_at ASC"
             )
             rows = await cursor.fetchall()
 
@@ -115,6 +115,7 @@ class JobRunner:
                     gpu_count,
                     row["timeout_seconds"],
                     self.settings.db_path,
+                    unix_username=row["unix_username"],
                 )
             )
             self.active_jobs[job_id] = task

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -59,7 +59,9 @@ def api_key() -> str:
     test_username = f"test-lifecycle-{suffix}"
 
     # Create a key using --json for reliable parsing
-    result = _run(["ds01-job-admin", "key-create", test_username, "--json"])
+    # key-create requires both github_username and unix_username
+    unix_user = os.environ.get("USER", "datasciencelab")
+    result = _run(["ds01-job-admin", "key-create", test_username, unix_user, "--json"])
     assert result.returncode == 0, f"key-create failed: {result.stderr}"
 
     data = json.loads(result.stdout)

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -54,7 +54,7 @@ def api_key() -> str:
     Uses ``ds01-job-admin key-create`` with the ``datasciencelab`` org member
     account. Revokes any pre-existing key first, then tears down after the test.
     """
-    github_user = "datasciencelab"
+    github_user = "henrycgbaker"
     unix_user = "datasciencelab"
 
     # Revoke any leftover key from a previous run

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -20,6 +20,7 @@ runner via Tier 2 CI.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import time
 

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -20,10 +20,8 @@ runner via Tier 2 CI.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import time
-import uuid
 
 import pytest
 
@@ -52,16 +50,16 @@ def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.Compl
 def api_key() -> str:
     """Create a temporary API key for the lifecycle test.
 
-    Uses ``ds01-job-admin key-create`` to create a key for a test user.
-    Tears down by revoking the key after the test.
+    Uses ``ds01-job-admin key-create`` with the ``datasciencelab`` org member
+    account. Revokes any pre-existing key first, then tears down after the test.
     """
-    suffix = uuid.uuid4().hex[:8]
-    test_username = f"test-lifecycle-{suffix}"
+    github_user = "datasciencelab"
+    unix_user = "datasciencelab"
 
-    # Create a key using --json for reliable parsing
-    # key-create requires both github_username and unix_username
-    unix_user = os.environ.get("USER", "datasciencelab")
-    result = _run(["ds01-job-admin", "key-create", test_username, unix_user, "--json"])
+    # Revoke any leftover key from a previous run
+    _run(["ds01-job-admin", "key-revoke", github_user, "--yes"])
+
+    result = _run(["ds01-job-admin", "key-create", github_user, unix_user, "--json"])
     assert result.returncode == 0, f"key-create failed: {result.stderr}"
 
     data = json.loads(result.stdout)
@@ -70,7 +68,7 @@ def api_key() -> str:
     yield raw_key
 
     # Teardown: revoke the key
-    _run(["ds01-job-admin", "key-revoke", test_username, "--yes"])
+    _run(["ds01-job-admin", "key-revoke", github_user, "--yes"])
 
 
 @pytest.fixture()

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -20,6 +20,7 @@ from ds01_jobs.executor import JobExecutor
 JOB_ID = "test-job-001"
 REPO_URL = "https://github.com/example/repo.git"
 BRANCH = "main"
+UNIX_USER = "testuser_unix"
 
 
 @pytest.fixture
@@ -34,6 +35,7 @@ def executor_settings(tmp_path: Path) -> Settings:
         default_job_timeout_seconds=120.0,
         max_job_timeout_seconds=300.0,
         db_path=tmp_path / "test.db",
+        get_resource_limits_bin=Path("/opt/ds01-infra/scripts/docker/get_resource_limits.py"),
     )
 
 
@@ -47,11 +49,12 @@ def db_path(tmp_path: Path) -> Path:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.executescript(SCHEMA_SQL)
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             JOB_ID,
             "testuser",
+            UNIX_USER,
             REPO_URL,
             BRANCH,
             1,
@@ -77,7 +80,7 @@ def _mock_process(returncode: int = 0) -> AsyncMock:
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Tests - existing behaviour (with unix_username)
 # ---------------------------------------------------------------------------
 
 
@@ -93,7 +96,13 @@ async def test_execute_success(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -120,13 +129,30 @@ async def test_execute_clone_failure_retries(
 ) -> None:
     """Clone retries once on failure and succeeds on second attempt."""
     # First clone call fails, second succeeds, rest succeed
+    # Sequence: clone(fail), clone-retry(ok), build(ok), get_resource_limits(ok),
+    #           run(ok), collect(ok), cleanup x3(ok)
     fail_proc = _mock_process(128)
     ok_proc = _mock_process(0)
-    mock_exec.side_effect = [fail_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc, ok_proc]
+    mock_exec.side_effect = [
+        fail_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+    ]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -157,7 +183,13 @@ async def test_execute_clone_failure_after_retry(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -184,7 +216,13 @@ async def test_execute_build_failure(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -209,12 +247,18 @@ async def test_execute_run_failure(
     """Run failure sets status=failed with failed_phase=run."""
     ok_proc = _mock_process(0)
     fail_proc = _mock_process(1)
-    # clone ok, build ok, run fails, cleanup procs
-    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+    # clone ok, build ok, get_resource_limits ok, run fails, cleanup x3
+    mock_exec.side_effect = [ok_proc, ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -266,7 +310,13 @@ async def test_execute_build_timeout(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -306,7 +356,13 @@ async def test_status_transitions_order(
     executor._update_status = tracking_update  # type: ignore[assignment]
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     assert statuses == ["cloning", "building", "running", "succeeded"]
@@ -328,20 +384,31 @@ async def test_cleanup_called_on_failure(
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     # Check cleanup calls were made (the last 3 create_subprocess_exec calls)
     calls = mock_exec.call_args_list
     docker = str(executor_settings.docker_bin)
 
-    # Find cleanup calls - they use docker rm, docker image rm, docker builder prune
-    cleanup_cmds = []
+    # Find cleanup calls - they use sudo -u ... docker rm, etc.
+    cleanup_cmds: list[str] = []
     for c in calls:
         args = c[0] if c[0] else ()
-        if args and args[0] == docker:
-            if len(args) > 1 and args[1] in ("rm", "image", "builder"):
-                cleanup_cmds.append(args[1])
+        # With sudo -u, args start with ("sudo", "-u", unix_user, docker_bin, ...)
+        # Find docker subcommand position
+        if "sudo" in args and docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1:
+                subcmd = args[docker_idx + 1]
+                if subcmd in ("rm", "image", "builder"):
+                    cleanup_cmds.append(subcmd)
 
     assert "rm" in cleanup_cmds
     assert "image" in cleanup_cmds
@@ -360,18 +427,24 @@ async def test_docker_bin_path_used(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     docker = str(executor_settings.docker_bin)
     for c in mock_exec.call_args_list:
         args = c[0] if c[0] else ()
-        # Skip the git clone call
-        if args and args[0] == "git":
+        # Skip the git clone call and get_resource_limits.py call
+        if args and args[0] in ("git", "python3"):
             continue
-        # All other calls should use the docker wrapper path
+        # With sudo -u, docker_bin appears at index 3; without, at index 0
         if args:
-            assert args[0] == docker, f"Expected {docker} but got {args[0]} in call {args}"
+            assert docker in args, f"Expected {docker} in call {args}"
 
 
 @pytest.mark.asyncio
@@ -386,7 +459,13 @@ async def test_log_files_created(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     workspace = executor_settings.workspace_root / JOB_ID
@@ -431,13 +510,18 @@ async def test_cancel_check_stops_execution(
     executor._check_cancelled = cancel_after_clone  # type: ignore[assignment]
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     # Verify build was never started - no docker build call should exist
     calls = mock_exec.call_args_list
-    docker_cmds = [c[0] for c in calls if c[0] and c[0][0] == str(executor_settings.docker_bin)]
-    build_calls = [c for c in docker_cmds if len(c) > 1 and c[1] == "build"]
+    build_calls = [c for c in calls if c[0] and "build" in c[0]]
     assert len(build_calls) == 0, "Build should not have been called after cancel"
 
 
@@ -453,7 +537,13 @@ async def test_phase_timestamps_recorded(
     executor = JobExecutor(executor_settings)
 
     await executor.execute(
-        JOB_ID, REPO_URL, BRANCH, gpu_count=1, timeout_seconds=None, db_path=db_path
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
     )
 
     async with aiosqlite.connect(db_path) as db:
@@ -471,3 +561,263 @@ async def test_phase_timestamps_recorded(
     # Completed phases should have ended_at set
     for phase in ("queued", "cloning", "building", "running"):
         assert timestamps[phase]["ended_at"] is not None, f"{phase} missing ended_at"
+
+
+# ---------------------------------------------------------------------------
+# Tests - sudo -u, resource limits, interface label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_build_uses_sudo_prefix(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Build command includes sudo -u {unix_username} prefix."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the build call
+    build_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1 and args[docker_idx + 1] == "build":
+                build_call = args
+                break
+
+    assert build_call is not None, "No build call found"
+    assert build_call[0] == "sudo"
+    assert build_call[1] == "-u"
+    assert build_call[2] == UNIX_USER
+    assert build_call[3] == docker
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_run_uses_sudo_with_interface_label(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Run command includes sudo -u and --label ds01.interface=api."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the run call
+    run_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1 and args[docker_idx + 1] == "run":
+                run_call = args
+                break
+
+    assert run_call is not None, "No run call found"
+    # Verify sudo -u prefix
+    assert run_call[0] == "sudo"
+    assert run_call[1] == "-u"
+    assert run_call[2] == UNIX_USER
+    assert run_call[3] == docker
+    # Verify interface label
+    assert "--label" in run_call
+    label_idx = run_call.index("--label")
+    assert run_call[label_idx + 1] == "ds01.interface=api"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_run_includes_resource_limits(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Run command includes resource limits from _get_resource_limits."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    # Mock _get_resource_limits to return known values
+    resource_args = ["--memory=32g", "--shm-size=16g"]
+    with patch.object(executor, "_get_resource_limits", return_value=resource_args):
+        await executor.execute(
+            JOB_ID,
+            REPO_URL,
+            BRANCH,
+            gpu_count=1,
+            timeout_seconds=None,
+            db_path=db_path,
+            unix_username=UNIX_USER,
+        )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the run call
+    run_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1 and args[docker_idx + 1] == "run":
+                run_call = args
+                break
+
+    assert run_call is not None, "No run call found"
+    assert "--memory=32g" in run_call
+    assert "--shm-size=16g" in run_call
+
+
+@pytest.mark.asyncio
+async def test_get_resource_limits_strips_cgroup_parent(
+    executor_settings: Settings,
+) -> None:
+    """_get_resource_limits strips --cgroup-parent from output."""
+    executor = JobExecutor(executor_settings)
+
+    # Mock subprocess that returns args including --cgroup-parent
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (
+        b"--cpus=32 --memory=32g --cgroup-parent=ds01-student-alice.slice --shm-size=16g",
+        b"",
+    )
+
+    async def passthrough_wait_for(coro: object, **kwargs: object) -> object:
+        return await coro  # type: ignore[misc]
+
+    with patch("ds01_jobs.executor.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("ds01_jobs.executor.asyncio.wait_for", side_effect=passthrough_wait_for):
+            result = await executor._get_resource_limits("alice")
+
+    assert "--cpus=32" in result
+    assert "--memory=32g" in result
+    assert "--shm-size=16g" in result
+    # cgroup-parent must be stripped
+    assert not any(a.startswith("--cgroup-parent=") for a in result)
+
+
+@pytest.mark.asyncio
+async def test_get_resource_limits_fallback_on_failure(
+    executor_settings: Settings,
+) -> None:
+    """_get_resource_limits returns empty list when subprocess fails."""
+    executor = JobExecutor(executor_settings)
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"user not found")
+
+    async def passthrough_wait_for(coro: object, **kwargs: object) -> object:
+        return await coro  # type: ignore[misc]
+
+    with patch("ds01_jobs.executor.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("ds01_jobs.executor.asyncio.wait_for", side_effect=passthrough_wait_for):
+            result = await executor._get_resource_limits("nonexistent")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_cleanup_uses_sudo(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Cleanup commands (rm, image rm, builder prune) all use sudo -u."""
+    ok_proc = _mock_process(0)
+    fail_proc = _mock_process(1)
+    cleanup_proc = _mock_process(0)
+    # clone ok, build fails, then 3 cleanup calls
+    mock_exec.side_effect = [ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+
+    executor = JobExecutor(executor_settings)
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find cleanup calls (rm, image rm, builder prune) - all should use sudo -u
+    cleanup_calls: list[tuple[str, ...]] = []
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1:
+                subcmd = args[docker_idx + 1]
+                if subcmd in ("rm", "image", "builder"):
+                    cleanup_calls.append(args)
+
+    assert len(cleanup_calls) == 3, f"Expected 3 cleanup calls, got {len(cleanup_calls)}"
+    for call_args in cleanup_calls:
+        assert call_args[0] == "sudo", f"Cleanup call missing sudo prefix: {call_args}"
+        assert call_args[1] == "-u"
+        assert call_args[2] == UNIX_USER
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_collect_results_uses_sudo(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """docker cp for result collection uses sudo -u prefix."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=1,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    # Find the cp call
+    cp_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1 and args[docker_idx + 1] == "cp":
+                cp_call = args
+                break
+
+    assert cp_call is not None, "No cp call found"
+    assert cp_call[0] == "sudo"
+    assert cp_call[1] == "-u"
+    assert cp_call[2] == UNIX_USER

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -35,11 +35,13 @@ def populated_db(tmp_path: Path) -> Path:
     conn.executescript(SCHEMA_SQL)
     for i in range(2):
         conn.execute(
-            "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-            "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+            "job_name, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 f"job-{i}",
                 "testuser",
+                "testuser_unix",
                 "https://github.com/test/repo.git",
                 "main",
                 1,
@@ -179,11 +181,12 @@ async def test_poll_skips_oversized_jobs(
     conn = sqlite3.connect(db_path)
     # Job needing 2 GPUs
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             "big-job",
             "testuser",
+            "testuser_unix",
             "https://github.com/test/repo.git",
             "main",
             2,
@@ -195,11 +198,12 @@ async def test_poll_skips_oversized_jobs(
     )
     # Job needing 1 GPU
     conn.execute(
-        "INSERT INTO jobs (id, username, repo_url, branch, gpu_count, "
-        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             "small-job",
             "testuser",
+            "testuser_unix",
             "https://github.com/test/repo.git",
             "main",
             1,
@@ -281,3 +285,53 @@ async def test_completed_tasks_cleaned_up(
 
     assert "done-job" not in runner.active_jobs
     assert "done-job" not in runner.active_executors
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.runner.get_available_gpu_count", new_callable=AsyncMock)
+@patch("ds01_jobs.runner.JobExecutor")
+async def test_poll_passes_unix_username_to_executor(
+    mock_executor_cls: AsyncMock,
+    mock_gpu: AsyncMock,
+    runner_settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Runner passes unix_username from DB to executor.execute()."""
+    db_path = tmp_path / "test.db"
+    runner_settings.db_path = db_path
+    _init_db_sync(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (id, username, unix_username, repo_url, branch, gpu_count, "
+        "job_name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "unix-test-job",
+            "alice_github",
+            "alice_unix",
+            "https://github.com/test/repo.git",
+            "main",
+            1,
+            "unix-test",
+            "queued",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    mock_gpu.return_value = 4
+    mock_executor = AsyncMock()
+    mock_executor.execute = AsyncMock()
+    mock_executor_cls.return_value = mock_executor
+
+    runner = JobRunner(runner_settings)
+    await runner._poll_and_dispatch()
+
+    # Verify executor.execute was called with unix_username="alice_unix"
+    assert len(runner.active_jobs) == 1
+    mock_executor.execute.assert_called_once()
+    call_kwargs = mock_executor.execute.call_args
+    # unix_username should be passed as a keyword argument
+    assert call_kwargs[1]["unix_username"] == "alice_unix"


### PR DESCRIPTION
## Summary
- Add `sudo -u {unix_username}` prefix to all Docker commands in executor
- Add dynamic resource limits via `get_resource_limits.py`
- Propagate `unix_username` from runner to executor
- Add schema migration for `unix_username` column (fixes OperationalError on existing DBs)
- Fix lifecycle integration test to use real org member (`henrycgbaker`)

Re-lands reverted PRs #48/#49 with fixes for the integration test failures.

## Test plan
- [x] Unit tests pass (207 passed)
- [x] Migration verified against old-schema DB
- [ ] CI checks pass
- [ ] Integration tests pass on GPU runner