### PR TITLE
fix: workspace permissions for sudo -u Docker builds

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Fix venv permissions and restart services
         run: |
-          chmod -R g+rX /opt/ds01-jobs
+          find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
           sudo systemctl restart ds01-api ds01-runner
           for i in $(seq 1 15); do
             curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           cd /opt/ds01-jobs
           git fetch origin "$GITHUB_SHA"
-          git checkout "$GITHUB_SHA"
+          git checkout -B ci-test "$GITHUB_SHA"
           uv sync --locked --all-groups
 
       - name: Fix permissions and restart services

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -17,13 +17,17 @@ jobs:
       - name: Unit tests
         run: uv run pytest -m 'not integration' --tb=short
 
+      - name: Sync code to deployment directory
+        run: |
+          cd /opt/ds01-jobs
+          git fetch origin "$GITHUB_SHA"
+          git checkout "$GITHUB_SHA"
+          uv sync --locked --all-groups
+
       - name: Fix permissions and restart services
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
-
-          # ds01 is in ds-admin group (same as $HOME), so group-execute is needed
           chmod g+x /home/datasciencelab
-
           sudo systemctl restart ds01-api ds01-runner
 
           for i in $(seq 1 20); do

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -20,13 +20,26 @@ jobs:
       - name: Fix venv permissions and restart services
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
+
+          # Diagnostics: verify service prerequisites
+          echo "--- Checking service prerequisites ---"
+          ls -la /etc/ds01-jobs/env 2>/dev/null || echo "WARNING: /etc/ds01-jobs/env not found"
+          systemctl list-unit-files ds01-api.service 2>/dev/null || echo "WARNING: ds01-api unit not found"
+          ls -la /opt/ds01-jobs/.venv/bin/uvicorn 2>/dev/null || echo "WARNING: uvicorn not found"
+
           sudo systemctl restart ds01-api ds01-runner
+
+          # Check status immediately after restart
+          sleep 1
+          sudo systemctl status ds01-api --no-pager 2>/dev/null || true
+
           for i in $(seq 1 15); do
             curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0
             sleep 1
           done
           echo "API not ready after 15s"
-          journalctl -u ds01-api --no-pager -n 20 2>/dev/null || true
+          sudo systemctl status ds01-api --no-pager 2>/dev/null || true
+          sudo journalctl -u ds01-api --no-pager -n 30 --since "5 minutes ago" 2>/dev/null || true
           exit 1
 
       - name: Integration tests

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -26,14 +26,13 @@ jobs:
 
           sudo systemctl restart ds01-api ds01-runner
 
-          for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0
+          for i in $(seq 1 20); do
+            python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8765/health')" 2>/dev/null && exit 0
             sleep 1
           done
-          echo "API not ready after 30s"
-          curl -v http://127.0.0.1:8765/health 2>&1 || true
+          echo "API not ready after 20s"
+          python3 -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:8765/health').read())" || true
           systemctl status ds01-api --no-pager || true
-          ss -tlnp | grep 8765 || echo "Port 8765 not listening"
           exit 1
 
       - name: Integration tests

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
 
-          # ds01 service user needs to traverse $HOME to reach anaconda3 Python
-          chmod o+x /home/datasciencelab
+          # ds01 is in ds-admin group (same as $HOME), so group-execute is needed
+          chmod g+x /home/datasciencelab
 
           sudo systemctl restart ds01-api ds01-runner
 

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -26,12 +26,14 @@ jobs:
 
           sudo systemctl restart ds01-api ds01-runner
 
-          for i in $(seq 1 20); do
+          for i in $(seq 1 30); do
             curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0
             sleep 1
           done
-          echo "API not ready after 20s"
+          echo "API not ready after 30s"
+          curl -v http://127.0.0.1:8765/health 2>&1 || true
           systemctl status ds01-api --no-pager || true
+          ss -tlnp | grep 8765 || echo "Port 8765 not listening"
           exit 1
 
       - name: Integration tests

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -17,16 +17,14 @@ jobs:
       - name: Unit tests
         run: uv run pytest -m 'not integration' --tb=short
 
-      - name: Fix venv permissions and restart services
+      - name: Fix permissions and restart services
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
 
-          sudo systemctl restart ds01-api ds01-runner
+          # ds01 service user needs to traverse $HOME to reach anaconda3 Python
+          chmod o+x /home/datasciencelab
 
-          # Check status immediately (no sudo needed for read-only status)
-          sleep 2
-          systemctl status ds01-api --no-pager || true
-          systemctl status ds01-runner --no-pager || true
+          sudo systemctl restart ds01-api ds01-runner
 
           for i in $(seq 1 20); do
             curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0
@@ -34,8 +32,6 @@ jobs:
           done
           echo "API not ready after 20s"
           systemctl status ds01-api --no-pager || true
-          journalctl --user-unit=ds01-api --no-pager -n 30 || true
-          journalctl -u ds01-api --no-pager -n 30 || true
           exit 1
 
       - name: Integration tests

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -21,25 +21,21 @@ jobs:
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
 
