### PR TITLE
refactor: unify 429 response format across rate limiters

### DIFF
--- a/src/ds01_jobs/middleware.py
+++ b/src/ds01_jobs/middleware.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 
-from ds01_jobs.models import RateLimitResponse
+from ds01_jobs.models import RateLimitErrorResponse
 
 
 def _get_api_key_identifier(request: Request) -> str:
@@ -28,14 +28,20 @@ limiter = Limiter(key_func=_get_api_key_identifier, default_limits=["60/minute"]
 
 
 async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    """Custom 429 handler returning structured JSON body."""
+    """Custom 429 handler returning structured JSON body.
+
+    Uses the same {detail: {error: ...}} shape as per-user rate limits
+    so clients see a consistent 429 format.
+    """
+    body = RateLimitErrorResponse(
+        limit_type="global",
+        message="Global rate limit exceeded (60/minute)",
+        limit=60,
+        current=60,
+        retry_after=60,
+    )
     return JSONResponse(
         status_code=429,
-        content=RateLimitResponse(
-            retry_after_seconds=60,
-            limit_type="global",
-            current_count=60,
-            max_allowed=60,
-        ).model_dump(),
+        content={"detail": {"error": body.model_dump()}},
         headers={"Retry-After": "60"},
     )

--- a/src/ds01_jobs/models.py
+++ b/src/ds01_jobs/models.py
@@ -13,16 +13,6 @@ class HealthResponse(BaseModel):
     db: Literal["ok", "error"]
 
 
-class RateLimitResponse(BaseModel):
-    """Response schema for 429 rate limit errors."""
-
-    error: str = "rate_limit_exceeded"
-    retry_after_seconds: int
-    limit_type: str
-    current_count: int
-    max_allowed: int
-
-
 # --- Job submission models ---
 
 
@@ -69,7 +59,7 @@ class APIError(BaseModel):
 
 
 class RateLimitErrorResponse(BaseModel):
-    """Structured 429 response body for per-user rate limits."""
+    """Structured 429 response body for all rate limits (global and per-user)."""
 
     type: Literal["rate_limit_error"] = "rate_limit_error"
     limit_type: str

--- a/src/ds01_jobs/submit.py
+++ b/src/ds01_jobs/submit.py
@@ -62,8 +62,15 @@ def _handle_error(resp: httpx.Response) -> None:
     """Print a structured error message from an API error response and exit."""
     try:
         body = resp.json()
+        # 422 validation errors: {"error": {"message": "..."}}
         if "error" in body and isinstance(body["error"], dict):
             typer.echo(f"Error: {body['error'].get('message', resp.status_code)}", err=True)
+        # 429 rate limits / HTTPException: {"detail": {"error": {"message": "..."}}}
+        elif "detail" in body and isinstance(body["detail"], dict):
+            inner = body["detail"].get("error", {})
+            msg = inner.get("message") if isinstance(inner, dict) else None
+            typer.echo(f"Error: {msg or body['detail']}", err=True)
+        # Simple HTTPException: {"detail": "string"}
         elif "detail" in body:
             typer.echo(f"Error: {body['detail']}", err=True)
         else:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,90 +1,19 @@
 """Tests for ds01_jobs.auth module - HMAC-SHA256 authentication."""
 
-import hashlib
-import hmac
-import secrets
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import init_db
-
-
-def _create_test_key() -> tuple[str, str, str]:
-    """Generate a test API key, key_id, and bcrypt hash.
-
-    Returns (raw_key, key_id, key_hash).
-    """
-    random_part = secrets.token_urlsafe(32)
-    raw_key = f"ds01_{random_part}"
-    key_id = random_part[:8]
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
-    return raw_key, key_id, key_hash
-
-
-def _sign_request(
-    raw_key: str,
-    method: str,
-    path: str,
-    body: bytes = b"",
-    timestamp: float | None = None,
-    nonce: str | None = None,
-) -> dict[str, str]:
-    """Build HMAC signing headers for a test request.
-
-    Returns dict of headers: X-Timestamp, X-Nonce, X-Signature.
-    """
-    ts = str(timestamp if timestamp is not None else time.time())
-    n = nonce or secrets.token_urlsafe(16)
-    body_hash = hashlib.sha256(body).hexdigest()
-    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
-    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-    return {
-        "X-Timestamp": ts,
-        "X-Nonce": n,
-        "X-Signature": sig,
-    }
-
-
-async def _seed_key(
-    db_path: Path,
-    key_id: str,
-    key_hash: str,
-    username: str = "testuser",
-    unix_username: str = "testuser_unix",
-    expires_at: str | None = None,
-    revoked: int = 0,
-) -> None:
-    """Insert a test API key into the database."""
-    import aiosqlite
-
-    if expires_at is None:
-        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
-
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            "INSERT INTO api_keys "
-            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                username,
-                unix_username,
-                key_id,
-                key_hash,
-                datetime.now(UTC).isoformat(),
-                expires_at,
-                revoked,
-            ),
-        )
-        await db.commit()
+from tests.helpers import create_test_key, seed_key, sign_request
 
 
 def _make_app(db_path: Path):
     """Create a minimal FastAPI app with the auth dependency for testing."""
