### PR TITLE
docs: add user guide and contributor guide

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -1,0 +1,743 @@
+# DS01 Jobs - Contributor Guide
+
+This guide is for developers who want to contribute to the `ds01-jobs` codebase itself. It covers environment setup, project structure, testing, code quality tooling, and the workflow for getting changes merged.
+
+## Prerequisites
+
+- **Python 3.13** - the project pins this version in `.python-version`
+- **[uv](https://docs.astral.sh/uv/)** - the package manager and build tool used throughout
+- **Git** - with access to the [hertie-data-science-lab/ds01-jobs](https://github.com/hertie-data-science-lab/ds01-jobs) repository
+
+## Setting Up the Development Environment
+
+```bash
+# Clone the repository
+git clone https://github.com/hertie-data-science-lab/ds01-jobs.git
+cd ds01-jobs
+
+# Install all dependencies (including dev group)
+uv sync --locked --all-groups
+
+# Verify setup - run unit tests
+uv run pytest -m 'not integration' --tb=short
+```
+
+If the tests pass, your environment is ready. The `uv sync --locked` flag ensures you get the exact dependency versions from `uv.lock`.
+
+## Project Structure
+
+The project uses a `src` layout with the package at `src/ds01_jobs/`:
+
+```
+ds01-jobs/
+├── pyproject.toml               # Project metadata, dependencies, tool config
+├── uv.lock                      # Locked dependency versions
+├── .python-version              # Python 3.13
+├── src/ds01_jobs/
+│   ├── __init__.py              # Package version (__version__)
+│   ├── app.py                   # FastAPI application factory (create_app)
+│   ├── config.py                # Settings from environment (pydantic-settings)
+│   ├── models.py                # Pydantic request/response schemas
+│   ├── auth.py                  # HMAC-SHA256 authentication dependency
+│   ├── jobs.py                  # API endpoints (submit, status, logs, results, cancel, list, quota)
+│   ├── executor.py              # Single-job execution pipeline (clone -> build -> run -> collect -> cleanup)
+│   ├── runner.py                # Long-running poll-dispatch service (JobRunner)
+│   ├── database.py              # SQLite schema, async/sync connection providers
+│   ├── client.py                # HTTP client with transparent HMAC signing
+│   ├── submit.py                # ds01-submit CLI (researcher-facing)
+│   ├── cli.py                   # ds01-job-admin CLI (admin-facing)
+│   ├── scanner.py               # Dockerfile static analysis (base images, blocked ENVs)
+│   ├── url_validation.py        # GitHub URL validation + SSRF prevention
+│   ├── gpu.py                   # nvidia-smi GPU availability queries
+│   ├── rate_limit.py            # Per-user quota enforcement (concurrent + daily)
+│   ├── middleware.py            # slowapi global rate limiting setup
+│   └── health.py                # GET /health endpoint
+├── tests/
+│   ├── conftest.py              # Shared fixtures
+│   ├── unit/                    # Unit tests (no GPU/Docker needed)
+│   └── integration/             # Integration tests (require GPU runner)
+├── .github/workflows/
+│   ├── ci.yml                   # Tier 1: lint, format, types, unit tests (ubuntu-latest)
+│   └── ci-integration.yml       # Tier 2: integration tests (self-hosted GPU runner)
+├── systemd/                     # Service unit files for deployment
+├── config/                      # Configuration files
+└── data/                        # SQLite database (runtime, not committed)
+```
+
+### Three Entry Points
+
+The package installs three CLI commands (defined in `pyproject.toml` under `[project.scripts]`):
+
+| Command | Module | Purpose |
+|---|---|---|
+| `ds01-submit` | `submit.py` | Researcher CLI - submit jobs, check status, download results |
+| `ds01-job-admin` | `cli.py` | Admin CLI - create/revoke/rotate API keys |
+| `ds01-job-runner` | `runner.py` | Background service - polls for queued jobs and executes them |
+
+### How the Pieces Fit Together
+
+The system has two long-running processes:
+
+1. **API server** (`app.py`) - a FastAPI application serving the REST API. It handles authentication (via `auth.py`), job submission and validation (via `jobs.py`, `scanner.py`, `url_validation.py`), rate limiting (via `rate_limit.py`, `middleware.py`), and job status/results queries. All state lives in SQLite (via `database.py`).
+
+2. **Runner** (`runner.py`) - an async poll-dispatch loop that reads queued jobs from SQLite, checks GPU availability (via `gpu.py`), and dispatches them through `executor.py`. The executor clones the repo, builds a Docker image, runs the container with GPU access, collects results from `/output/`, then cleans up.
+
+The researcher CLI (`submit.py`) and admin CLI (`cli.py`) are client-side tools. The researcher CLI uses `client.py` to sign every HTTP request with HMAC-SHA256, matching the server's `auth.py` verification.
+
+## Architecture Overview
+
+The following diagram shows how requests flow through the system:
+
+```
+Researcher CLI (ds01-submit)
+     |
+     | HTTPS + HMAC signing
+     v
+Reverse Proxy (443) --> uvicorn (127.0.0.1:8765) --> FastAPI (app.py)
+     |                                                  |
+     |                                          Depends(get_current_user) --> auth.py
+     |                                          Depends(get_db) --> database.py
+     |                                                  |
+     |                                          jobs.py endpoints
+     |                                                  |
+     v                                                  v
+SQLite DB  <--- --- --- --- --- --- --- --- --- runner.py (polls for queued jobs)
+(data/jobs.db)                                          |
+                                                 executor.py
+                                                        |
+                                                 Docker (git clone --> build --> run)
+                                                        |
+                                                 GPU (via --gpus all)
+```
+
+**Key architectural points:**
+
+- The **API server** and the **runner** are separate processes. They do not communicate directly - they share state through the SQLite database. The API writes job records (with status `queued`), and the runner polls for jobs in that status.
+- **SQLite** is the single source of truth for all state. WAL mode is enabled at init to allow concurrent reads during writes, which is essential since the API and runner access the database simultaneously.
+- The **reverse proxy** (nginx) handles TLS termination on port 443 and forwards to uvicorn on `127.0.0.1:8765`. The API server never handles TLS directly.
+- **Authentication** uses HMAC-SHA256 request signing. The CLI (`client.py`) signs each request with the API key, and the server (`auth.py`) verifies the signature. This prevents replay attacks via timestamps and nonces.
+- The **executor** runs each job through a pipeline: clone the repository, build a Docker image, run the container with GPU access, copy results from `/output/`, then clean up the container and image. Each phase has its own timeout and log file.
+- Docker commands are executed via `sudo -u <unix_username>` so that each researcher's containers run under their own Unix user, providing process-level isolation.
+
+## Database Schema
+
+The database has two tables, defined in `database.py` (`SCHEMA_SQL`).
+
+### `api_keys` Table
+
+Stores API key credentials for authentication.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INTEGER | Auto-incrementing primary key |
+| `username` | TEXT | GitHub username (the identity used for job ownership) |
+| `unix_username` | TEXT | Unix username on the server (used for `sudo -u` in Docker execution) |
+| `key_id` | TEXT | First 8 characters of the token, used for key lookup (UNIQUE, indexed) |
+| `key_hash` | TEXT | bcrypt hash of the full API key |
+| `created_at` | TEXT | ISO timestamp of key creation |
+| `expires_at` | TEXT | ISO timestamp of key expiry |
+| `revoked` | INTEGER | 0 = active, 1 = revoked |
+| `last_used_at` | TEXT | ISO timestamp of last successful authentication (nullable) |
+
+### `jobs` Table
+
+Stores all job records and their execution state.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | TEXT | UUID primary key (generated at submission time) |
+| `username` | TEXT | GitHub username of the submitter (FK to `api_keys.username`) |
+| `unix_username` | TEXT | Unix username (copied from the API key at submission) |
+| `repo_url` | TEXT | GitHub repository URL |
+| `branch` | TEXT | Git branch to clone (default: `main`) |
+| `gpu_count` | INTEGER | Number of GPUs requested (default: 1) |
+| `job_name` | TEXT | Human-readable job name |
+| `timeout_seconds` | INTEGER | Maximum run time in seconds (nullable - uses default) |
+| `dockerfile_content` | TEXT | Inline Dockerfile content if provided via `--dockerfile` (nullable) |
+| `status` | TEXT | Current job status (default: `queued`) |
+| `created_at` | TEXT | ISO timestamp of job creation |
+| `updated_at` | TEXT | ISO timestamp of last status change |
+| `failed_phase` | TEXT | Which phase failed: `clone`, `build`, or `run` (nullable) |
+| `exit_code` | INTEGER | Process exit code on failure (nullable) |
+| `error_summary` | TEXT | Human-readable error message (nullable) |
+| `started_at` | TEXT | ISO timestamp when execution began (nullable) |
+| `completed_at` | TEXT | ISO timestamp when the job reached a terminal state (nullable) |
+| `phase_timestamps` | TEXT | JSON object with per-phase `started_at`/`ended_at` timestamps |
+
+### Job Status State Machine
+
+Jobs progress through these states:
+
+```
+              +----------+
+              |  queued   |  (initial state, set at submission)
+              +----+-----+
+                   |
+                   v
+              +----------+
+              | cloning   |  (shallow git clone, retries once)
+              +----+-----+
+                   |
+                   v
+              +----------+
+              | building  |  (docker build, 15 min timeout)
+              +----+-----+
+                   |
+                   v
+              +----------+
+              | running   |  (container execution, user-defined timeout)
+              +----+-----+
+                   |
+            +------+------+
+            |             |
+            v             v
+      +-----------+  +--------+
+      | succeeded |  | failed |
+      +-----------+  +--------+
+```
+
+A job can transition to `failed` from any active state (including via user cancellation). Once a job reaches `succeeded` or `failed`, it is terminal and cannot change state.
+
+## Running Locally
+
+### API Server
+
+```bash
+uv run uvicorn ds01_jobs.app:app --host 127.0.0.1 --port 8765 --reload
+```
+
+The `--reload` flag enables auto-reload on code changes. The API will be available at `http://127.0.0.1:8765`, with interactive docs at `http://127.0.0.1:8765/docs`.
+
+### Runner
+
+In a separate terminal:
+
+```bash
+uv run ds01-job-runner
+```
+
+**Note:** The runner requires GPU access (nvidia-smi) and Docker. For local development without a GPU, you can work on the API layer and unit tests without starting the runner.
+
+### Configuration
+
+All settings are loaded from environment variables with the `DS01_JOBS_` prefix (see `config.py`). The defaults are sensible for the production server. Key settings you might override locally:
+
+- `DS01_JOBS_DB_PATH` - SQLite database path (default: `/opt/ds01-jobs/data/jobs.db`)
+- `DS01_JOBS_API_HOST` / `DS01_JOBS_API_PORT` - API bind address (default: `127.0.0.1:8765`)
+- `DS01_JOBS_WORKSPACE_ROOT` - where job workspaces are created (default: `/var/lib/ds01-jobs/workspaces`)
+
+You can also place a `.env` file in the project root.
+
+## Environment Variables for Local Development
+
+The following table lists all settings you are likely to override during local development. Each maps to a field in the `Settings` class in `config.py` with the `DS01_JOBS_` prefix.
+
+| Variable | Description | Default | Local dev suggestion |
+|---|---|---|---|
+| `DS01_JOBS_DB_PATH` | Path to the SQLite database file | `/opt/ds01-jobs/data/jobs.db` | `/tmp/ds01-dev.db` |
+| `DS01_JOBS_WORKSPACE_ROOT` | Directory where job workspaces are created | `/var/lib/ds01-jobs/workspaces` | `/tmp/ds01-workspaces` |
+| `DS01_JOBS_DOCKER_BIN` | Path to the Docker binary | `/usr/local/bin/docker` | `docker` (if on PATH) |
+| `DS01_JOBS_API_HOST` | Host address for the API server | `127.0.0.1` | `127.0.0.1` |
+| `DS01_JOBS_API_PORT` | Port for the API server | `8765` | `8765` |
+| `DS01_JOBS_BUILD_TIMEOUT_SECONDS` | Docker build timeout | `900` (15 min) | `300` (5 min, faster feedback) |
+| `DS01_JOBS_DEFAULT_JOB_TIMEOUT_SECONDS` | Default job run timeout | `14400` (4 hours) | `600` (10 min) |
+
+### Minimal `.env` File for Local Development
+
+Create a `.env` file in the project root:
+
+```bash
+DS01_JOBS_DB_PATH=/tmp/ds01-dev.db
+DS01_JOBS_WORKSPACE_ROOT=/tmp/ds01-workspaces
+```
+
+The `.env` file is already in `.gitignore`, so it will not be committed.
+
+## Running Tests
+
+### Unit Tests
+
+Unit tests do not require a GPU, Docker, or a running API server:
+
+```bash
+# Run all unit tests
+uv run pytest -m 'not integration' --tb=short
+
+# Verbose output
+uv run pytest -m 'not integration' -v
+
+# Single test file
+uv run pytest tests/unit/test_auth.py -v
+
+# Single test function
+uv run pytest tests/unit/test_auth.py::test_valid_request -v
+
+# With coverage report
+uv run pytest -m 'not integration' --cov=ds01_jobs --cov-report=term-missing
+```
+
+### Integration Tests
+
+Integration tests require the full stack (API server, runner, GPU, Docker) and run on the self-hosted GPU runner in CI. You generally do not need to run these locally:
+
+```bash
+uv run pytest -m integration --tb=short
+```
+
+### Test Organisation
+
+Each source module has a corresponding test file:
+
+| Source | Tests |
+|---|---|
+| `auth.py` | `tests/unit/test_auth.py` |
+| `jobs.py` | `tests/unit/test_jobs.py` |
+| `scanner.py` | `tests/unit/test_scanner.py` |
+| `executor.py` | `tests/unit/test_executor.py` |
+| ... | ... |
+
+## Code Quality Tools
+
+### Formatting
+
+Ruff is the formatter, configured to a 100-character line length:
+
+```bash
+uv run ruff format .
+```
+
+### Linting
+
+Ruff also handles linting. The `--fix` flag auto-corrects what it can:
+
+```bash
+uv run ruff check --fix .
+```
+
+Enabled rule sets: `E` (pycodestyle errors), `F` (pyflakes), `I` (isort), `W` (pycodestyle warnings), `UP` (pyupgrade).
+
+### Type Checking
+
+mypy runs in strict mode with the Pydantic plugin:
+
+```bash
+uv run mypy src/ds01_jobs/
+```
+
+### Pre-commit Hooks
+
+Git hooks run automatically on every `git commit`:
+
+- **Identity check** - verifies your Git author identity
+- **Secrets scan** - blocks commits containing API keys, passwords, etc.
+- **Branch protection** - blocks direct commits to `main`
+- **Ruff format + lint** - auto-formats and lints staged files
+
+If a hook fails, fix the issue and try committing again. The hooks only run on staged files, so they are fast.
+
+### Full Quality Check
+
+Run everything in sequence before opening a PR:
+
+```bash
+uv run ruff format . && uv run ruff check --fix . && uv run mypy src/ds01_jobs/ && uv run pytest -m 'not integration' --tb=short
+```
+
+## Git Workflow
+
+### Branching
+
+All work happens on feature branches. Branch naming convention:
+
+| Prefix | Use for |
+|---|---|
+| `feature/*` | New features |
+| `fix/*` | Bug fixes |
+| `refactor/*` | Code restructuring |
+| `docs/*` | Documentation changes |
+
+### Development Flow
+
+1. **Create a branch from an up-to-date main:**
+   ```bash
+   git checkout main && git pull
+   git checkout -b feature/my-feature
+   ```
+
+2. **Commit freely on your branch.** WIP commits, experiments, and notes are all fine on feature branches. There is no need to follow strict commit message conventions here.
+
+3. **Open a PR when ready:**
+   - Title: conventional commit format (e.g. `feat: add job priority support`)
+   - Description: explain what changed, why, and how you tested it
+   - CI must pass (lint, format, types, unit tests)
+
+4. **Squash merge to main** after approval. The squash commit message should follow conventional commit format:
+   ```
+   type(scope): description
+   ```
+   Types: `feat`, `fix`, `docs`, `refactor`, `test`. Subject line under 72 characters, imperative mood.
+
+5. **Delete the branch** after merging.
+
+### Branch Protection
+
+Main branch has these protections:
+
+- PR required (no direct pushes)
+- CI status checks must pass
+- Review approval required before merge
+
+## CI Pipeline
+
+### Tier 1 - PR Checks (every PR)
+
+Runs on `ubuntu-latest`:
+
+1. Install dependencies (`uv sync --locked --all-groups`)
+2. Lint (`ruff check`)
+3. Format check (`ruff format --check`)
+4. Type check (`mypy src/ds01_jobs/`)
+5. Unit tests (`pytest -m 'not integration'`)
+
+All four steps must pass for the PR to be mergeable.
+
+### Tier 2 - Integration Tests (push to main)
+
+Runs on the self-hosted GPU runner:
+
+1. Install dependencies
+2. Unit tests (sanity check on the real hardware)
+3. Restart services (API + runner) with updated code
+4. Integration tests (end-to-end job submission and execution)
+
+## Adding a New Endpoint
+
+Here is a step-by-step example of adding a new API endpoint.
+
+### 1. Define the Response Model
+
+In `models.py`, add a Pydantic model for the response:
+
+```python
+class MyResponse(BaseModel):
+    """Response schema for GET /api/v1/my-endpoint."""
+
+    field: str
+    count: int
+```
+
+### 2. Add the Endpoint
+
+In `jobs.py` (or a new router file if the feature is unrelated to jobs), add the route:
+
+```python
+@router.get("/my-endpoint", response_model=MyResponse)
+async def my_endpoint(
+    user: dict[str, str] = Depends(get_current_user),
+    db: aiosqlite.Connection = Depends(get_db),
+) -> MyResponse:
+    """Short description of what this endpoint does."""
+    # Your logic here
+    return MyResponse(field="value", count=42)
+```
+
+Key points:
+
+- Use `Depends(get_current_user)` to require authentication. This injects a dict with `username` and `unix_username` keys.
+- Use `Depends(get_db)` for an async SQLite connection.
+- Return Pydantic model instances, not raw dicts.
+- For validation errors, return a `JSONResponse` with the Stripe-like error structure (see existing endpoints in `jobs.py` for examples).
+- For auth/not-found errors, raise `HTTPException`.
+
+### 3. Write Tests
+
+Create `tests/unit/test_my_feature.py`:
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_my_endpoint(client: TestClient, auth_headers: dict[str, str]):
+    resp = client.get("/api/v1/my-endpoint", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["field"] == "value"
+    assert data["count"] == 42
+```
+
+Check `tests/conftest.py` for available fixtures (test client, auth headers, database setup, etc.).
+
+### 4. Run the Full Check
+
+```bash
+uv run ruff format . && uv run ruff check --fix . && uv run mypy src/ds01_jobs/ && uv run pytest -m 'not integration' --tb=short
+```
+
+## Adding a New CLI Command
+
+### Researcher CLI (`submit.py`)
+
+Add a new command using Typer:
+
+```python
+@app.command()
+def my_command(
+    arg: Annotated[str, typer.Argument(help="Description of the argument")],
+    json_output: JsonOption = False,
+) -> None:
+    """Short description of what this command does."""
+    client = _get_client()
+    try:
+        resp = client.get("/api/v1/my-endpoint")
+        if resp.status_code != 200:
+            _handle_error(resp)
+
+        data = resp.json()
+        if json_output:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            typer.echo(f"Result: {data['field']}")
+    finally:
+        client.close()
+```
+
+Key patterns:
+
+- Always use `_get_client()` to create a signing HTTP client, and close it in a `finally` block.
+- Support `--json` output for machine-readable results using the `JsonOption` type alias.
+- Use `_handle_error(resp)` for non-success status codes - it prints structured error messages and exits.
+
+### Admin CLI (`cli.py`)
+
+The admin CLI follows the same Typer pattern but uses `get_db_sync()` for direct SQLite access rather than the HTTP client.
+
+## Debugging Tips
+
+### Auto-reload for Fast Iteration
+
+Use the `--reload` flag with uvicorn during development. The server automatically restarts when you save changes to any Python file:
+
+```bash
+uv run uvicorn ds01_jobs.app:app --host 127.0.0.1 --port 8765 --reload
+```
+
+### Throwaway Database
+
+Point at a temporary database so you can experiment freely without affecting any real data:
+
+```bash
+DS01_JOBS_DB_PATH=/tmp/test.db uv run uvicorn ds01_jobs.app:app --host 127.0.0.1 --port 8765
+```
+
+The database is created automatically on startup (via `init_db`). Delete it and restart to get a clean slate.
+
+### Interactive API Testing
+
+FastAPI's built-in `/docs` endpoint provides a Swagger UI where you can try out endpoints interactively. Navigate to `http://127.0.0.1:8765/docs` in your browser. Note that authenticated endpoints require HMAC signing headers, so `/docs` is most useful for unauthenticated endpoints (like `/health`) or for understanding request/response schemas.
+
+### Inspecting the Database Directly
+
+Use the SQLite CLI to query the database:
+
+```bash
+sqlite3 /tmp/test.db
+```
+
+Useful queries:
+
+```sql
+-- View all jobs
+SELECT id, status, job_name, created_at FROM jobs ORDER BY created_at DESC;
+
+-- View active API keys
+SELECT username, key_id, expires_at, revoked FROM api_keys WHERE revoked = 0;
+
+-- Check job phase timestamps
+SELECT id, status, phase_timestamps FROM jobs WHERE id = '<job_id>';
+```
+
+### Verbose Logging
+
+Set `LOG_LEVEL=DEBUG` for detailed log output from the API server and runner:
+
+```bash
+LOG_LEVEL=DEBUG uv run uvicorn ds01_jobs.app:app --host 127.0.0.1 --port 8765
+```
+
+### Debugging Tests
+
+Use pytest flags to get more information when tests fail:
+
+- **`-s`** - shows print statements and log output during test execution (pytest captures stdout by default)
+- **`--pdb`** - drops into the Python debugger on the first test failure, so you can inspect variables interactively
+- **`-v`** - verbose mode, shows each test name and result
+- **`-x`** - stop on first failure (useful when debugging one specific issue)
+
+```bash
+# Show all output and drop into debugger on failure
+uv run pytest tests/unit/test_auth.py -s --pdb -v
+```
+
+## Performance Considerations
+
+Understanding these design choices helps when working on performance-sensitive parts of the codebase.
+
+### SQLite WAL Mode
+
+The database is initialised with `PRAGMA journal_mode=WAL` in `init_db()`. Write-Ahead Logging allows the API server to read the database concurrently while the runner writes status updates. Without WAL, readers would be blocked during writes, causing API latency spikes.
+
+### bcrypt in Thread Pool
+
+Password hashing with bcrypt is CPU-bound and deliberately slow (that is the point of bcrypt). The auth module offloads `bcrypt.checkpw()` via `asyncio.to_thread()` so it does not block the event loop. Without this, a single authentication request would block all other requests for the duration of the hash check.
+
+### aiosqlite for Async Database Access
+
+All API endpoint database access uses `aiosqlite`, which wraps SQLite calls in a background thread. This prevents database I/O from blocking the async event loop, allowing the server to handle other requests concurrently.
+
+### TLS Termination at the Proxy
+
+TLS handshakes are CPU-intensive. The nginx reverse proxy handles TLS termination, so uvicorn only deals with plain HTTP on the loopback interface. This keeps the Python process focused on application logic.
+
+### Docker Build Cache Pruning
+
+After each job completes, the executor runs `docker builder prune --force --filter until=1h` to remove build cache entries older than one hour. This prevents Docker's disk usage from growing without bound on a shared machine. The `--filter until=1h` keeps recent cache entries so that back-to-back builds of similar images remain fast.
+
+## Common Gotchas
+
+These are issues that have caught contributors in the past.
+
+### Forgetting to `await` an Async Call
+
+If you call an async function without `await`, Python returns a coroutine object instead of the actual result. This often manifests as a test passing (because a coroutine object is truthy) but the actual database operation never happening:
+
+```python
+# Wrong - returns a coroutine object, does nothing
+db.execute("UPDATE jobs SET status=? WHERE id=?", ("failed", job_id))
+
+# Correct
+await db.execute("UPDATE jobs SET status=? WHERE id=?", ("failed", job_id))
+```
+
+### Modifying the Database Schema
+
+If you add a column to a table, you must also add an `ALTER TABLE` migration to the `_MIGRATIONS` list in `database.py`. The `CREATE TABLE IF NOT EXISTS` statement only runs on first creation - existing databases will not pick up new columns from the schema definition alone.
+
+### Not Running `uv sync` After Pulling
+
+If someone has added a new dependency and you pull their changes, your local environment will be missing the package. Always run `uv sync --locked --all-groups` after pulling changes that modify `pyproject.toml` or `uv.lock`.
+
+### Pre-commit Hook Failures
+
+If a commit is rejected by the pre-commit hooks, run the formatters and linters manually to fix the issues:
+
+```bash
+uv run ruff format . && uv run ruff check --fix .
+```
+
+Then stage the fixed files and commit again. The hooks only check staged files, so they are fast.
+
+## Common Patterns
+
+### Authentication Dependency
+
+```python
+user: dict[str, str] = Depends(get_current_user)
+```
+
+Returns `{"username": "github_user", "unix_username": "unix_user"}` on success. Raises HTTP 401 on any authentication failure (invalid key, expired, bad signature, replay attack, etc.). All 401 responses are intentionally generic to avoid leaking information.
+
+### Database Access
+
+**Async (API endpoints):**
+```python
+db: aiosqlite.Connection = Depends(get_db)
+```
+
+**Sync (CLI tools):**
+```python
+with get_db_sync() as conn:
+    cursor = conn.execute("SELECT ...")
+```
+
+Both use `row_factory` so rows are accessible by column name (e.g. `row["username"]`).
+
+### Error Responses
+
+The API uses a Stripe-like error structure for validation errors:
+
+```json
+{
+  "error": {
+    "type": "validation_error",
+    "message": "Request validation failed",
+    "errors": [
+      {
+        "field": "repo_url",
+        "code": "invalid_url",
+        "message": "Must be a valid GitHub repository URL"
+      }
+    ]
+  }
+}
+```
+
+For simple errors (auth, not found), use `HTTPException`. For structured validation errors, return `JSONResponse` directly with the error body.
+
+### Async Subprocesses
+
+The executor uses `asyncio.create_subprocess_exec` with `process_group=0` for process isolation. This ensures that if a process needs to be killed (timeout or cancellation), the entire process group is terminated:
+
+```python
+proc = await asyncio.create_subprocess_exec(
+    *cmd,
+    stdout=log_file,
+    stderr=asyncio.subprocess.STDOUT,
+    process_group=0,
+)
+```
+
+### Settings
+
+All configuration is centralised in `config.py` via Pydantic Settings:
+
+```python
+settings = Settings()  # reads DS01_JOBS_* env vars + .env file
+```
+
+Environment variables use the `DS01_JOBS_` prefix. For example, `DS01_JOBS_DB_PATH` maps to `settings.db_path`.
+
+## Style Guide
+
+- **Type hints required** on all public function signatures
+- **Python 3.10+ syntax** - use `list[str]` not `List[str]`, `X | None` not `Optional[X]`
+- **pathlib.Path** over `os.path` for file system operations
+- **f-strings** for string formatting
+- **Google-style docstrings** for complex functions; brief one-liners for simple ones
+- **Ruff enforces formatting** at 100-character line length - do not manually review formatting
+- **mypy strict mode** - all type errors must be resolved
+
+## Try It Yourself
+
+1. **Set up the dev environment.** Clone the repo, run `uv sync --locked --all-groups`, and verify that the unit test suite passes:
+   ```bash
+   uv run pytest -m 'not integration' --tb=short
+   ```
+
+2. **Trace the application wiring.** Read `app.py`'s `create_app()` function and follow how it wires together the lifespan (database init), rate limiter, validation error handler, and routers. Then look at how `jobs.py` uses `Depends(get_current_user)` and `Depends(get_db)`.
+
+3. **Add a toy endpoint.** Create a new endpoint at `GET /api/v1/hello` that returns `{"hello": "world"}` with authentication required. Write a unit test for it. Run the full quality pipeline to make sure everything passes.
+
+4. **Run the full quality check.** Execute each step and fix any issues:
+   ```bash
+   uv run ruff format .
+   uv run ruff check --fix .
+   uv run mypy src/ds01_jobs/
+   uv run pytest -m 'not integration' --tb=short
+   ```
+
+5. **Practice the Git workflow.** Create a feature branch, make a small change (e.g. improve a docstring or add a test), commit it, and open a draft PR against `main`. Check that CI passes on your PR.
+
+6. **Explore the API via /docs.** Start the API server locally with a throwaway database and open `http://127.0.0.1:8765/docs` in your browser. Find the job submission endpoint and study its request schema. To actually submit a job, you would need to construct HMAC signing headers - try writing a small Python script that uses `client.py`'s signing logic to authenticate a request against your local server.
+
+7. **Read the test fixtures and explain the test infrastructure.** Open `tests/integration/conftest.py` and trace how it sets up an isolated test environment. Note how it creates a temporary SQLite database (`db_path` fixture), generates test API keys with `create_test_key()` and seeds them with `seed_key()`, overrides FastAPI dependencies so the app uses the test database, builds HMAC-signed headers with `build_signed_headers()`, and clears the nonce cache between tests. Understanding this infrastructure is essential for writing new tests - write a brief summary of how a test request flows from the `client` fixture through authentication to a database query and back.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,667 @@
+# DS01 Jobs - User Guide
+
+This guide covers everything you need to submit GPU jobs to the DS01 compute cluster, from initial setup through to downloading your results. It is aimed at researchers who want to run containerised workloads on shared GPU hardware.
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- **Python 3.10 or later** installed on your local machine
+- **Access to the DS01 cluster** - you must be a member of the [Hertie Data Science Lab GitHub organisation](https://github.com/hertie-data-science-lab). If you are not yet a member, ask your supervisor or lab administrator to invite you.
+- **An API key** issued by a cluster administrator (see below)
+
+## Getting an API Key
+
+API keys authenticate your CLI requests to the DS01 cluster. You cannot submit jobs without one.
+
+1. **Contact a cluster administrator** and provide your GitHub username and your Unix username on the server.
+2. The administrator runs:
+   ```bash
+   ds01-job-admin key-create <github_username> <unix_username>
+   ```
+3. You receive a key in the format `ds01_XXXXXXXXXXXX...` (a `ds01_` prefix followed by a base64url-encoded token).
+4. Keys expire after **90 days** by default. The administrator can set a custom expiry (e.g. `--expires 180d`). When your key is within 14 days of expiry, the API will include an `X-DS01-Key-Expiry-Warning` header in responses - contact your administrator to rotate the key before it expires.
+5. **Store your key securely.** Never commit it to Git, paste it in Slack messages, or include it in scripts that are checked into version control.
+
+## Installing the CLI
+
+The `ds01-submit` CLI is distributed as a Python package:
+
+```bash
+pip install ds01-jobs
+```
+
+Or, if you use [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv pip install ds01-jobs
+```
+
+This installs the `ds01-submit` command, which is your main interface to the cluster.
+
+## Configuring Credentials
+
+You need to tell the CLI your API key. There are two ways to do this:
+
+### Option 1: Environment Variable
+
+Set the `DS01_API_KEY` environment variable. This is useful for CI pipelines or temporary sessions:
+
+```bash
+export DS01_API_KEY=ds01_your_key_here
+```
+
+### Option 2: The `configure` Command (Recommended)
+
+Run the interactive configure command, which validates your key against the API and saves it locally:
+
+```bash
+ds01-submit configure
+```
+
+You will be prompted to enter your API key. On success, the CLI displays your username and group, and saves the key to `~/.config/ds01/credentials` (with `0600` permissions so only you can read it).
+
+**Credential resolution order:** The CLI checks `DS01_API_KEY` first, then falls back to the saved credentials file. The environment variable always takes precedence.
+
+## Preparing Your Repository
+
+The DS01 cluster builds and runs Docker containers from your GitHub repository. Your repo must meet a few requirements:
+
+### Dockerfile
+
+Your repository must contain a `Dockerfile` at the root (or you can provide one via the `--dockerfile` flag). The Dockerfile is statically scanned before the build starts, and the following rules are enforced:
+
+**Allowed base images** - your `FROM` directive must use an image from one of these registries:
+
+| Registry prefix | Description |
+|---|---|
+| `docker.io/library/*` | Official Docker Hub images (e.g. `python:3.12`, `ubuntu:22.04`) |
+| `nvcr.io/nvidia/*` | NVIDIA NGC images (e.g. `nvcr.io/nvidia/pytorch:24.01-py3`) |
+| `docker.io/pytorch/*` | PyTorch images |
+| `docker.io/tensorflow/*` | TensorFlow images |
+| `docker.io/huggingface/*` | Hugging Face images |
+| `ghcr.io/astral-sh/*` | Astral/uv images |
+
+Images from other registries will be rejected with a `BLOCKED_BASE_IMAGE` error.
+
+**Blocked ENV directives** - the following environment variables are blocked in your Dockerfile's final stage for security reasons:
+
+- `LD_PRELOAD`
+- `LD_LIBRARY_PATH`
+- `LD_AUDIT`
+
+Setting any of these produces an error. Additionally, `LD_DEBUG` and `PYTHONPATH` will generate warnings but are not blocked outright.
+
+### Output Directory
+
+Write any results you want to retrieve to `/output/` inside your container. After your job completes, the cluster copies everything from `/output/` and makes it available for download. If your container does not write to `/output/`, there will be nothing to download.
+
+Example in your Dockerfile or entrypoint script:
+
+```bash
+mkdir -p /output
+python train.py --save-dir /output
+```
+
+### Repository Visibility
+
+The repository URL must be a valid GitHub HTTPS URL (e.g. `https://github.com/org/repo`). The cluster performs a pre-flight check to verify the repository exists and is accessible.
+
+## Submitting a Job
+
+Use the `run` command to submit a job:
+
+```bash
+# Basic submission (1 GPU, main branch)
+ds01-submit run https://github.com/org/repo
+
+# With options
+ds01-submit run https://github.com/org/repo \
+  --gpus 2 \
+  --branch feature/experiment \
+  --name "my-training-job" \
+  --timeout 3600 \
+  --dockerfile path/to/Dockerfile
+```
+
+On success, the command prints the job ID (a UUID). Use this ID to check status, download results, or cancel the job.
+
+### Options
+
+| Flag | Description | Default |
+|---|---|---|
+| `--gpus N` | Number of GPUs to allocate (1-8) | `1` |
+| `--branch NAME` | Git branch to clone and build | `main` |
+| `--name TEXT` | Human-readable job name (auto-generated if omitted) | `<repo>-<id prefix>` |
+| `--timeout SECONDS` | Maximum run time in seconds (60-86,400) | 4 hours (14,400s) |
+| `--dockerfile PATH` | Path to a local Dockerfile to use instead of the repo's | Repo's `Dockerfile` |
+| `--json` | Output the full response as JSON instead of just the job ID | Off |
+
+### What Happens After Submission
+
+When you submit a job, the cluster:
+
+1. Validates the repository URL format and accessibility
+2. Scans the Dockerfile (if provided) for disallowed base images and blocked ENV directives
+3. Checks your quota (concurrent and daily limits)
+4. Queues the job and returns a job ID
+
+The job then proceeds through these phases:
+
+```
+queued -> cloning -> building -> running -> succeeded / failed
+```
+
+- **queued** - waiting for GPU availability
+- **cloning** - shallow-cloning your repository (retries once on failure)
+- **building** - running `docker build` with your Dockerfile (15-minute timeout)
+- **running** - executing the container with GPU access
+- **succeeded** - container exited cleanly; results are available
+- **failed** - something went wrong; check the error details
+
+## Complete Worked Example
+
+This section walks through a full end-to-end job, from writing a training script to downloading the results.
+
+### Step 1: Create a Training Script
+
+Create a file called `train.py` that trains a tiny model on synthetic data:
+
+```python
+"""Minimal PyTorch training example for DS01."""
+
+import torch
+import torch.nn as nn
+
+model = nn.Linear(10, 1).cuda()
+optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+loss_fn = nn.MSELoss()
+
+for epoch in range(100):
+    x = torch.randn(32, 10, device="cuda")
+    y = torch.randn(32, 1, device="cuda")
+    loss = loss_fn(model(x), y)
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+
+print(f"Final loss: {loss.item():.4f}")
+torch.save(model.state_dict(), "/output/model.pt")
+print("Model saved to /output/model.pt")
+```
+
+### Step 2: Write a Dockerfile
+
+Create a `Dockerfile` in the repository root:
+
+```dockerfile
+FROM nvcr.io/nvidia/pytorch:24.01-py3
+
+WORKDIR /workspace
+
+# Copy and install dependencies first (layer caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the training script
+COPY train.py .
+
+# Ensure the output directory exists
+RUN mkdir -p /output
+
+CMD ["python", "train.py"]
+```
+
+If your script has no additional dependencies beyond what the base image provides, your `requirements.txt` can be empty or omitted (and you can remove the `COPY requirements.txt` and `RUN pip install` lines).
+
+### Step 3: Push to GitHub
+
+Commit everything and push to a GitHub repository:
+
+```bash
+git init
+git add train.py Dockerfile requirements.txt
+git commit -m "Minimal training example"
+git remote add origin https://github.com/your-org/gpu-example.git
+git push -u origin main
+```
+
+### Step 4: Submit the Job
+
+```bash
+ds01-submit run https://github.com/your-org/gpu-example \
+  --name "tiny-model-test" \
+  --timeout 600
+```
+
+Output:
+
+```
+Job submitted: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Save the job ID - you will need it for the next steps.
+
+### Step 5: Monitor Progress
+
+Watch the job move through its phases:
+
+```bash
+ds01-submit status a1b2c3d4-e5f6-7890-abcd-ef1234567890 --follow
+```
+
+You will see output similar to:
+
+```
+Job:     a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Name:    tiny-model-test
+Status:  cloning
+...
+Status:  building
+...
+Status:  running
+...
+Status:  succeeded
+```
+
+The CLI polls with exponential back-off until the job reaches a terminal state.
+
+### Step 6: Download Results
+
+```bash
+ds01-submit results a1b2c3d4-e5f6-7890-abcd-ef1234567890 -o ./my-results
+```
+
+This streams and extracts the results archive into `./my-results/`.
+
+### Step 7: Inspect the Output
+
+```bash
+ls ./my-results/
+# model.pt
+
+python -c "
+import torch, torch.nn as nn
+model = nn.Linear(10, 1)
+model.load_state_dict(torch.load('./my-results/model.pt', map_location='cpu'))
+print('Model loaded successfully')
+print('Weight shape:', model.weight.shape)
+"
+```
+
+You now have a trained model on your local machine that was computed on the cluster's GPU.
+
+## Checking Job Status
+
+```bash
+# One-time status check
+ds01-submit status <job_id>
+
+# Poll until the job reaches a terminal state (succeeded or failed)
+ds01-submit status <job_id> --follow
+```
+
+The status output includes the job ID, current status, repo URL, branch, GPU count, creation time, phase timestamps, queue position (if queued), and error details (if failed).
+
+With `--follow`, the CLI polls the API with exponential back-off (starting at 2 seconds, up to 30 seconds) until the job either succeeds or fails. If the job fails, the CLI exits with code 2.
+
+Use `--json` for machine-readable output.
+
+## Downloading Results
+
+Once a job has succeeded, download its output:
+
+```bash
+# Download and extract to ./results/
+ds01-submit results <job_id>
+
+# Download to a custom directory
+ds01-submit results <job_id> -o ./my-results
+```
+
+The results are streamed as a `.tar.gz` archive and automatically extracted into the target directory. For large downloads (over 1 MB), a progress bar is shown.
+
+**Note:** Results are only available for jobs with status `succeeded`. Attempting to download results for a failed or still-running job will return an error.
+
+## Listing Jobs
+
+View your submitted jobs:
+
+```bash
+# List recent jobs (default: 20)
+ds01-submit list
+
+# List more jobs
+ds01-submit list --limit 50
+```
+
+Output is a table showing job ID, status, name, and creation time. Use `--json` for the full response including pagination metadata (`total`, `limit`, `offset`).
+
+## Cancelling a Job
+
+Cancel a job that is still queued or running:
+
+```bash
+ds01-submit cancel <job_id>
+```
+
+Cancellation sets the job status to `failed` with the message "Cancelled by user". You can only cancel your own jobs, and only while they are in an active state (`queued`, `cloning`, `building`, or `running`).
+
+## Quotas and Rate Limits
+
+Each user has two types of quota:
+
+| Limit | Description | Default |
+|---|---|---|
+| **Concurrent jobs** | Maximum number of active jobs at once | 3 |
+| **Daily submissions** | Maximum jobs submitted per day (resets at midnight UTC) | 10 |
+| **Result size** | Maximum download size per job | 1024 MB |
+
+These limits may vary by user group. The API includes rate limit headers in every job submission response:
+
+- `X-RateLimit-Limit-Concurrent` / `X-RateLimit-Remaining-Concurrent`
+- `X-RateLimit-Limit-Daily` / `X-RateLimit-Remaining-Daily`
+- `X-RateLimit-Reset-Daily` (ISO timestamp of next midnight UTC)
+
+Check your current quota usage:
+
+```bash
+ds01-submit configure
+```
+
+The configure command displays your username, group, and current limits.
+
+There is also a global rate limit of 60 requests per minute across all API endpoints, applied per API key.
+
+## API URL
+
+By default, the CLI connects to the production cluster:
+
+```
+https://ds01.hertie-data-science-lab.org
+```
+
+To point at a different server (e.g. for local development or testing):
+
+```bash
+export DS01_API_URL=http://127.0.0.1:8765
+```
+
+## Troubleshooting
+
+### 401 Authentication failed
+
+Your API key is invalid, expired, or has been revoked. Run `ds01-submit configure` to re-validate your key. If the key has expired, contact an administrator to rotate it.
+
+### 422 Validation error
+
+The request failed validation. Common causes:
+
+- **Invalid repository URL** - must be `https://github.com/owner/repo` format
+- **Blocked base image** - your Dockerfile uses an image from a disallowed registry
+- **Blocked ENV directive** - your Dockerfile sets `LD_PRELOAD`, `LD_LIBRARY_PATH`, or `LD_AUDIT`
+- **Repository not found** - the repository does not exist or is not accessible
+
+The error response includes specific field-level details explaining what went wrong.
+
+### 429 Rate limit exceeded
+
+You have hit your concurrent job limit or daily submission limit. The response body includes:
+
+- `limit_type` - whether it is a `concurrent` or `daily` limit
+- `current` / `limit` - your usage versus the cap
+- `retry_after` - seconds until the daily limit resets (for daily limits)
+
+Wait for active jobs to complete, or wait for the daily reset at midnight UTC.
+
+### 409 Conflict
+
+You are trying to cancel a job that has already finished (`succeeded` or `failed`). Only active jobs can be cancelled.
+
+### 404 Job not found
+
+The job ID is invalid, or the job belongs to a different user. You can only view and manage your own jobs.
+
+### Job failed in the "clone" phase
+
+The repository could not be cloned. Check that:
+
+- The repository URL is correct and the repository exists
+- The branch name is correct
+- The repository is accessible (not private, or credentials are configured)
+
+### Job failed in the "build" phase
+
+The Docker build failed. This usually means there is an error in your Dockerfile. Check the error message for the exit code. Common causes include missing dependencies, syntax errors in the Dockerfile, or network issues during package installation.
+
+The build phase has a 15-minute timeout. If your build takes longer than this, consider using a pre-built base image with your dependencies already installed.
+
+### Job failed in the "run" phase
+
+Your container exited with a non-zero exit code, or hit the timeout. Check:
+
+- Your entrypoint script exits cleanly on success
+- Your code does not run out of GPU memory
+- The timeout is long enough for your workload (default: 4 hours, maximum: 24 hours)
+
+## Best Practices for Dockerfiles (GPU Workloads)
+
+Writing good Dockerfiles makes your jobs build faster, fail less often, and use less disk space on the cluster. Here are practical tips for GPU workloads.
+
+### Start from NVIDIA Base Images
+
+NVIDIA NGC images come with CUDA, cuDNN, and GPU drivers pre-configured. You do not need to install these yourself:
+
+```dockerfile
+# Good - includes CUDA 12.x, cuDNN, PyTorch, and common Python packages
+FROM nvcr.io/nvidia/pytorch:24.01-py3
+
+# Bad - you'll need to install CUDA/cuDNN manually, which is fragile
+FROM ubuntu:22.04
+```
+
+The NVIDIA images are large (several GB) but they save you from debugging CUDA version mismatches.
+
+### Install Dependencies Before Copying Code
+
+Docker caches each layer. If you copy your code before installing dependencies, every code change invalidates the pip install cache:
+
+```dockerfile
+# Good - dependencies are cached unless requirements.txt changes
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+# Bad - changing any source file re-runs pip install
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+```
+
+### Handle /dev/shm Size
+
+Some frameworks (notably PyTorch DataLoader with `num_workers > 0`) use shared memory (`/dev/shm`). Docker containers have a small default `/dev/shm`. If your training crashes with a "Bus error" or shared memory errors, reduce `num_workers` or use `--shm-size`-friendly patterns in your code:
+
+```python
+# Safer default for containerised training
+dataloader = DataLoader(dataset, batch_size=32, num_workers=0)
+```
+
+The cluster allocates per-user resource limits including shared memory, but it is best not to assume a large `/dev/shm` is available.
+
+### Write All Outputs to /output/
+
+The cluster only collects files from `/output/`. Files written to `/tmp/`, `/home/`, or anywhere else are lost when the container exits:
+
+```python
+# Good
+torch.save(model.state_dict(), "/output/model.pt")
+
+# Bad - this file will not be in your results
+torch.save(model.state_dict(), "/tmp/model.pt")
+```
+
+### Keep Your Docker Image Small
+
+Large images take longer to build and consume cluster disk space:
+
+- **Use a `.dockerignore` file** to exclude `.git/`, `data/`, `__pycache__/`, and other unnecessary files from the build context
+- **Use `--no-cache-dir`** with pip to avoid storing wheel caches in the image
+- **Consider multi-stage builds** if you need build tools that are not required at runtime
+
+Example `.dockerignore`:
+
+```
+.git
+__pycache__
+*.pyc
+data/
+notebooks/
+.venv/
+```
+
+### Pin Dependency Versions
+
+Reproducible builds require pinned versions. Without them, a new package release can break your build between runs:
+
+```
+# Good - requirements.txt with pinned versions
+torch==2.2.0
+numpy==1.26.3
+pandas==2.1.5
+
+# Bad - unpinned, could break at any time
+torch
+numpy
+pandas
+```
+
+Use `pip freeze > requirements.txt` or `uv pip compile requirements.in -o requirements.txt` to generate pinned versions.
+
+### Test Locally First
+
+Before submitting to the cluster, verify your Dockerfile builds and runs:
+
+```bash
+docker build -t test-job .
+docker run --gpus all test-job
+```
+
+If you do not have a GPU locally, you can at least verify the build succeeds and the entrypoint runs (it will fail on CUDA calls, but you can catch Dockerfile errors early).
+
+## Viewing Job Logs
+
+When a job fails (or even when it succeeds), you may want to see the logs from each execution phase.
+
+### How Logs Work
+
+The API provides per-phase logs via `GET /api/v1/jobs/{id}/logs`. Each phase of execution (clone, build, run) has its own log. Logs are tail-truncated to **1 MB per phase** to keep response sizes manageable.
+
+### Accessing Logs
+
+Currently the CLI does not have a dedicated `logs` command. You can access logs via the API directly using `curl` with the appropriate HMAC signing headers, or ask a cluster administrator to retrieve them for you.
+
+Example (if you have the signing headers available):
+
+```bash
+curl -H "Authorization: Bearer $DS01_API_KEY" \
+     -H "X-Timestamp: ..." \
+     -H "X-Nonce: ..." \
+     -H "X-Signature: ..." \
+     https://ds01.hertie-data-science-lab.org/api/v1/jobs/<job_id>/logs
+```
+
+The response is JSON with a `logs` object containing keys for each phase that has a log:
+
+```json
+{
+  "job_id": "a1b2c3d4-...",
+  "logs": {
+    "clone": "Cloning into '/workspace/repo'...\n",
+    "build": "Step 1/5 : FROM nvcr.io/nvidia/pytorch:24.01-py3\n...",
+    "run": "Final loss: 0.0234\nModel saved to /output/model.pt\n"
+  }
+}
+```
+
+### Common Log Patterns
+
+When investigating failures, look for these patterns in the logs:
+
+- **"No space left on device"** - the Docker build or run exhausted disk space. Reduce your image size or contact an administrator.
+- **"OOM killed"** or **"Killed"** - your process ran out of memory. Reduce batch size, model size, or request fewer concurrent operations.
+- **"permission denied"** - a file or directory permission issue inside the container. Ensure your Dockerfile does not rely on specific user IDs.
+- **"CUDA out of memory"** - GPU memory exhaustion. Reduce batch size or model complexity.
+- **"No module named ..."** - a missing Python dependency. Check your `requirements.txt`.
+
+## FAQ
+
+**Q: How long can my job run?**
+A: The default timeout is 4 hours (14,400 seconds). The maximum is 24 hours (86,400 seconds). Set a custom timeout with the `--timeout` flag in seconds.
+
+**Q: Can I use private repositories?**
+A: The repository must be accessible via HTTPS without authentication. This means public repositories work out of the box. Private repositories are only supported if the cluster has deploy keys configured for them - ask your cluster administrator.
+
+**Q: Why was my Dockerfile rejected?**
+A: The Dockerfile scanner checks two things before your job is queued. First, the `FROM` directive must reference an allowed base image registry (see the table in "Preparing Your Repository"). If it does not, you get a `BLOCKED_BASE_IMAGE` error. Second, certain `ENV` directives (`LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`) are blocked for security. Check the specific error message in the API response for details.
+
+**Q: Can I SSH into my running container?**
+A: No. The cluster runs containers non-interactively. There is no SSH access, no interactive terminal, and no way to attach to a running container. Design your workload to run unattended and write all outputs to `/output/`.
+
+**Q: How do I know which GPUs my job will get?**
+A: The cluster assigns available GPUs automatically. Your container sees all allocated GPUs via the `--gpus all` Docker flag. You do not get to choose specific GPU models or IDs. Use `torch.cuda.device_count()` in your code to check how many GPUs are available.
+
+**Q: My job succeeded but there are no results.**
+A: Your code must write files to `/output/` inside the container. If your script writes to any other directory (e.g. `/tmp/`, `/home/`, or a relative path), those files are not collected. Check your training script and ensure all saved artefacts go to `/output/`.
+
+**Q: Can I run multiple jobs in parallel?**
+A: Yes, up to your concurrent job limit (default: 3). Each job is independent and gets its own container. You can submit several jobs and monitor them individually.
+
+## Try It Yourself
+
+1. **Validate your credentials.** Run `ds01-submit configure` and verify that it displays your username and group.
+
+2. **Check your quota.** After configuring, note your concurrent and daily limits. These constrain how many jobs you can run.
+
+3. **Submit a test job.** Pick one of the lab's example repositories and submit a job:
+   ```bash
+   ds01-submit run https://github.com/hertie-data-science-lab/ds01-test-job
+   ```
+   Note the job ID printed on success.
+
+4. **Watch a job through all phases.** Use `--follow` to see the job progress from `queued` through to `succeeded` or `failed`:
+   ```bash
+   ds01-submit status <job_id> --follow
+   ```
+
+5. **Download and inspect results.** Once the job succeeds, download the output and look at what your container produced:
+   ```bash
+   ds01-submit results <job_id> -o ./test-results
+   ls ./test-results/
+   ```
+
+6. **Write a minimal Dockerfile from scratch.** Create a simple Python script that writes "Hello from GPU" to `/output/result.txt`, wrap it in a Dockerfile, push it to a GitHub repository, and submit it as a job:
+   ```python
+   # hello_gpu.py
+   import torch
+   device = "cuda" if torch.cuda.is_available() else "cpu"
+   with open("/output/result.txt", "w") as f:
+       f.write(f"Hello from GPU (device: {device})\n")
+   ```
+   ```dockerfile
+   FROM nvcr.io/nvidia/pytorch:24.01-py3
+   COPY hello_gpu.py .
+   RUN mkdir -p /output
+   CMD ["python", "hello_gpu.py"]
+   ```
+   After the job succeeds, download the results and verify that `result.txt` contains the expected message.
+
+7. **Submit a job that intentionally fails.** Test your understanding of error handling by submitting a job with an invalid branch name:
+   ```bash
+   ds01-submit run https://github.com/hertie-data-science-lab/ds01-test-job \
+     --branch nonexistent-branch-xyz
+   ```
+   Then check the status:
+   ```bash
+   ds01-submit status <job_id>
+   ```
+   The job should fail in the "clone" phase. Read the error details and understand what went wrong. This is a safe way to familiarise yourself with how the cluster reports failures.


### PR DESCRIPTION
## Summary
- Add comprehensive **user guide** (`docs/user-guide.md`) for researchers submitting GPU jobs — covers API key setup, CLI usage, job lifecycle, Dockerfile requirements, quotas, troubleshooting, FAQ, and worked examples
- Add comprehensive **contributor guide** (`docs/contributor-guide.md`) for developers — covers dev environment, architecture overview, database schema, testing, debugging, adding endpoints/CLI commands, common patterns, and performance considerations

## Test plan
- [ ] Markdown renders correctly in GitHub preview
- [ ] Code examples reference real files/functions in the codebase
- [ ] CLI commands and flags are accurate against current implementation