### PR TITLE
fix(cli): catch ConnectError in all submit commands

### DIFF
--- a/ds01-test-job/README.md
+++ b/ds01-test-job/README.md
@@ -1,0 +1,7 @@
+# ds01-test-job
+
+Minimal test job for ds01-jobs integration tests.
+
+Runs `nvidia-smi` and writes output to `/output/gpu.txt`, verifying the full GPU pipeline works end-to-end.
+
+Used by `tests/integration/test_lifecycle.py` in [ds01-jobs](https://github.com/hertie-data-science-lab/ds01-jobs).

--- a/src/ds01_jobs/submit.py
+++ b/src/ds01_jobs/submit.py
@@ -46,6 +46,15 @@ def _get_client() -> DS01Client:
     return DS01Client(api_key=api_key, base_url=resolve_api_url())
 
 
+def _api_call(func: object, *args: object, **kwargs: object) -> httpx.Response:
+    """Wrap an API call with ConnectError handling."""
+    try:
+        return func(*args, **kwargs)  # type: ignore[operator]
+    except httpx.ConnectError:
+        typer.echo(f"Error: Could not connect to server at {resolve_api_url()}", err=True)
+        raise typer.Exit(code=1)
+
+
 def _handle_error(resp: httpx.Response) -> None:
     """Print a structured error message from an API error response and exit."""
     try:
@@ -114,7 +123,7 @@ def run_job(
         if dockerfile is not None:
             body["dockerfile_content"] = dockerfile.read_text()
 
-        resp = client.post("/api/v1/jobs", json=body)
+        resp = _api_call(client.post, "/api/v1/jobs", json=body)
         if resp.status_code != 202:
             _handle_error(resp)
 
@@ -142,7 +151,7 @@ def status(
         max_backoff = 30.0
 
         while True:
-            resp = client.get(f"/api/v1/jobs/{job_id}")
+            resp = _api_call(client.get, f"/api/v1/jobs/{job_id}")
             if resp.status_code != 200:
                 _handle_error(resp)
 
@@ -256,7 +265,7 @@ def list_jobs(
     """List submitted jobs."""
     client = _get_client()
     try:
-        resp = client.get(f"/api/v1/jobs?limit={limit}&offset={offset}")
+        resp = _api_call(client.get, f"/api/v1/jobs?limit={limit}&offset={offset}")
         if resp.status_code != 200:
             _handle_error(resp)
 
@@ -304,7 +313,7 @@ def cancel(
     """Cancel a running job."""
     client = _get_client()
     try:
-        resp = client.post(f"/api/v1/jobs/{job_id}/cancel")
+        resp = _api_call(client.post, f"/api/v1/jobs/{job_id}/cancel")
         if resp.status_code not in (200, 202):
             _handle_error(resp)
 

--- a/src/ds01_jobs/submit.py
+++ b/src/ds01_jobs/submit.py
@@ -8,6 +8,7 @@ import io
 import json
 import tarfile
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated
 
@@ -46,10 +47,12 @@ def _get_client() -> DS01Client:
     return DS01Client(api_key=api_key, base_url=resolve_api_url())
 
 
-def _api_call(func: object, *args: object, **kwargs: object) -> httpx.Response:
+def _api_call(
+    func: Callable[..., httpx.Response], *args: object, **kwargs: object
+) -> httpx.Response:
     """Wrap an API call with ConnectError handling."""
     try:
-        return func(*args, **kwargs)  # type: ignore[operator]
+        return func(*args, **kwargs)
     except httpx.ConnectError:
         typer.echo(f"Error: Could not connect to server at {resolve_api_url()}", err=True)
         raise typer.Exit(code=1)

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -204,6 +204,9 @@ def test_configure_invalid_key(integration_env, tmp_path: Path, monkeypatch: pyt
     """configure with invalid key prints error and exits 1."""
     creds_path = tmp_path / "creds" / "credentials"
     monkeypatch.setattr("ds01_jobs.submit.CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr("ds01_jobs.client.CREDENTIALS_PATH", creds_path)
+    # Unset DS01_API_KEY so configure falls through to the prompt input
+    monkeypatch.delenv("DS01_API_KEY", raising=False)
 
     result = runner.invoke(submit_app, ["configure"], input="invalid_key_abc\n")
     assert result.exit_code == 1
@@ -315,7 +318,12 @@ def test_cancel_job(integration_env):
 def test_no_credentials_error(monkeypatch: pytest.MonkeyPatch):
     """Commands without credentials print helpful error."""
     monkeypatch.delenv("DS01_API_KEY", raising=False)
-    # Ensure credentials file doesn't exist
+    # Ensure credentials file doesn't exist - patch in both client (where
+    # resolve_api_key reads it) and submit (where configure writes it)
+    monkeypatch.setattr(
+        "ds01_jobs.client.CREDENTIALS_PATH",
+        Path("/nonexistent/path/credentials"),
+    )
     monkeypatch.setattr(
         "ds01_jobs.submit.CREDENTIALS_PATH",
         Path("/nonexistent/path/credentials"),


### PR DESCRIPTION
## Summary
- Add `_api_call()` wrapper that catches `httpx.ConnectError` with a friendly error message
- Apply to all commands: run, status, list, cancel (configure was already fixed in #57)
- Previously only `configure` caught ConnectError; all other commands showed a full traceback

Found during UAT Test 31 when `ds01-submit status` was called without `DS01_API_URL` set.

## Test plan
- [ ] `ds01-submit status <id>` with bad URL shows friendly error, no traceback
- [ ] `ds01-submit list` with bad URL shows friendly error
- [ ] `ds01-submit run` with bad URL shows friendly error
- [ ] `ds01-submit cancel <id>` with bad URL shows friendly error
- [ ] All unit tests pass