### PR TITLE
refactor: wire in orphaned models, remove dead code, add GPU validation

### DIFF
--- a/src/ds01_jobs/app.py
+++ b/src/ds01_jobs/app.py
@@ -17,6 +17,7 @@ from ds01_jobs.database import init_db
 from ds01_jobs.health import router as health_router
 from ds01_jobs.jobs import router as jobs_router
 from ds01_jobs.middleware import limiter, rate_limit_handler
+from ds01_jobs.models import APIError, ErrorDetail, ErrorResponse
 
 
 @asynccontextmanager
@@ -28,27 +29,20 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 async def _validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """Return Stripe-like structured 422 for validation errors."""
-    errors = []
-    for err in exc.errors():
-        # Build field path, skipping the "body" prefix that Pydantic adds
-        field = ".".join(str(loc) for loc in err.get("loc", []) if loc != "body")
-        errors.append(
-            {
-                "field": field or "unknown",
-                "code": err.get("type", "validation_error"),
-                "message": err.get("msg", "Validation failed"),
-            }
+    errors = [
+        ErrorDetail(
+            field=".".join(str(loc) for loc in err.get("loc", []) if loc != "body") or "unknown",
+            code=err.get("type", "validation_error"),
+            message=err.get("msg", "Validation failed"),
         )
-    return JSONResponse(
-        status_code=422,
-        content={
-            "error": {
-                "type": "validation_error",
-                "message": "Request validation failed",
-                "errors": errors,
-            }
-        },
+        for err in exc.errors()
+    ]
+    body = APIError(
+        error=ErrorResponse(
+            type="validation_error", message="Request validation failed", errors=errors
+        )
     )
+    return JSONResponse(status_code=422, content=body.model_dump())
 
 
 def create_app() -> FastAPI:

--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -71,7 +71,7 @@ class JobExecutor:
                 return []
             args = stdout.decode().strip().split()
             return [a for a in args if not a.startswith("--cgroup-parent=")]
-        except (TimeoutError, FileNotFoundError, OSError) as exc:
+        except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
             logger.warning("get_resource_limits.py error for %s: %s", unix_username, exc)
             return []
 

--- a/src/ds01_jobs/jobs.py
+++ b/src/ds01_jobs/jobs.py
@@ -27,7 +27,11 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from ds01_jobs.auth import get_current_user
 from ds01_jobs.config import Settings
 from ds01_jobs.database import get_db
+from ds01_jobs.gpu import get_gpu_count
 from ds01_jobs.models import (
+    APIError,
+    ErrorDetail,
+    ErrorResponse,
     JobDetailResponse,
     JobError,
     JobListResponse,
@@ -39,7 +43,12 @@ from ds01_jobs.models import (
     QuotaResponse,
     UsageCount,
 )
-from ds01_jobs.rate_limit import check_rate_limits, get_user_job_counts, get_user_quota_info
+from ds01_jobs.rate_limit import (
+    ACTIVE_STATUSES,
+    check_rate_limits,
+    get_user_job_counts,
+    get_user_quota_info,
+)
 from ds01_jobs.scanner import scan_dockerfile
 from ds01_jobs.url_validation import check_ssrf, validate_repo_url_format, verify_repo_accessible
 
@@ -55,6 +64,16 @@ def _get_settings() -> Settings:
 
 
 MAX_LOG_BYTES = 1_048_576  # 1 MB per phase
+
+
+def _validation_error_response(
+    error_type: str, message: str, errors: list[ErrorDetail]
+) -> JSONResponse:
+    """Build a structured 422 JSONResponse using the standard error models."""
+    body = APIError(error=ErrorResponse(type=error_type, message=message, errors=errors))
+    return JSONResponse(status_code=422, content=body.model_dump())
+
+
 DEFAULT_PAGE_LIMIT = 20
 MAX_PAGE_LIMIT = 100
 
@@ -102,21 +121,10 @@ async def submit_job(
     try:
         owner, repo = validate_repo_url_format(body.repo_url, settings.allowed_github_orgs)
     except ValueError as e:
-        return JSONResponse(  # type: ignore[return-value]
-            status_code=422,
-            content={
-                "error": {
-                    "type": "validation_error",
-                    "message": str(e),
-                    "errors": [
-                        {
-                            "field": "repo_url",
-                            "code": "invalid_url",
-                            "message": str(e),
-                        }
-                    ],
-                }
-            },
+        return _validation_error_response(  # type: ignore[return-value]
+            "validation_error",
+            str(e),
+            [ErrorDetail(field="repo_url", code="invalid_url", message=str(e))],
         )
 
     # 2. Rate limit check (raises 429 on failure)
@@ -124,7 +132,17 @@ async def submit_job(
         db, unix_username, username, settings
     )
 
-    # 3. SSRF check
+    # 3. GPU count validation
+    total_gpus = await get_gpu_count()
+    if total_gpus > 0 and body.gpu_count > total_gpus:
+        msg = f"Requested {body.gpu_count} GPUs but only {total_gpus} available on this server"
+        return _validation_error_response(  # type: ignore[return-value]
+            "validation_error",
+            msg,
+            [ErrorDetail(field="gpu_count", code="exceeds_total", message=msg)],
+        )
+
+    # 4. SSRF check
     try:
         await check_ssrf("github.com")
     except ValueError as e:
@@ -134,21 +152,10 @@ async def submit_job(
     try:
         await verify_repo_accessible(body.repo_url, settings.preflight_timeout_seconds)
     except ValueError as e:
-        return JSONResponse(  # type: ignore[return-value]
-            status_code=422,
-            content={
-                "error": {
-                    "type": "validation_error",
-                    "message": str(e),
-                    "errors": [
-                        {
-                            "field": "repo_url",
-                            "code": "repo_not_found",
-                            "message": str(e),
-                        }
-                    ],
-                }
-            },
+        return _validation_error_response(  # type: ignore[return-value]
+            "validation_error",
+            str(e),
+            [ErrorDetail(field="repo_url", code="repo_not_found", message=str(e))],
         )
 
     # 5. Dockerfile scan (if provided)
@@ -159,24 +166,17 @@ async def submit_job(
             settings.blocked_env_keys,
             settings.warning_env_keys,
         )
-        errors = [v for v in violations if v.severity == "error"]
-        if errors:
-            return JSONResponse(  # type: ignore[return-value]
-                status_code=422,
-                content={
-                    "error": {
-                        "type": "dockerfile_scan_error",
-                        "message": "Dockerfile scan found errors",
-                        "errors": [
-                            {
-                                "field": f"dockerfile_content:{v.line}",
-                                "code": v.rule,
-                                "message": v.message,
-                            }
-                            for v in errors
-                        ],
-                    }
-                },
+        scan_errors = [v for v in violations if v.severity == "error"]
+        if scan_errors:
+            return _validation_error_response(  # type: ignore[return-value]
+                "dockerfile_scan_error",
+                "Dockerfile scan found errors",
+                [
+                    ErrorDetail(
+                        field=f"dockerfile_content:{v.line}", code=v.rule, message=v.message
+                    )
+                    for v in scan_errors
+                ],
             )
 
     # 6. Generate job_id
@@ -235,9 +235,6 @@ async def submit_job(
         status_url=f"/api/v1/jobs/{job_id}",
         created_at=now_iso,
     )
-
-
-ACTIVE_STATUSES = ("queued", "cloning", "building", "running")
 
 
 @router.post("/jobs/{job_id}/cancel", status_code=200)

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -23,12 +23,6 @@ class RateLimitResponse(BaseModel):
     max_allowed: int
 
 
-class AuthErrorResponse(BaseModel):
-    """Response schema for 401 authentication errors."""
-
-    detail: str = "Authentication failed"
-
-
 # --- Job submission models ---
 
 
@@ -83,15 +77,6 @@ class RateLimitErrorResponse(BaseModel):
     limit: int
     current: int
     retry_after: int | None
-
-
-class ScanViolationModel(BaseModel):
-    """Pydantic model for a single Dockerfile scan violation."""
-
-    line: int
-    severity: str
-    rule: str
-    message: str
 
 
 # --- Status and results models ---

--- a/src/ds01_jobs/rate_limit.py
+++ b/src/ds01_jobs/rate_limit.py
@@ -15,6 +15,7 @@ import yaml
 from fastapi import HTTPException
 
 from ds01_jobs.config import Settings
+from ds01_jobs.models import RateLimitErrorResponse
 
 logger = logging.getLogger(__name__)
 
@@ -52,28 +53,6 @@ async def _get_user_group(unix_username: str, bin_path: Path) -> str:
     except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
         logger.warning("get_resource_limits.py --group error for %s: %s", unix_username, exc)
     return "default"
-
-
-async def get_user_limits(unix_username: str, settings: Settings) -> tuple[int, int]:
-    """Return (concurrent_limit, daily_limit) for a user based on their group.
-
-    Precedence (lowest to highest):
-    1. Settings defaults
-    2. resource-limits.yaml group limits (group resolved via subprocess)
-    """
-    concurrent = settings.default_concurrent_limit
-    daily = settings.default_daily_limit
-
-    group = await _get_user_group(unix_username, settings.get_resource_limits_bin)
-
-    data = load_resource_limits(settings.resource_limits_path)
-    groups = data.get("groups", {})
-    if group in groups:
-        group_cfg = groups[group]
-        concurrent = group_cfg.get("max_concurrent_jobs", concurrent)
-        daily = group_cfg.get("max_daily_submissions", daily)
-
-    return concurrent, daily
 
 
 async def get_user_quota_info(unix_username: str, settings: Settings) -> tuple[str, int, int, int]:
@@ -135,26 +114,19 @@ async def check_rate_limits(
 
     Returns (concurrent_count, concurrent_limit, daily_count, daily_limit) on success.
     """
-    concurrent_limit, daily_limit = await get_user_limits(unix_username, settings)
+    _, concurrent_limit, daily_limit, _ = await get_user_quota_info(unix_username, settings)
     concurrent_count, daily_count = await get_user_job_counts(db, username)
 
     # Check concurrent limit first
     if concurrent_count >= concurrent_limit:
-        raise HTTPException(
-            status_code=429,
-            detail={
-                "error": {
-                    "type": "rate_limit_error",
-                    "limit_type": "concurrent",
-                    "message": (
-                        f"Concurrent job limit reached ({concurrent_count}/{concurrent_limit})"
-                    ),
-                    "limit": concurrent_limit,
-                    "current": concurrent_count,
-                    "retry_after": None,
-                }
-            },
+        body = RateLimitErrorResponse(
+            limit_type="concurrent",
+            message=f"Concurrent job limit reached ({concurrent_count}/{concurrent_limit})",
+            limit=concurrent_limit,
+            current=concurrent_count,
+            retry_after=None,
         )
+        raise HTTPException(status_code=429, detail={"error": body.model_dump()})
 
     # Check daily limit
     if daily_count >= daily_limit:
@@ -165,19 +137,17 @@ async def check_rate_limits(
         )
         retry_after = int((midnight_tomorrow - now).total_seconds())
 
+        body = RateLimitErrorResponse(
+            limit_type="daily",
+            message=f"Daily submission limit reached ({daily_count}/{daily_limit})",
+            limit=daily_limit,
+            current=daily_count,
+            retry_after=retry_after,
+        )
         raise HTTPException(
             status_code=429,
             headers={"Retry-After": str(retry_after)},
-            detail={
-                "error": {
-                    "type": "rate_limit_error",
-                    "limit_type": "daily",
-                    "message": f"Daily submission limit reached ({daily_count}/{daily_limit})",
-                    "limit": daily_limit,
-                    "current": daily_count,
-                    "retry_after": retry_after,
-                }
-            },
+            detail={"error": body.model_dump()},
         )
 
     return concurrent_count, concurrent_limit, daily_count, daily_limit

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -436,3 +436,37 @@ async def test_submit_job_repo_not_found(
     assert resp.status_code == 422
     data = resp.json()
     assert data["error"]["errors"][0]["code"] == "repo_not_found"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
+@patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.check_ssrf", new_callable=AsyncMock)
+@patch("ds01_jobs.jobs.get_gpu_count", new_callable=AsyncMock, return_value=4)
+async def test_submit_job_gpu_count_exceeds_total(
+    mock_gpu: AsyncMock,
+    mock_ssrf: AsyncMock,
+    mock_verify: AsyncMock,
+    mock_group: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    """Requesting more GPUs than available returns 422 with exceeds_total."""
+    db_path = tmp_path / "test.db"
+    await init_db(db_path=db_path)
+
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
+
+    app = _make_app(db_path)
+    body = {"repo_url": "https://github.com/testorg/myrepo", "gpu_count": 8}
+    headers = _build_headers(raw_key, body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/jobs", content=json.dumps(body), headers=headers)
+
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data["error"]["type"] == "validation_error"
+    assert data["error"]["errors"][0]["field"] == "gpu_count"
+    assert data["error"]["errors"][0]["code"] == "exceeds_total"

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -13,7 +13,6 @@ from ds01_jobs.rate_limit import (
     _get_user_group,
     check_rate_limits,
     get_user_job_counts,
-    get_user_limits,
     get_user_quota_info,
 )
 
@@ -53,49 +52,7 @@ async def _insert_job(
 
 
 @pytest.mark.asyncio
-async def test_get_user_limits_defaults() -> None:
-    """No resource-limits.yaml returns settings defaults (3, 20)."""
-    settings = _test_settings(resource_limits_path=Path("/nonexistent/path.yaml"))
-    with patch(
-        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
-    ):
-        concurrent, daily = await get_user_limits("someuser", settings)
-    assert concurrent == 3
-    assert daily == 20
-
-
-@pytest.mark.asyncio
-async def test_get_user_limits_from_group(tmp_path: Path) -> None:
-    """User resolved to student group gets group limits (2, 5)."""
-    yaml_path = tmp_path / "resource-limits.yaml"
-    yaml_path.write_text(
-        "groups:\n"
-        "  student:\n"
-        "    max_concurrent_jobs: 2\n"
-        "    max_daily_submissions: 5\n"
-        "  researcher:\n"
-        "    max_concurrent_jobs: 5\n"
-        "    max_daily_submissions: 20\n"
-    )
-    settings = _test_settings(resource_limits_path=yaml_path)
-
-    with patch(
-        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="student"
-    ):
-        concurrent, daily = await get_user_limits("bob_unix", settings)
-    assert concurrent == 2
-    assert daily == 5
-
-    with patch(
-        "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="researcher"
-    ):
-        concurrent, daily = await get_user_limits("alice_unix", settings)
-    assert concurrent == 5
-    assert daily == 20
-
-
-@pytest.mark.asyncio
-async def test_get_user_limits_unknown_group(tmp_path: Path) -> None:
+async def test_get_user_quota_info_unknown_group(tmp_path: Path) -> None:
     """User with group not in YAML falls back to defaults."""
     yaml_path = tmp_path / "resource-limits.yaml"
     yaml_path.write_text(
@@ -105,9 +62,13 @@ async def test_get_user_limits_unknown_group(tmp_path: Path) -> None:
     with patch(
         "ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default"
     ):
-        concurrent, daily = await get_user_limits("unknown_unix", settings)
+        group, concurrent, daily, max_result_mb = await get_user_quota_info(
+            "unknown_unix", settings
+        )
+    assert group == "default"
     assert concurrent == 3
     assert daily == 20
+    assert max_result_mb == 1024
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Wire `ErrorDetail`/`ErrorResponse`/`APIError` models into validation error responses (`app.py`, `jobs.py`) and `RateLimitErrorResponse` into per-user 429s — these models existed but were never imported
- Delete genuinely unused `AuthErrorResponse` and `ScanViolationModel` from `models.py`
- Add `gpu_count > total` validation at submission time using the existing `get_gpu_count()` function (was previously unused in production code)
- Consolidate `get_user_limits()` into `get_user_quota_info()` — identical group resolution + config loading was duplicated
- Deduplicate `ACTIVE_STATUSES` constant (defined identically in `rate_limit.py` and `jobs.py`)
- Extract `_validation_error_response()` helper replacing 3 identical hand-crafted dict constructions
- Fix `TimeoutError` → `asyncio.TimeoutError` in `executor.py` for Python 3.10 compatibility

Net: -59 lines, no external behaviour change except the new GPU count validation.

## Follow-up items (separate PRs)

- **Test helper duplication**: `_create_test_key`, `_sign_request`, `_seed_key`, `_make_app` are copy-pasted across 5-6 test files — should be shared fixtures in `conftest.py`
- **429 response format inconsistency**: global rate limiter (`RateLimitResponse` — flat) vs per-user (`RateLimitErrorResponse` — nested `error.error`) return different JSON shapes for the same status code

## Test plan

- [x] `uv run pytest tests/unit/ -x -v` — 206 passed
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — all passed
- [x] `uv run ruff format --check src/ tests/` — all formatted