### PR TITLE
fix(cli): runner help/output and configure error handling

### DIFF
--- a/src/ds01_jobs/runner.py
+++ b/src/ds01_jobs/runner.py
@@ -140,10 +140,23 @@ class JobRunner:
 
 def cli_main() -> None:
     """CLI entry point for ds01-job-runner."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="ds01-job-runner",
+        description="DS01 job runner - polls for queued jobs and executes them via Docker",
+    )
+    parser.parse_args()
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     settings = Settings()
+    logger.info(
+        "ds01-job-runner starting (db=%s, poll=%.0fs)",
+        settings.db_path,
+        settings.runner_poll_interval,
+    )
     runner = JobRunner(settings)
     asyncio.run(runner.run())

--- a/src/ds01_jobs/submit.py
+++ b/src/ds01_jobs/submit.py
@@ -64,7 +64,7 @@ def _handle_error(resp: httpx.Response) -> None:
 @app.command()
 def configure() -> None:
     """Set up API credentials for ds01-submit."""
-    api_key = typer.prompt("DS01 API key")
+    api_key = resolve_api_key() or typer.prompt("DS01 API key")
     api_url = resolve_api_url()
 
     client = DS01Client(api_key=api_key, base_url=api_url)
@@ -73,6 +73,9 @@ def configure() -> None:
         resp.raise_for_status()
     except httpx.HTTPStatusError:
         typer.echo("Error: Invalid or expired API key", err=True)
+        raise typer.Exit(code=1)
+    except httpx.ConnectError:
+        typer.echo(f"Error: Could not connect to server at {api_url}", err=True)
         raise typer.Exit(code=1)
     finally:
         client.close()

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -49,6 +49,7 @@ def test_configure_success(MockClient, tmp_path, monkeypatch):
     monkeypatch.setenv("DS01_API_URL", "http://localhost:8765")
     creds_path = tmp_path / "credentials"
     monkeypatch.setattr("ds01_jobs.submit.CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr("ds01_jobs.client.CREDENTIALS_PATH", creds_path)
 
     mock_client = MagicMock()
     mock_client.get.return_value = _mock_response(


### PR DESCRIPTION
## Summary
- Add argparse wrapper to ds01-job-runner so --help works instead of hanging
- Add startup log line to runner (db path, poll interval)
- Catch httpx.ConnectError in configure with friendly error message
- Check DS01_API_KEY env var before prompting in configure

## Test plan
- [ ] ds01-job-runner --help prints usage and exits
- [ ] ds01-job-runner logs startup info
- [ ] ds01-submit configure shows friendly error on connection failure
- [ ] DS01_API_KEY env var skips prompt in configure
- [ ] All unit tests pass