### PR TITLE
feat: add sudoers config for runner user impersonation

### DIFF
--- a/systemd/ds01-jobs-sudoers
+++ b/systemd/ds01-jobs-sudoers
@@ -1,0 +1,14 @@
+# /etc/sudoers.d/ds01-jobs
+# Allow the ds01-jobs runner to execute Docker commands as any user.
+# Required because the runner impersonates job owners via sudo -u so
+# the Docker wrapper can apply per-user GPU quotas, cgroup slices,
+# and resource limits from ds01-infra.
+#
+# Install: sudo cp systemd/ds01-jobs-sudoers /etc/sudoers.d/ds01-jobs
+#          sudo chmod 440 /etc/sudoers.d/ds01-jobs
+
+# Service account (systemd)
+ds01 ALL=(ALL) NOPASSWD: /usr/local/bin/docker
+
+# Dev/manual runner (datasciencelab)
+datasciencelab ALL=(ALL) NOPASSWD: /usr/local/bin/docker


### PR DESCRIPTION
## Summary
- Add `systemd/ds01-jobs-sudoers` — sudoers rule allowing the runner to execute Docker as job owners via `sudo -u`
- Required for per-user GPU quotas, cgroup slices, and resource limits via the ds01-infra Docker wrapper
- Covers both `ds01` (systemd service) and `datasciencelab` (dev/manual runner)

## Install
```bash
sudo cp systemd/ds01-jobs-sudoers /etc/sudoers.d/ds01-jobs
sudo chmod 440 /etc/sudoers.d/ds01-jobs
```

## Test plan
- [ ] `sudo -u h.baker@hertie-school.lan /usr/local/bin/docker run --rm hello-world` works without password prompt
- [ ] Job submission as `h.baker@hertie-school.lan` builds and runs via Docker wrapper