-          # Diagnostics: verify service prerequisites
-          echo "--- Checking service prerequisites ---"
-          ls -la /etc/ds01-jobs/env 2>/dev/null || echo "WARNING: /etc/ds01-jobs/env not found"
-          systemctl list-unit-files ds01-api.service 2>/dev/null || echo "WARNING: ds01-api unit not found"
-          ls -la /opt/ds01-jobs/.venv/bin/uvicorn 2>/dev/null || echo "WARNING: uvicorn not found"
-
           sudo systemctl restart ds01-api ds01-runner
 
-          # Check status immediately after restart
-          sleep 1
-          sudo systemctl status ds01-api --no-pager 2>/dev/null || true
+          # Check status immediately (no sudo needed for read-only status)
+          sleep 2
+          systemctl status ds01-api --no-pager || true
+          systemctl status ds01-runner --no-pager || true
 
-          for i in $(seq 1 15); do
+          for i in $(seq 1 20); do
             curl -sf http://127.0.0.1:8765/health >/dev/null 2>&1 && exit 0
             sleep 1
           done
-          echo "API not ready after 15s"
-          sudo systemctl status ds01-api --no-pager 2>/dev/null || true
-          sudo journalctl -u ds01-api --no-pager -n 30 --since "5 minutes ago" 2>/dev/null || true
+          echo "API not ready after 20s"
+          systemctl status ds01-api --no-pager || true
+          journalctl --user-unit=ds01-api --no-pager -n 30 || true
+          journalctl -u ds01-api --no-pager -n 30 || true
           exit 1
 
       - name: Integration tests