+    import aiosqlite
     from fastapi import Depends, FastAPI
 
     from ds01_jobs.auth import get_current_user
@@ -93,8 +22,6 @@ def _make_app(db_path: Path):
     app = FastAPI()
 
     async def _override_get_db():
-        import aiosqlite
-
         async with aiosqlite.connect(db_path) as db:
             db.row_factory = aiosqlite.Row
             yield db
@@ -114,11 +41,11 @@ async def test_valid_hmac_auth_passes(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -137,7 +64,7 @@ async def test_invalid_key_prefix_returns_401(tmp_path: Path):
 
     app = _make_app(db_path)
     headers = {"Authorization": "Bearer badprefix_abc12345"}
-    headers.update(_sign_request("badprefix_abc12345", "GET", "/protected"))
+    headers.update(sign_request("badprefix_abc12345", "GET", "/protected"))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -153,12 +80,12 @@ async def test_expired_key_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
+    raw_key, key_id, key_hash = create_test_key()
     expired = (datetime.now(UTC) - timedelta(days=1)).isoformat()
-    await _seed_key(db_path, key_id, key_hash, expires_at=expired)
+    await seed_key(db_path, key_id, key_hash, expires_at=expired)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -174,11 +101,11 @@ async def test_revoked_key_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash, revoked=1)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash, revoked=1)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -194,12 +121,12 @@ async def test_stale_timestamp_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     stale_ts = time.time() - 600  # 10 minutes ago
-    headers = _sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
+    headers = sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -215,14 +142,14 @@ async def test_nonce_replay_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     fixed_nonce = "replay-nonce-123"
 
     # First request should succeed
