### PR TITLE
docs: install instructions, deployment reference, bump daily limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ ds01-submit run https://github.com/hertie-data-science-lab/ds01-test-job --gpus 
 ### 1. Install the CLI
 
 ```bash
-pip install ds01-jobs
+pip install git+https://github.com/hertie-data-science-lab/ds01-jobs.git
 # or with uv:
-uv tool install ds01-jobs
+uv tool install git+https://github.com/hertie-data-science-lab/ds01-jobs.git
 ```
 
 ### 2. Configure your API key

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,7 +177,7 @@ systemd reads it before dropping privileges to the `ds01` user.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DS01_JOBS_DEFAULT_CONCURRENT_LIMIT` | `3` | Per-user concurrent job limit (override via resource-limits.yaml) |
-| `DS01_JOBS_DEFAULT_DAILY_LIMIT` | `10` | Per-user daily submission limit (override via resource-limits.yaml) |
+| `DS01_JOBS_DEFAULT_DAILY_LIMIT` | `20` | Per-user daily submission limit (override via resource-limits.yaml) |
 | `DS01_JOBS_DEFAULT_MAX_RESULT_SIZE_MB` | `1024` | Maximum downloadable result archive size (MB) |
 
 ### Job execution timeouts
@@ -204,7 +204,7 @@ only if your deployment differs from the defaults.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DS01_JOBS_ALLOWED_GITHUB_ORGS` | _(empty - all orgs allowed)_ | Restrict job repo URLs to specific GitHub orgs (comma-separated) |
-| `DS01_JOBS_ALLOWED_BASE_REGISTRIES` | See config.py | Docker registry prefixes permitted in Dockerfiles |
+| `DS01_JOBS_ALLOWED_BASE_REGISTRIES` | `docker.io/library/`, `nvcr.io/nvidia/`, `ghcr.io/astral-sh/`, `docker.io/pytorch/`, `docker.io/tensorflow/`, `docker.io/huggingface/` | Docker registry prefixes permitted in Dockerfiles (comma-separated) |
 | `DS01_JOBS_BLOCKED_ENV_KEYS` | `LD_PRELOAD,LD_LIBRARY_PATH,LD_AUDIT` | ENV keys that cause Dockerfile scan errors |
 | `DS01_JOBS_WARNING_ENV_KEYS` | `LD_DEBUG,PYTHONPATH` | ENV keys that cause Dockerfile scan warnings |
 

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # Rate limiting defaults
     default_concurrent_limit: int = 3
-    default_daily_limit: int = 10
+    default_daily_limit: int = 20
 
     # Result size limit
     default_max_result_size_mb: int = 1024

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -272,14 +272,14 @@ async def test_concurrent_rate_limit_enforced(mock_ssrf, mock_verify, client, au
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
 @patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
 async def test_daily_rate_limit_enforced(mock_ssrf, mock_verify, client, auth_key, db_path):
-    """Seeding 10 completed jobs (default daily limit), next submit returns 429."""
+    """Seeding 20 completed jobs (default daily limit), next submit returns 429."""
     raw_key = auth_key[0]
 
-    # Seed 10 completed jobs directly in DB
-    for _ in range(10):
+    # Seed 20 completed jobs directly in DB
+    for _ in range(20):
         await insert_job(db_path, username="testuser", status="succeeded")
 
-    # 11th submission should hit daily limit
+    # 21st submission should hit daily limit
     body = {"repo_url": "https://github.com/testorg/myrepo"}
     body_bytes = json.dumps(body).encode()
     headers = build_signed_headers(raw_key, "POST", "/api/v1/jobs", body=body_bytes)

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -306,8 +306,8 @@ async def test_submit_job_daily_limit_exceeded(
     raw_key, key_id, key_hash = _create_test_key()
     await _seed_key(db_path, key_id, key_hash)
 
-    # Insert 10 completed jobs today (default daily limit)
-    for _ in range(10):
+    # Insert 20 completed jobs today (default daily limit)
+    for _ in range(20):
         await _insert_job(db_path, status="succeeded")
 
     app = _make_app(db_path)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -220,7 +220,7 @@ async def test_check_rate_limits_passes(tmp_path: Path) -> None:
     assert concurrent_count == 1
     assert concurrent_limit == 3
     assert daily_count == 1
-    assert daily_limit == 20
+    assert daily_limit == 10
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -54,14 +54,14 @@ async def _insert_job(
 
 @pytest.mark.asyncio
 async def test_get_user_limits_defaults() -> None:
-    """No resource-limits.yaml returns settings defaults (3, 10)."""
+    """No resource-limits.yaml returns settings defaults (3, 20)."""
     settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
     with patch(
         "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
     ):
         concurrent, daily = await get_user_limits("someuser", settings)
     assert concurrent == 3
-    assert daily == 10
+    assert daily == 20
 
 
 @pytest.mark.asyncio
@@ -107,7 +107,7 @@ async def test_get_user_limits_unknown_group(tmp_path: Path) -> None:
     ):
         concurrent, daily = await get_user_limits("unknown_unix", settings)
     assert concurrent == 3
-    assert daily == 10
+    assert daily == 20
 
 
 @pytest.mark.asyncio
@@ -220,7 +220,7 @@ async def test_check_rate_limits_passes(tmp_path: Path) -> None:
     assert concurrent_count == 1
     assert concurrent_limit == 3
     assert daily_count == 1
-    assert daily_limit == 10
+    assert daily_limit == 20
 
 
 @pytest.mark.asyncio
@@ -338,7 +338,7 @@ async def test_get_user_quota_info_defaults() -> None:
         group, concurrent, daily, max_result_mb = await get_user_quota_info("someuser", settings)
     assert group == "default"
     assert concurrent == 3
-    assert daily == 10
+    assert daily == 20
     assert max_result_mb == 1024
 
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -576,7 +576,7 @@ async def test_get_quota_defaults(mock_group: AsyncMock, tmp_path: Path) -> None
     data = resp.json()
     assert data["group"] == "default"
     assert data["concurrent"]["limit"] == 3
-    assert data["daily"]["limit"] == 10
+    assert data["daily"]["limit"] == 20
     assert data["max_result_size_mb"] == 1024
     assert data["username"] == "testuser"
 


### PR DESCRIPTION
## Summary
- README: use git+https install URL instead of PyPI (package is not published)
- Deployment guide: list actual allowed base registries instead of "See config.py"
- Bump default daily submission limit from 10 to 20

## Test plan
- [ ] README install instructions use git+https URL
- [ ] Deployment docs show actual registry list
- [ ] config.py default_daily_limit is 20