### PR TITLE
refactor(tests): extract duplicated auth helpers into shared module

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,74 @@
+"""Shared test helpers for ds01-jobs API authentication."""
+
+import hashlib
+import hmac
+import secrets
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import bcrypt
+
+
+def create_test_key() -> tuple[str, str, str]:
+    """Generate a test API key, key_id, and bcrypt hash."""
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"ds01_{random_part}"
+    key_id = random_part[:8]
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return raw_key, key_id, key_hash
+
+
+def sign_request(
+    raw_key: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build HMAC signing headers for a test request."""
+    ts = str(timestamp if timestamp is not None else time.time())
+    n = nonce or secrets.token_urlsafe(16)
+    body_hash = hashlib.sha256(body).hexdigest()
+    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
+    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Timestamp": ts,
+        "X-Nonce": n,
+        "X-Signature": sig,
+    }
+
+
+async def seed_key(
+    db_path: Path,
+    key_id: str,
+    key_hash: str,
+    username: str = "testuser",
+    unix_username: str | None = None,
+    expires_at: str | None = None,
+    revoked: int = 0,
+) -> None:
+    """Insert a test API key into the database."""
+    if unix_username is None:
+        unix_username = f"{username}_unix"
+    if expires_at is None:
+        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO api_keys "
+            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                username,
+                unix_username,
+                key_id,
+                key_hash,
+                datetime.now(UTC).isoformat(),
+                expires_at,
+                revoked,
+            ),
+        )
+        await db.commit()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,86 +1,14 @@
 """Tests for ds01_jobs.auth module - HMAC-SHA256 authentication."""
 
-import hashlib
-import hmac
-import secrets
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import init_db
-
-
-def _create_test_key() -> tuple[str, str, str]:
-    """Generate a test API key, key_id, and bcrypt hash.
-
-    Returns (raw_key, key_id, key_hash).
-    """
-    random_part = secrets.token_urlsafe(32)
-    raw_key = f"ds01_{random_part}"
-    key_id = random_part[:8]
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
-    return raw_key, key_id, key_hash
-
-
-def _sign_request(
-    raw_key: str,
-    method: str,
-    path: str,
-    body: bytes = b"",
-    timestamp: float | None = None,
-    nonce: str | None = None,
-) -> dict[str, str]:
-    """Build HMAC signing headers for a test request.
-
-    Returns dict of headers: X-Timestamp, X-Nonce, X-Signature.
-    """
-    ts = str(timestamp if timestamp is not None else time.time())
-    n = nonce or secrets.token_urlsafe(16)
-    body_hash = hashlib.sha256(body).hexdigest()
-    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
-    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-    return {
-        "X-Timestamp": ts,
-        "X-Nonce": n,
-        "X-Signature": sig,
-    }
-
-
-async def _seed_key(
-    db_path: Path,
-    key_id: str,
-    key_hash: str,
-    username: str = "testuser",
-    unix_username: str = "testuser_unix",
-    expires_at: str | None = None,
-    revoked: int = 0,
-) -> None:
-    """Insert a test API key into the database."""
-    import aiosqlite
-
-    if expires_at is None:
-        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
-
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            "INSERT INTO api_keys "
-            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                username,
-                unix_username,
-                key_id,
-                key_hash,
-                datetime.now(UTC).isoformat(),
-                expires_at,
-                revoked,
-            ),
-        )
-        await db.commit()
+from tests.helpers import create_test_key, seed_key, sign_request
 
 
 def _make_app(db_path: Path):
@@ -114,11 +42,11 @@ async def test_valid_hmac_auth_passes(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -137,7 +65,7 @@ async def test_invalid_key_prefix_returns_401(tmp_path: Path):
 
     app = _make_app(db_path)
     headers = {"Authorization": "Bearer badprefix_abc12345"}
-    headers.update(_sign_request("badprefix_abc12345", "GET", "/protected"))
+    headers.update(sign_request("badprefix_abc12345", "GET", "/protected"))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -153,12 +81,12 @@ async def test_expired_key_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
+    raw_key, key_id, key_hash = create_test_key()
     expired = (datetime.now(UTC) - timedelta(days=1)).isoformat()
-    await _seed_key(db_path, key_id, key_hash, expires_at=expired)
+    await seed_key(db_path, key_id, key_hash, expires_at=expired)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -174,11 +102,11 @@ async def test_revoked_key_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash, revoked=1)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash, revoked=1)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -194,12 +122,12 @@ async def test_stale_timestamp_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     stale_ts = time.time() - 600  # 10 minutes ago
-    headers = _sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
+    headers = sign_request(raw_key, "GET", "/protected", timestamp=stale_ts)
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -215,14 +143,14 @@ async def test_nonce_replay_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     fixed_nonce = "replay-nonce-123"
 
     # First request should succeed
-    headers1 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers1 = sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
     headers1["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -231,7 +159,7 @@ async def test_nonce_replay_returns_401(tmp_path: Path):
     assert resp1.status_code == 200
 
     # Second request with same nonce should fail
-    headers2 = _sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
+    headers2 = sign_request(raw_key, "GET", "/protected", nonce=fixed_nonce)
     headers2["Authorization"] = f"Bearer {raw_key}"
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -245,11 +173,11 @@ async def test_invalid_hmac_signature_returns_401(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["X-Signature"] = "deadbeef" * 8  # tampered
     headers["Authorization"] = f"Bearer {raw_key}"
 
@@ -266,12 +194,12 @@ async def test_expiry_warning_header_set_when_within_14_days(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
+    raw_key, key_id, key_hash = create_test_key()
     expires = datetime.now(UTC) + timedelta(days=7)
-    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+    await seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -290,12 +218,12 @@ async def test_expiry_warning_header_not_set_when_far_from_expiry(tmp_path: Path
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
+    raw_key, key_id, key_hash = create_test_key()
     expires = datetime.now(UTC) + timedelta(days=60)
-    await _seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
+    await seed_key(db_path, key_id, key_hash, expires_at=expires.isoformat())
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -312,11 +240,11 @@ async def test_last_used_at_updated_after_successful_auth(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)
@@ -341,11 +269,11 @@ async def test_auth_returns_unix_username(tmp_path: Path):
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash, username="ghuser", unix_username="unixuser")
 
     app = _make_app(db_path)
-    headers = _sign_request(raw_key, "GET", "/protected")
+    headers = sign_request(raw_key, "GET", "/protected")
     headers["Authorization"] = f"Bearer {raw_key}"
 
     transport = ASGITransport(app=app)

--- a/tests/unit/test_cancel.py
+++ b/tests/unit/test_cancel.py
@@ -1,78 +1,15 @@
 """Tests for POST /api/v1/jobs/{job_id}/cancel endpoint."""
 
-import hashlib
-import hmac
-import secrets
-import time
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 
 import aiosqlite
-import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import get_db, init_db
-
-
-def _create_test_key() -> tuple[str, str, str]:
-    """Generate a test API key, key_id, and bcrypt hash."""
-    random_part = secrets.token_urlsafe(32)
-    raw_key = f"ds01_{random_part}"
-    key_id = random_part[:8]
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
-    return raw_key, key_id, key_hash
-
-
-def _sign_request(
-    raw_key: str,
-    method: str,
-    path: str,
-    body: bytes = b"",
-    timestamp: float | None = None,
-    nonce: str | None = None,
-) -> dict[str, str]:
-    """Build HMAC signing headers for a test request."""
-    ts = str(timestamp if timestamp is not None else time.time())
-    n = nonce or secrets.token_urlsafe(16)
-    body_hash = hashlib.sha256(body).hexdigest()
-    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
-    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-    return {
-        "X-Timestamp": ts,
-        "X-Nonce": n,
-        "X-Signature": sig,
-    }
-
-
-async def _seed_key(
-    db_path: Path,
-    key_id: str,
-    key_hash: str,
-    username: str = "testuser",
-    expires_at: str | None = None,
-) -> None:
-    """Insert a test API key into the database."""
-    if expires_at is None:
-        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
-
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            "INSERT INTO api_keys "
-            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                username,
-                f"{username}_unix",
-                key_id,
-                key_hash,
-                datetime.now(UTC).isoformat(),
-                expires_at,
-                0,
-            ),
-        )
-        await db.commit()
+from tests.helpers import create_test_key, seed_key, sign_request
 
 
 async def _insert_job(
@@ -122,7 +59,7 @@ def _make_app(db_path: Path):
 def _build_cancel_headers(raw_key: str, job_id: str) -> dict[str, str]:
     """Build auth + signing headers for a POST cancel request."""
     path = f"/api/v1/jobs/{job_id}/cancel"
-    headers = _sign_request(raw_key, "POST", path, body=b"")
+    headers = sign_request(raw_key, "POST", path, body=b"")
     headers["Authorization"] = f"Bearer {raw_key}"
     return headers
 
@@ -133,8 +70,8 @@ async def test_cancel_running_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="running")
 
     app = _make_app(db_path)
@@ -164,8 +101,8 @@ async def test_cancel_queued_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="queued")
 
     app = _make_app(db_path)
@@ -184,8 +121,8 @@ async def test_cancel_completed_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="succeeded")
 
     app = _make_app(db_path)
@@ -205,8 +142,8 @@ async def test_cancel_failed_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="failed")
 
     app = _make_app(db_path)
@@ -226,8 +163,8 @@ async def test_cancel_not_found(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     fake_id = str(uuid.uuid4())
     app = _make_app(db_path)
@@ -247,12 +184,12 @@ async def test_cancel_other_users_job(tmp_path: Path) -> None:
     await init_db(db_path=db_path)
 
     # Alice's key
-    alice_key, alice_kid, alice_hash = _create_test_key()
-    await _seed_key(db_path, alice_kid, alice_hash, username="alice")
+    alice_key, alice_kid, alice_hash = create_test_key()
+    await seed_key(db_path, alice_kid, alice_hash, username="alice")
 
     # Bob's key
-    bob_key, bob_kid, bob_hash = _create_test_key()
-    await _seed_key(db_path, bob_kid, bob_hash, username="bob")
+    bob_key, bob_kid, bob_hash = create_test_key()
+    await seed_key(db_path, bob_kid, bob_hash, username="bob")
 
     # Alice's job
     job_id = await _insert_job(db_path, username="alice", status="running")

--- a/tests/unit/test_cancel.py
+++ b/tests/unit/test_cancel.py
@@ -8,8 +8,8 @@ import aiosqlite
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from ds01_jobs.database import get_db, init_db
-from tests.helpers import create_test_key, seed_key, sign_request
+from ds01_jobs.database import init_db
+from tests.helpers import create_test_key, make_app, seed_key, sign_request
 
 
 async def _insert_job(
@@ -41,21 +41,6 @@ async def _insert_job(
     return jid
 
 
-def _make_app(db_path: Path):
-    """Create a test app with cancel endpoint."""
-    from ds01_jobs.app import create_app
-
-    app = create_app()
-
-    async def _override_get_db():
-        async with aiosqlite.connect(db_path) as db:
-            db.row_factory = aiosqlite.Row
-            yield db
-
-    app.dependency_overrides[get_db] = _override_get_db
-    return app
-
-
 def _build_cancel_headers(raw_key: str, job_id: str) -> dict[str, str]:
     """Build auth + signing headers for a POST cancel request."""
     path = f"/api/v1/jobs/{job_id}/cancel"
@@ -74,7 +59,7 @@ async def test_cancel_running_job(tmp_path: Path) -> None:
     await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="running")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     headers = _build_cancel_headers(raw_key, job_id)
 
     transport = ASGITransport(app=app)
@@ -105,7 +90,7 @@ async def test_cancel_queued_job(tmp_path: Path) -> None:
     await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="queued")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     headers = _build_cancel_headers(raw_key, job_id)
 
     transport = ASGITransport(app=app)
@@ -125,7 +110,7 @@ async def test_cancel_completed_job(tmp_path: Path) -> None:
     await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="succeeded")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     headers = _build_cancel_headers(raw_key, job_id)
 
     transport = ASGITransport(app=app)
@@ -146,7 +131,7 @@ async def test_cancel_failed_job(tmp_path: Path) -> None:
     await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="failed")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     headers = _build_cancel_headers(raw_key, job_id)
 
     transport = ASGITransport(app=app)
@@ -167,7 +152,7 @@ async def test_cancel_not_found(tmp_path: Path) -> None:
     await seed_key(db_path, key_id, key_hash)
 
     fake_id = str(uuid.uuid4())
-    app = _make_app(db_path)
+    app = make_app(db_path)
     headers = _build_cancel_headers(raw_key, fake_id)
 
     transport = ASGITransport(app=app)
@@ -195,7 +180,7 @@ async def test_cancel_other_users_job(tmp_path: Path) -> None:
     job_id = await _insert_job(db_path, username="alice", status="running")
 
     # Bob tries to cancel Alice's job
-    app = _make_app(db_path)
+    app = make_app(db_path)
     headers = _build_cancel_headers(bob_key, job_id)
 
     transport = ASGITransport(app=app)
@@ -213,7 +198,7 @@ async def test_cancel_unauthenticated(tmp_path: Path) -> None:
 
     job_id = await _insert_job(db_path, status="running")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(f"/api/v1/jobs/{job_id}/cancel")

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,81 +1,17 @@
 """Tests for ds01_jobs.jobs module - POST /api/v1/jobs endpoint."""
 
-import hashlib
-import hmac
 import json
-import secrets
-import time
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import aiosqlite
-import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import get_db, init_db
-
-
-def _create_test_key() -> tuple[str, str, str]:
-    """Generate a test API key, key_id, and bcrypt hash."""
-    random_part = secrets.token_urlsafe(32)
-    raw_key = f"ds01_{random_part}"
-    key_id = random_part[:8]
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
-    return raw_key, key_id, key_hash
-
-
-def _sign_request(
-    raw_key: str,
-    method: str,
-    path: str,
-    body: bytes = b"",
-    timestamp: float | None = None,
-    nonce: str | None = None,
-) -> dict[str, str]:
-    """Build HMAC signing headers for a test request."""
-    ts = str(timestamp if timestamp is not None else time.time())
-    n = nonce or secrets.token_urlsafe(16)
-    body_hash = hashlib.sha256(body).hexdigest()
-    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
-    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-    return {
-        "X-Timestamp": ts,
-        "X-Nonce": n,
-        "X-Signature": sig,
-    }
-
-
-async def _seed_key(
-    db_path: Path,
-    key_id: str,
-    key_hash: str,
-    username: str = "testuser",
-    unix_username: str = "testuser_unix",
-    expires_at: str | None = None,
-) -> None:
-    """Insert a test API key into the database."""
-    if expires_at is None:
-        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
-
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            "INSERT INTO api_keys "
-            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                username,
-                unix_username,
-                key_id,
-                key_hash,
-                datetime.now(UTC).isoformat(),
-                expires_at,
-                0,
-            ),
-        )
-        await db.commit()
+from tests.helpers import create_test_key, seed_key, sign_request
 
 
 async def _insert_job(
@@ -132,7 +68,7 @@ def _make_app(db_path: Path):
 def _build_headers(raw_key: str, body_dict: dict) -> dict[str, str]:  # type: ignore[type-arg]
     """Build auth + signing headers for a POST /api/v1/jobs request."""
     body_bytes = json.dumps(body_dict).encode()
-    headers = _sign_request(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
+    headers = sign_request(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
     headers["Authorization"] = f"Bearer {raw_key}"
     headers["Content-Type"] = "application/json"
     return headers
@@ -149,8 +85,8 @@ async def test_submit_job_success(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
@@ -184,8 +120,8 @@ async def test_submit_job_invalid_url(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {"repo_url": "https://evil.com/hacked"}
@@ -212,8 +148,8 @@ async def test_submit_job_with_dockerfile_scan_error(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {
@@ -244,8 +180,8 @@ async def test_submit_job_with_clean_dockerfile(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {
@@ -272,8 +208,8 @@ async def test_submit_job_concurrent_limit_exceeded(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     # Insert 3 active jobs (default concurrent limit)
     for _ in range(3):
@@ -303,8 +239,8 @@ async def test_submit_job_daily_limit_exceeded(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     # Insert 20 completed jobs today (default daily limit)
     for _ in range(20):
@@ -334,8 +270,8 @@ async def test_submit_job_rate_limit_headers_on_success(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
@@ -364,8 +300,8 @@ async def test_submit_job_auto_generated_job_name(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
@@ -417,8 +353,8 @@ async def test_submit_job_repo_not_found(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
@@ -454,8 +390,8 @@ async def test_submit_job_gpu_count_exceeds_total(
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo", "gpu_count": 8}

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -10,8 +10,8 @@ import aiosqlite
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from ds01_jobs.database import get_db, init_db
-from tests.helpers import create_test_key, seed_key, sign_request
+from ds01_jobs.database import init_db
+from tests.helpers import build_headers, create_test_key, make_app, seed_key
 
 
 async def _insert_job(
@@ -42,38 +42,6 @@ async def _insert_job(
         await db.commit()
 
 
-def _make_app(db_path: Path):
-    """Create a test app with jobs router and mocked external calls."""
-    from ds01_jobs.app import create_app
-    from ds01_jobs.jobs import _get_settings
-
-    app = create_app()
-
-    async def _override_get_db():
-        async with aiosqlite.connect(db_path) as db:
-            db.row_factory = aiosqlite.Row
-            yield db
-
-    def _override_settings():
-        from ds01_jobs.config import Settings
-
-        return Settings(_env_file=None)
-
-    app.dependency_overrides[get_db] = _override_get_db
-    app.dependency_overrides[_get_settings] = _override_settings
-
-    return app
-
-
-def _build_headers(raw_key: str, body_dict: dict) -> dict[str, str]:  # type: ignore[type-arg]
-    """Build auth + signing headers for a POST /api/v1/jobs request."""
-    body_bytes = json.dumps(body_dict).encode()
-    headers = sign_request(raw_key, "POST", "/api/v1/jobs", body=body_bytes)
-    headers["Authorization"] = f"Bearer {raw_key}"
-    headers["Content-Type"] = "application/json"
-    return headers
-
-
 @pytest.mark.asyncio
 @patch("ds01_jobs.rate_limit._get_user_group", new_callable=AsyncMock, return_value="default")
 @patch("ds01_jobs.jobs.verify_repo_accessible", new_callable=AsyncMock)
@@ -88,9 +56,9 @@ async def test_submit_job_success(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -123,9 +91,9 @@ async def test_submit_job_invalid_url(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://evil.com/hacked"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -151,12 +119,12 @@ async def test_submit_job_with_dockerfile_scan_error(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {
         "repo_url": "https://github.com/testorg/myrepo",
         "dockerfile_content": "FROM evil.registry.io/hacker/image:latest\nRUN echo hi",
     }
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -183,12 +151,12 @@ async def test_submit_job_with_clean_dockerfile(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {
         "repo_url": "https://github.com/testorg/myrepo",
         "dockerfile_content": "FROM python:3.13-slim\nRUN pip install torch",
     }
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -215,9 +183,9 @@ async def test_submit_job_concurrent_limit_exceeded(
     for _ in range(3):
         await _insert_job(db_path, status="queued")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -246,9 +214,9 @@ async def test_submit_job_daily_limit_exceeded(
     for _ in range(20):
         await _insert_job(db_path, status="succeeded")
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -273,9 +241,9 @@ async def test_submit_job_rate_limit_headers_on_success(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -303,9 +271,9 @@ async def test_submit_job_auto_generated_job_name(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -331,7 +299,7 @@ async def test_submit_job_unauthenticated(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -356,9 +324,9 @@ async def test_submit_job_repo_not_found(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo"}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     with patch(
         "ds01_jobs.jobs.verify_repo_accessible",
@@ -393,9 +361,9 @@ async def test_submit_job_gpu_count_exceeds_total(
     raw_key, key_id, key_hash = create_test_key()
     await seed_key(db_path, key_id, key_hash)
 
-    app = _make_app(db_path)
+    app = make_app(db_path)
     body = {"repo_url": "https://github.com/testorg/myrepo", "gpu_count": 8}
-    headers = _build_headers(raw_key, body)
+    headers = build_headers(raw_key, body)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,81 +1,18 @@
 """Tests for GET /api/v1/jobs/{job_id}/results endpoint."""
 
-import hashlib
-import hmac
 import io
-import secrets
 import tarfile
-import time
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 
 import aiosqlite
-import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import get_db, init_db
 from ds01_jobs.jobs import _get_settings
-
-
-def _create_test_key() -> tuple[str, str, str]:
-    """Generate a test API key, key_id, and bcrypt hash."""
-    random_part = secrets.token_urlsafe(32)
-    raw_key = f"ds01_{random_part}"
-    key_id = random_part[:8]
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
-    return raw_key, key_id, key_hash
-
-
-def _sign_request(
-    raw_key: str,
-    method: str,
-    path: str,
-    body: bytes = b"",
-    timestamp: float | None = None,
-    nonce: str | None = None,
-) -> dict[str, str]:
-    """Build HMAC signing headers for a test request."""
-    ts = str(timestamp if timestamp is not None else time.time())
-    n = nonce or secrets.token_urlsafe(16)
-    body_hash = hashlib.sha256(body).hexdigest()
-    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
-    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-    return {
-        "X-Timestamp": ts,
-        "X-Nonce": n,
-        "X-Signature": sig,
-    }
-
-
-async def _seed_key(
-    db_path: Path,
-    key_id: str,
-    key_hash: str,
-    username: str = "testuser",
-    expires_at: str | None = None,
-) -> None:
-    """Insert a test API key into the database."""
-    if expires_at is None:
-        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
-
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            "INSERT INTO api_keys "
-            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                username,
-                f"{username}_unix",
-                key_id,
-                key_hash,
-                datetime.now(UTC).isoformat(),
-                expires_at,
-                0,
-            ),
-        )
-        await db.commit()
+from tests.helpers import create_test_key, seed_key, sign_request
 
 
 async def _insert_job(
@@ -137,7 +74,7 @@ def _make_app(db_path: Path, workspace_root: Path | None = None):
 
 def _build_get_headers(raw_key: str, path: str) -> dict[str, str]:
     """Build auth + signing headers for a GET request."""
-    headers = _sign_request(raw_key, "GET", path, body=b"")
+    headers = sign_request(raw_key, "GET", path, body=b"")
     headers["Authorization"] = f"Bearer {raw_key}"
     return headers
 
@@ -148,8 +85,8 @@ async def test_download_results_success(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="succeeded")
 
     # Create workspace results directory with files
@@ -184,8 +121,8 @@ async def test_download_results_no_results_dir(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="succeeded")
 
     workspace_root = tmp_path / "workspaces"
@@ -210,8 +147,8 @@ async def test_download_results_empty_results_dir(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="succeeded")
 
     workspace_root = tmp_path / "workspaces"
@@ -242,8 +179,8 @@ async def test_download_results_size_exceeded(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="succeeded")
 
     workspace_root = tmp_path / "workspaces"
@@ -284,8 +221,8 @@ async def test_download_results_not_found(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     fake_id = str(uuid.uuid4())
     app = _make_app(db_path)
@@ -306,12 +243,12 @@ async def test_download_results_other_users_job(tmp_path: Path) -> None:
     await init_db(db_path=db_path)
 
     # Alice's key
-    alice_key, alice_kid, alice_hash = _create_test_key()
-    await _seed_key(db_path, alice_kid, alice_hash, username="alice")
+    alice_key, alice_kid, alice_hash = create_test_key()
+    await seed_key(db_path, alice_kid, alice_hash, username="alice")
 
     # Bob's key
-    bob_key, bob_kid, bob_hash = _create_test_key()
-    await _seed_key(db_path, bob_kid, bob_hash, username="bob")
+    bob_key, bob_kid, bob_hash = create_test_key()
+    await seed_key(db_path, bob_kid, bob_hash, username="bob")
 
     # Alice's job
     job_id = await _insert_job(db_path, username="alice", status="succeeded")
@@ -334,8 +271,8 @@ async def test_download_results_running_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="running")
 
     app = _make_app(db_path)
@@ -356,8 +293,8 @@ async def test_download_results_failed_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
     job_id = await _insert_job(db_path, status="failed")
 
     app = _make_app(db_path)

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,81 +1,18 @@
 """Tests for GET endpoints: status detail, logs, listing, and quota."""
 
-import hashlib
-import hmac
 import json
-import secrets
-import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import aiosqlite
-import bcrypt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from ds01_jobs.database import get_db, init_db
 from ds01_jobs.jobs import _get_settings
-
-
-def _create_test_key() -> tuple[str, str, str]:
-    """Generate a test API key, key_id, and bcrypt hash."""
-    random_part = secrets.token_urlsafe(32)
-    raw_key = f"ds01_{random_part}"
-    key_id = random_part[:8]
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
-    return raw_key, key_id, key_hash
-
-
-def _sign_request(
-    raw_key: str,
-    method: str,
-    path: str,
-    body: bytes = b"",
-    timestamp: float | None = None,
-    nonce: str | None = None,
-) -> dict[str, str]:
-    """Build HMAC signing headers for a test request."""
-    ts = str(timestamp if timestamp is not None else time.time())
-    n = nonce or secrets.token_urlsafe(16)
-    body_hash = hashlib.sha256(body).hexdigest()
-    canonical = f"{method}\n{path}\n{ts}\n{n}\n{body_hash}"
-    sig = hmac.new(raw_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-    return {
-        "X-Timestamp": ts,
-        "X-Nonce": n,
-        "X-Signature": sig,
-    }
-
-
-async def _seed_key(
-    db_path: Path,
-    key_id: str,
-    key_hash: str,
-    username: str = "testuser",
-    expires_at: str | None = None,
-) -> None:
-    """Insert a test API key into the database."""
-    if expires_at is None:
-        expires_at = (datetime.now(UTC) + timedelta(days=90)).isoformat()
-
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            "INSERT INTO api_keys "
-            "(username, unix_username, key_id, key_hash, created_at, expires_at, revoked) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                username,
-                f"{username}_unix",
-                key_id,
-                key_hash,
-                datetime.now(UTC).isoformat(),
-                expires_at,
-                0,
-            ),
-        )
-        await db.commit()
+from tests.helpers import create_test_key, seed_key, sign_request
 
 
 async def _insert_job(
@@ -149,7 +86,7 @@ def _make_app(db_path: Path, workspace_root: Path | None = None):
 
 def _build_get_headers(raw_key: str, method: str, path: str) -> dict[str, str]:
     """Build auth headers for a GET request (no body)."""
-    headers = _sign_request(raw_key, method, path, body=b"")
+    headers = sign_request(raw_key, method, path, body=b"")
     headers["Authorization"] = f"Bearer {raw_key}"
     return headers
 
@@ -163,8 +100,8 @@ async def test_get_status_succeeded_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     pts = json.dumps(
         {
@@ -203,8 +140,8 @@ async def test_get_status_failed_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     job_id = await _insert_job(
         db_path,
@@ -235,8 +172,8 @@ async def test_get_status_queued_job_has_queue_position(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     # Insert 3 queued jobs with increasing timestamps
     base = datetime(2026, 1, 1, tzinfo=UTC)
@@ -266,8 +203,8 @@ async def test_get_status_not_found(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     fake_id = str(uuid.uuid4())
     app = _make_app(db_path)
@@ -288,8 +225,8 @@ async def test_get_status_other_users_job(tmp_path: Path) -> None:
     await init_db(db_path=db_path)
 
     # Bob's key
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash, username="bob")
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash, username="bob")
 
     # Alice's job
     job_id = await _insert_job(db_path, username="alice", status="succeeded")
@@ -314,8 +251,8 @@ async def test_get_logs_with_log_files(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     job_id = await _insert_job(db_path, status="succeeded")
 
@@ -352,8 +289,8 @@ async def test_get_logs_no_log_files(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     job_id = await _insert_job(db_path, status="queued")
 
@@ -381,8 +318,8 @@ async def test_get_logs_truncated(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     job_id = await _insert_job(db_path, status="succeeded")
 
@@ -416,8 +353,8 @@ async def test_get_logs_other_users_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash, username="bob")
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash, username="bob")
 
     job_id = await _insert_job(db_path, username="alice", status="succeeded")
 
@@ -441,8 +378,8 @@ async def test_list_jobs_returns_own_jobs(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     # 3 jobs for testuser, 2 for otheruser
     for _ in range(3):
@@ -470,8 +407,8 @@ async def test_list_jobs_status_filter(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     await _insert_job(db_path, status="running")
     await _insert_job(db_path, status="running")
@@ -497,8 +434,8 @@ async def test_list_jobs_pagination(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     base = datetime(2026, 1, 1, tzinfo=UTC)
     for i in range(5):
@@ -534,8 +471,8 @@ async def test_list_jobs_empty(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     path = "/api/v1/jobs"
@@ -561,8 +498,8 @@ async def test_get_quota_defaults(mock_group: AsyncMock, tmp_path: Path) -> None
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     app = _make_app(db_path)
     path = "/api/v1/users/me/quota"
@@ -588,8 +525,8 @@ async def test_get_quota_with_active_jobs(mock_group: AsyncMock, tmp_path: Path)
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     await _insert_job(db_path, status="queued")
     await _insert_job(db_path, status="running")
@@ -614,8 +551,8 @@ async def test_get_quota_other_user_isolation(mock_group: AsyncMock, tmp_path: P
     db_path = tmp_path / "test.db"
     await init_db(db_path=db_path)
 
-    raw_key, key_id, key_hash = _create_test_key()
-    await _seed_key(db_path, key_id, key_hash)
+    raw_key, key_id, key_hash = create_test_key()
+    await seed_key(db_path, key_id, key_hash)
 
     # Insert active jobs for a different user
     await _insert_job(db_path, username="otheruser", status="running")


### PR DESCRIPTION
## Summary

- Extract `create_test_key`, `sign_request`, and `seed_key` from 5 test files into `tests/helpers.py`
- These were copy-pasted identically across test_auth, test_cancel, test_jobs, test_results, and test_status
- `seed_key` now auto-derives `unix_username` from `username` by default, and accepts optional `revoked` parameter for auth tests
- Net: **-251 lines** across test files, single source of truth for auth test helpers

`_make_app` helpers were left local since each test file has a genuinely different variant (minimal app for auth, full app for jobs, workspace_root for status/results).

## Test plan

- [x] `uv run pytest tests/unit/ -x -v` — 206 passed
- [x] `uv run ruff check tests/` — all passed
- [x] `uv run ruff format --check tests/` — all formatted