--- a/deploy.sh
+++ b/deploy.sh
@@ -176,8 +176,10 @@ setup_directories() {
     chmod 770 /opt/ds01-jobs/data
 
     mkdir -p /var/lib/ds01-jobs/workspaces
-    chown ds01:ds01 /var/lib/ds01-jobs
-    chown ds01:ds01 /var/lib/ds01-jobs/workspaces
+    chown ds01:ds-admin /var/lib/ds01-jobs
+    chown ds01:ds-admin /var/lib/ds01-jobs/workspaces
+    chmod 0750 /var/lib/ds01-jobs
+    chmod 0750 /var/lib/ds01-jobs/workspaces
 
     mkdir -p /var/log/ds01
     touch /var/log/ds01/events.jsonl

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -100,8 +100,9 @@ class JobExecutor:
         workspace = self.settings.workspace_root / job_id
         workspace.mkdir(parents=True, exist_ok=True)
 
-        # Ensure workspace root is traversable for sudo -u Docker builds
+        # Ensure workspace dirs are traversable for sudo -u Docker builds
         if unix_username:
+            self.settings.workspace_root.parent.chmod(0o755)
             self.settings.workspace_root.chmod(0o755)
 
         try:

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -100,6 +100,10 @@ class JobExecutor:
         workspace = self.settings.workspace_root / job_id
         workspace.mkdir(parents=True, exist_ok=True)
 
+        # Ensure workspace root is traversable for sudo -u Docker builds
+        if unix_username:
+            self.settings.workspace_root.chmod(0o755)
+
         try:
             # Set started_at and record queued phase timestamp
             async with aiosqlite.connect(db_path) as db:

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -116,6 +116,12 @@ class JobExecutor:
                 await db.commit()
 
             await self._clone(job_id, repo_url, branch, workspace, db_path)
+
+            # Make workspace readable by unix_username for Docker build context
+            if unix_username:
+                proc = await asyncio.create_subprocess_exec("chmod", "-R", "a+rX", str(workspace))
+                await proc.wait()
+
             await self._build(job_id, workspace, db_path, unix_username)
             await self._run_container(
                 job_id, workspace, gpu_count, timeout_seconds, db_path, unix_username

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -404,6 +404,8 @@ class JobExecutor:
         container_name = f"ds01-job-{job_id}"
         results_dir = workspace / "results"
         results_dir.mkdir(exist_ok=True)
+        if self._unix_username:
+            results_dir.chmod(0o777)
 
         unix_username = self._unix_username
         if unix_username:

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -122,9 +122,9 @@ class JobExecutor:
 
             await self._clone(job_id, repo_url, branch, workspace, db_path)
 
-            # Make workspace readable by unix_username for Docker build context
+            # Make workspace accessible by unix_username for Docker build/cp
             if unix_username:
-                proc = await asyncio.create_subprocess_exec("chmod", "-R", "a+rX", str(workspace))
+                proc = await asyncio.create_subprocess_exec("chmod", "-R", "a+rwX", str(workspace))
                 await proc.wait()
 
             await self._build(job_id, workspace, db_path, unix_username)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -129,12 +129,13 @@ async def test_execute_clone_failure_retries(
 ) -> None:
     """Clone retries once on failure and succeeds on second attempt."""
     # First clone call fails, second succeeds, rest succeed
-    # Sequence: clone(fail), clone-retry(ok), build(ok), get_resource_limits(ok),
-    #           run(ok), collect(ok), cleanup x3(ok)
+    # Sequence: clone(fail), clone-retry(ok), chmod(ok), build(ok),
+    #           get_resource_limits(ok), run(ok), collect(ok), cleanup x3(ok)
     fail_proc = _mock_process(128)
     ok_proc = _mock_process(0)
     mock_exec.side_effect = [
         fail_proc,
+        ok_proc,
         ok_proc,
         ok_proc,
         ok_proc,
@@ -211,8 +212,8 @@ async def test_execute_build_failure(
     """Build failure sets status=failed with failed_phase=build."""
     ok_proc = _mock_process(0)
     fail_proc = _mock_process(1)
-    # clone ok, build fails, cleanup procs
-    mock_exec.side_effect = [ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+    # clone ok, chmod ok, build fails, cleanup procs
+    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
@@ -247,8 +248,17 @@ async def test_execute_run_failure(
     """Run failure sets status=failed with failed_phase=run."""
     ok_proc = _mock_process(0)
     fail_proc = _mock_process(1)
-    # clone ok, build ok, get_resource_limits ok, run fails, cleanup x3
-    mock_exec.side_effect = [ok_proc, ok_proc, ok_proc, fail_proc, ok_proc, ok_proc, ok_proc]
+    # clone ok, chmod ok, build ok, get_resource_limits ok, run fails, cleanup x3
+    mock_exec.side_effect = [
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+        fail_proc,
+        ok_proc,
+        ok_proc,
+        ok_proc,
+    ]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
@@ -290,9 +300,17 @@ async def test_execute_build_timeout(
     timeout_proc.returncode = None
     timeout_proc.wait.return_value = -9
 
+    chmod_proc = _mock_process(0)
     cleanup_proc = _mock_process(0)
-    # clone ok, build times out, cleanup procs
-    mock_exec.side_effect = [ok_proc, timeout_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+    # clone ok, chmod ok, build times out, cleanup procs
+    mock_exec.side_effect = [
+        ok_proc,
+        chmod_proc,
+        timeout_proc,
+        cleanup_proc,
+        cleanup_proc,
+        cleanup_proc,
+    ]
 
     # First wait_for call (clone) succeeds, second (build) times out
     call_count = 0
@@ -379,8 +397,8 @@ async def test_cleanup_called_on_failure(
     ok_proc = _mock_process(0)
     fail_proc = _mock_process(1)
     cleanup_proc = _mock_process(0)
-    # clone ok, build fails, then 3 cleanup calls (rm, image rm, builder prune)
-    mock_exec.side_effect = [ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+    # clone ok, chmod ok, build fails, then 3 cleanup calls (rm, image rm, builder prune)
+    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(
@@ -439,8 +457,8 @@ async def test_docker_bin_path_used(
     docker = str(executor_settings.docker_bin)
     for c in mock_exec.call_args_list:
         args = c[0] if c[0] else ()
-        # Skip the git clone call and get_resource_limits.py call
-        if args and args[0] in ("git", "python3"):
+        # Skip non-docker calls: git clone, get_resource_limits.py, chmod
+        if args and args[0] in ("git", "python3", "chmod"):
             continue
         # With sudo -u, docker_bin appears at index 3; without, at index 0
         if args:
@@ -484,7 +502,8 @@ async def test_cancel_check_stops_execution(
     """If job is cancelled between phases, executor stops before the next phase."""
     ok_proc = _mock_process(0)
     cleanup_proc = _mock_process(0)
-    mock_exec.side_effect = [ok_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+    # clone ok, chmod ok, build cancelled, cleanup x3
+    mock_exec.side_effect = [ok_proc, ok_proc, cleanup_proc, cleanup_proc, cleanup_proc]
 
     executor = JobExecutor(executor_settings)
 
@@ -752,8 +771,8 @@ async def test_cleanup_uses_sudo(
     ok_proc = _mock_process(0)
     fail_proc = _mock_process(1)
     cleanup_proc = _mock_process(0)
-    # clone ok, build fails, then 3 cleanup calls
-    mock_exec.side_effect = [ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
+    # clone ok, chmod ok, build fails, then 3 cleanup calls
+    mock_exec.side_effect = [ok_proc, ok_proc, fail_proc, cleanup_proc, cleanup_proc, cleanup_proc]
 
     executor = JobExecutor(executor_settings)
     await executor.execute(


### PR DESCRIPTION
## Summary
Fixes integration test failures caused by permission issues when the executor runs Docker commands via `sudo -u {unix_username}`.

**Issues fixed:**
- CI: exclude `data/` from `chmod -R` (owned by ds01, runner can't chmod)
- CI: `chmod g+x /home/datasciencelab` so ds01 can traverse to anaconda3 Python (fixes 203/EXEC)
- CI: sync branch code to deployment directory before restarting services
- CI: use `python3 urllib` instead of `curl` for health checks (curl has env config issues)
- Executor: `chmod -R a+rwX` on workspace after clone for Docker build context access
- Executor: `chmod 0o755` on workspace root parent dirs for traversability
- Executor: `chmod 0o777` on results_dir before `docker cp`
- deploy.sh: workspace dirs use ds-admin group with 0750 for shared access

## Test plan
- [x] 219 unit tests pass
- [x] Integration tests pass via workflow_dispatch on branch (run 23121803154)