-    headers1 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers1 = sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
     headers1["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -231,7 +158,7 @@ async def test_nonce_replay_returns_401(tmp_path: Path):
     assert resp1.status_code == 200
 
     # Second request with same nonce should fail
-    headers2 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers2 = sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
     headers2["Authorization"] = f"Bearer {raw_key}"
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -245,11 +172,11 @@ async def test_invalid_hmac_signature_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["X-Signature"] = "deadbeef" * 8  # tampered
     headers["Authorization"] = f"Bearer {raw_key}"
 
@@ -266,12 +193,12 @@ async def test_expiry_warning_header_set_when_within_14_days(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
+    raw_key, key_id, key_hash = create_test_key()
     expires = datetime.now(UTC) + timedelta(days=7)
-    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+    await seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -290,12 +217,12 @@ async def test_expiry_warning_header_not_set_when_far_from_expiry(tmp_path: Path
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
+    raw_key, key_id, key_hash = create_test_key()
     expires = datetime.now(UTC) + timedelta(days=60)
-    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+    await seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -312,11 +239,11 @@ async def test_last_used_at_updated_after_successful_auth(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -341,11 +268,11 @@ async def test_auth_returns_unix_username(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,19 +1,90 @@
 """Tests for ds01_jobs.auth module - HMAC-SHA256 authentication."""
 
+import hashlib
+import hmac
+import secrets
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import init_db
-from tests.helpers import create_test_key, seed_key, sign_request
+
+
+def _create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash.
+
+    Returns (raw_key, key_id, key_hash).
+    """
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def _sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request.
+
+    Returns dict of headers: X-Timestamp, X-Nonce, X-Signature.
+    """
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def _seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    unix_username: str = "testuser_unix",
+    expires_at: str | None = None,
+    revoked: int = 0,
+) -> None:
+    """Insert a test API key into the database."""
+    import aiosqlite
+
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                unix_username,
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                revoked,
+            ),
+        )
+        await db.commit()
 
 
 def _make_app(db_path: Path):
     """Create a minimal FastAPI app with the auth dependency for testing."""
-    import aiosqlite
     from fastapi import Depends, FastAPI
 
     from ds01_jobs.auth import get_current_user
@@ -22,6 +93,8 @@ def _make_app(db_path: Path):
     app = FastAPI()
 
     async def _override_get_db():
+        import aiosqlite
+
         async with aiosqlite.connect(db_path) as db:
             db.row_factory = aiosqlite.Row
             yield db
@@ -41,11 +114,11 @@ async def test_valid_hmac_auth_passes(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -64,7 +137,7 @@ async def test_invalid_key_prefix_returns_401(tmp_path: Path):
 
     app = _make_app(db_path)
     headers = {"Authorization": "Bearer badprefix_abc12345"}
-    headers.update(sign_request("badprefix_abc12345", "GET", "/protected"))
+    headers.update(_sign_request("badprefix_abc12345", "GET", "/protected"))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -80,12 +153,12 @@ async def test_expired_key_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
+    raw_key, key_id, key_hash = _create_test_key()
     expired = (datetime.now(UTC) - timedelta(days=1)).isoformat()
-    await seed_key(db_path, key_id, key_hash, expires_at=expired)
+    await _seed_key(db_path, key_id, key_hash, expires_at=expired)
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -101,11 +174,11 @@ async def test_revoked_key_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash, revoked=1)
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, revoked=1)
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -121,12 +194,12 @@ async def test_stale_timestamp_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     stale_ts = time.time() - 600  # 10 minutes ago
-    headers = sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
+    headers = _sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -142,14 +215,14 @@ async def test_nonce_replay_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     fixed_nonce = "replay-nonce-123"
 
     # First request should succeed
-    headers1 = sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers1 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
     headers1["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -158,7 +231,7 @@ async def test_nonce_replay_returns_401(tmp_path: Path):
     assert resp1.status_code == 200
 
     # Second request with same nonce should fail
-    headers2 = sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers2 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
     headers2["Authorization"] = f"Bearer {raw_key}"
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -172,11 +245,11 @@ async def test_invalid_hmac_signature_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["X-Signature"] = "deadbeef" * 8  # tampered
     headers["Authorization"] = f"Bearer {raw_key}"
 
@@ -193,12 +266,12 @@ async def test_expiry_warning_header_set_when_within_14_days(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
+    raw_key, key_id, key_hash = _create_test_key()
     expires = datetime.now(UTC) + timedelta(days=7)
-    await seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -217,12 +290,12 @@ async def test_expiry_warning_header_not_set_when_far_from_expiry(tmp_path: Path
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
+    raw_key, key_id, key_hash = _create_test_key()
     expires = datetime.now(UTC) + timedelta(days=60)
-    await seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -239,11 +312,11 @@ async def test_last_used_at_updated_after_successful_auth(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -268,11 +341,11 @@ async def test_auth_returns_unix_username(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = create_test_key()
-    await seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
+    raw_key, key_id, key_hash = _create_test_key()
+    await _seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
 
     app = _make_app(db_path)
-    headers = sign_request(raw_key, "GET", "/protected")
+    headers = _sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)


### PR DESCRIPTION
## Summary

- Global rate limiter (slowapi/middleware.py) and per-user rate limiter (rate_limit.py) now return the same JSON shape: `{"detail": {"error": {"type", "limit_type", "message", "limit", "current", "retry_after"}}}`
- Delete `RateLimitResponse` model — replaced by `RateLimitErrorResponse` for both use cases
- Update CLI `_handle_error` to extract message from nested `detail.error` path

Previously clients received completely different JSON schemas depending on which rate limiter triggered a 429.

## Test plan

- [x] `uv run pytest tests/unit/ -x -v` — 206 passed
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — all passed
- [x] `uv run ruff format --check src/ tests/` — all formatted