### PR TITLE
fix(ci): restore chmod needed for ds01 to reach venv Python symlink

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Deploy updated code to production services
         run: |
           find /opt/ds01-jobs -path /opt/ds01-jobs/data -prune -o -print0 | xargs -0 chmod g+rX
+          # Allow ds01 service user to traverse datasciencelab's home to reach the
+          # venv's Python symlink (-> anaconda3). Redundant once PR 3 lands (venv
+          # relocated to /var/lib/ds01-jobs/venv with a system Python).
+          chmod g+x /home/datasciencelab
           sudo systemctl restart ds01-api ds01-runner
 
           for i in $(seq 1 20); do


### PR DESCRIPTION
## Summary

- PR #68 removed `chmod g+x /home/datasciencelab` reasoning it was only needed for the now-decommissioned admin runner identity. This was incorrect.
- The chmod is needed because `uv sync` creates `.venv/bin/python` as a symlink to `/home/datasciencelab/anaconda3/bin/python3.13`. The `ds01` service user can't traverse `datasciencelab`'s home dir (`drwx------`) to follow that symlink, causing `status=203/EXEC` on service start.
- Restored with an explanatory comment. Becomes redundant when PR 3 (venv relocation to `/var/lib/ds01-jobs/venv` with system Python) lands.

## Test plan
- [ ] Tier 1 green
- [ ] Tier 2 green — services restart and health check passes, integration test runs