### PR TITLE
fix(ci): use pre-provisioned bot key, drop admin surface from Tier 2

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -24,10 +24,9 @@ jobs:
           git checkout -B ci-test "$GITHUB_SHA"
           uv sync --locked --all-groups
 
-      - name: Fix permissions and restart services
+      - name: Deploy updated code to production services
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
-          chmod g+x /home/datasciencelab
           sudo systemctl restart ds01-api ds01-runner
 
           for i in $(seq 1 20); do
@@ -40,4 +39,6 @@ jobs:
           exit 1
 
       - name: Integration tests
+        env:
+          DS01_CI_API_KEY: ${{ secrets.DS01_CI_API_KEY }}
         run: uv run pytest -m integration --tb=short || [ $? -eq 5 ]

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -123,21 +123,82 @@ def _resolve_github_token() -> str | None:
     return None
 
 
-def check_org_membership(username: str, org: str) -> bool:
-    """Check GitHub organisation membership.
+def _check_bot_app_installed(app_slug: str, org: str, token: str) -> bool:
+    """Check whether a GitHub App (identified by slug) is installed on the org.
 
-    Resolves a GitHub token from (in order): GITHUB_TOKEN env var, gh CLI.
-    With a token, uses the authenticated members endpoint (sees private
-    memberships). Without a token, falls back to the public members endpoint.
+    Uses GET /orgs/{org}/installations which requires a token with read:org scope
+    (org owner or fine-grained token). Paginates through all installations.
 
     Args:
-        username: GitHub username to check.
+        app_slug: The App slug (username without the trailing ``[bot]``).
+        org: GitHub organisation name.
+        token: GitHub token with read:org scope.
+
+    Returns:
+        True if the App is installed on the org, False otherwise.
+    """
+    headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+    page = 1
+    while True:
+        url = f"https://api.github.com/orgs/{org}/installations?per_page=100&page={page}"
+        try:
+            response = httpx.get(url, headers=headers, timeout=10.0)
+        except httpx.HTTPError as exc:
+            typer.echo(f"Error checking GitHub App installation: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+        if response.status_code != 200:
+            typer.echo(
+                f"Unexpected response from GitHub API ({response.status_code}) while checking App installation. "
+                "Ensure your token has read:org scope.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        data = response.json()
+        for installation in data.get("installations", []):
+            if installation.get("app_slug") == app_slug:
+                return True
+
+        if len(data.get("installations", [])) < 100:
+            break
+        page += 1
+
+    return False
+
+
+def check_org_membership(username: str, org: str) -> bool:
+    """Check GitHub organisation membership or App installation.
+
+    For regular users: resolves a GitHub token from (in order): GITHUB_TOKEN
+    env var, gh CLI. With a token, uses the authenticated members endpoint
+    (sees private memberships). Without a token, falls back to the public
+    members endpoint.
+
+    For GitHub App bot users (username ending in ``[bot]``): verifies the App
+    is installed on the org via GET /orgs/{org}/installations. Requires a token
+    with read:org scope — a gh CLI session as org owner satisfies this.
+
+    Args:
+        username: GitHub username (regular user or ``{app-slug}[bot]``).
         org: GitHub organisation name.
 
     Returns:
-        True if user is a member, False otherwise.
+        True if user is a member / App is installed, False otherwise.
     """
     token = _resolve_github_token()
+
+    if username.endswith("[bot]"):
+        app_slug = username[:-5]  # strip "[bot]"
+        if not token:
+            typer.echo(
+                "A GitHub token with read:org scope is required to verify GitHub App installation. "
+                "Run 'gh auth login' or set GITHUB_TOKEN.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        return _check_bot_app_installed(app_slug, org, token)
+
     headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
 
     if token:

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -149,8 +149,8 @@ def _check_bot_app_installed(app_slug: str, org: str, token: str) -> bool:
 
         if response.status_code != 200:
             typer.echo(
-                f"Unexpected response from GitHub API ({response.status_code}) while checking App installation. "
-                "Ensure your token has read:org scope.",
+                f"Unexpected response from GitHub API ({response.status_code}) "
+                "while checking App installation. Ensure your token has read:org scope.",
                 err=True,
             )
             raise typer.Exit(code=1)

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -47,27 +47,23 @@ def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.Compl
 
 @pytest.fixture()
 def api_key() -> str:
-    """Create a temporary API key for the lifecycle test.
+    """Return the pre-provisioned CI API key.
 
-    Uses ``ds01-job-admin key-create`` with the ``datasciencelab`` org member
-    account. Revokes any pre-existing key first, then tears down after the test.
+    Reads ``DS01_CI_API_KEY`` from the environment (set via the ``DS01_CI_API_KEY``
+    GitHub Actions secret). The key is issued once by an admin via::
+
+        ds01-job-admin key-create ds01-ci-bot[bot] datasciencelab --expires 365d --json
+
+    and stored as a repository secret. Tests are skipped if the variable is unset
+    (e.g. local runs without the secret configured).
     """
