### PR TITLE
fix(config): align default db_path with deployed EnvironmentFile

### DIFF
--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -13,7 +13,8 @@ class Settings(BaseSettings):
     )
 
     # Database
-    db_path: Path = Path("/var/lib/ds01-jobs/ds01.db")
+    # Must match DS01_JOBS_DB_PATH in /etc/ds01-jobs/env (the systemd EnvironmentFile).
+    db_path: Path = Path("/opt/ds01-jobs/data/jobs.db")
 
     # API
     api_host: str = "127.0.0.1"


### PR DESCRIPTION
## Summary

- `config.py` defaulted `db_path` to `/var/lib/ds01-jobs/ds01.db`, but the systemd `EnvironmentFile` at `/etc/ds01-jobs/env` sets `DS01_JOBS_DB_PATH=/opt/ds01-jobs/data/jobs.db`.
- Any process reading `Settings()` without the env file loaded (i.e. `ds01-job-admin` run by an admin in their shell) silently used the wrong database — keys provisioned there were invisible to the running service.
- Found 2026-04-13 when CI bot key was provisioned to the wrong DB and Tier 2 returned 401 despite the key existing.

## Change

One-line default update in `config.py`. The `EnvironmentFile` override becomes a harmless no-op; `ds01-job-admin` now works correctly out-of-the-box without requiring `DS01_JOBS_DB_PATH` to be set manually.

## Test plan
- [x] 218 unit tests pass locally
- [ ] Tier 1 CI green
- [ ] Tier 2 green on merge
- [ ] `ds01-job-admin key-list` without any env var shows keys from `data/jobs.db`