-    github_user = "henrycgbaker"
-    unix_user = "datasciencelab"
-
-    # Revoke any leftover key from a previous run
-    _run(["ds01-job-admin", "key-revoke", github_user, "--yes"])
-
-    result = _run(["ds01-job-admin", "key-create", github_user, unix_user, "--json"])
-    assert result.returncode == 0, f"key-create failed: {result.stderr}"
-
-    data = json.loads(result.stdout)
-    raw_key = data["key"]
-
-    yield raw_key
-
-    # Teardown: revoke the key
-    _run(["ds01-job-admin", "key-revoke", github_user, "--yes"])
+    key = os.environ.get("DS01_CI_API_KEY")
+    if not key:
+        pytest.skip(
+            "DS01_CI_API_KEY not set — provision via 'ds01-job-admin key-create' "
+            "and store as a GitHub Actions secret"
+        )
+    return key
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- Tier 2 CI has been failing intermittently since 2026-03-31 due to two self-hosted runners registered under identical `[self-hosted, gpu]` labels — one as `datasciencelab` (admin), one as `h.baker` (non-admin). GitHub dispatched round-robin; the `h.baker` runner can't write `/var/lib/ds01-jobs/ds01.db`, causing the `api_key` fixture to fail.
- Root cause: `api_key` fixture called `ds01-job-admin key-create` per run, requiring admin DB-write in CI. Removed entirely.
- **After this PR:** one runner (`h.baker`, non-admin), zero admin surface in CI path.

## Changes

**`tests/integration/test_lifecycle.py`** — `api_key` fixture now reads `DS01_CI_API_KEY` from env (pre-provisioned long-lived key for `ds01-ci-bot[bot]` / `ds01-ci-bot` unix user) and skips if unset. No key minting/revoking per run.

**`.github/workflows/ci-integration.yml`** — pass `DS01_CI_API_KEY` secret to integration step; rename "Fix permissions" step to "Deploy updated code" to clarify its purpose is prod deployment not test setup; remove `chmod g+x /home/datasciencelab` (only needed for the decommissioned admin runner).

**`src/ds01_jobs/cli.py`** — extend `check_org_membership` to handle GitHub App bot usernames (`[bot]` suffix) via `GET /orgs/{org}/installations`, so `ds01-ci-bot[bot]` can be issued a key through the standard admin flow.

## Admin prerequisites (already completed)

- [x] `ds01-ci-bot` GitHub App created and installed on `hertie-data-science-lab` org
- [x] `ds01-ci-bot` Linux user created with researcher cgroup slice
- [x] Key provisioned: `ds01-job-admin key-create 'ds01-ci-bot[bot]' ds01-ci-bot --expires 365d`
- [x] `DS01_CI_API_KEY` secret set on this repo
- [ ] Decommission `datasciencelab` systemd runner (before merging — see note below)

## Remaining before merge

The `datasciencelab` systemd runner (`actions.runner.hertie-data-science-lab.ds01-runner.service`) must be stopped and unregistered before merging, otherwise it may still pick up the Tier 2 run and the round-robin failure mode persists.

```bash
sudo systemctl stop actions.runner.hertie-data-science-lab.ds01-runner
sudo systemctl disable actions.runner.hertie-data-science-lab.ds01-runner
# Obtain removal token from GitHub Settings → Actions → Runners → Remove
cd /home/datasciencelab/workspace/actions-runner
sudo -u datasciencelab ./config.sh remove --token <TOKEN>
```

## Test plan

- [x] Tier 1 (`ci.yml`): 218 unit tests pass locally
- [ ] Tier 1 CI green on this PR
- [ ] Decommission admin runner
- [ ] Merge → Tier 2 green on push to main (first run with `h.baker` as sole runner)
- [ ] Second `workflow_dispatch` run also green (no race)
- [ ] `curl http://127.0.0.1:8765/health` returns 200 after deployment step