### PR TITLE
feat(auth): normalise state ownership, add revalidation + team gate

### DIFF
--- a/config/sudoers.d/ds01-jobs
+++ b/config/sudoers.d/ds01-jobs
@@ -3,6 +3,3 @@
 # Required for: sudo -u {unix_username} /usr/local/bin/docker ...
 # Deployed by: /opt/ds01-jobs/deploy.sh
 ds01 ALL=(ALL) NOPASSWD: /usr/local/bin/docker
-
-# Allow CI runner (datasciencelab) to restart ds01 services
-datasciencelab ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart ds01-api, /usr/bin/systemctl restart ds01-runner, /usr/bin/systemctl restart ds01-api ds01-runner

--- a/deploy.sh
+++ b/deploy.sh
@@ -155,15 +155,32 @@ check_active_jobs() {
 # Deployment steps
 # ---------------------------------------------------------------------------
 setup_system_user() {
+    # Dedicated admin group for ds01-jobs state ownership.
+    # Admins granted membership here can run ds01-job-admin without locking
+    # out the service user or other admins.
+    groupadd -f ds01-admin
+    log "  Ensured ds01-admin group exists"
+
     if id ds01 &>/dev/null; then
         log "  User ds01 already exists"
     else
-        useradd --system --shell /usr/sbin/nologin --home-dir /opt/ds01-jobs ds01
-        log "  Created system user ds01"
+        useradd --system --shell /usr/sbin/nologin --home-dir /var/lib/ds01-jobs ds01
+        log "  Created system user ds01 (home: /var/lib/ds01-jobs)"
     fi
+
+    # Keep home dir aligned with state dir so ~/.cache / ~/.local don't land
+    # in the source tree. -d without -m: only update passwd entry.
+    local current_home
+    current_home="$(getent passwd ds01 | cut -d: -f6)"
+    if [[ "$current_home" != "/var/lib/ds01-jobs" ]]; then
+        usermod -d /var/lib/ds01-jobs ds01
+        log "  Updated ds01 home dir: $current_home -> /var/lib/ds01-jobs"
+    fi
+
     usermod -aG docker ds01 2>/dev/null || true
     usermod -aG ds-admin ds01 2>/dev/null || true
-    log "  Ensured ds01 is in docker and ds-admin groups"
+    usermod -aG ds01-admin ds01 2>/dev/null || true
+    log "  Ensured ds01 is in docker, ds-admin, and ds01-admin groups"
 }
 
 setup_directories() {
@@ -171,15 +188,27 @@ setup_directories() {
     chmod 0755 /etc/ds01-jobs
 
     chmod -R g+rX /opt/ds01-jobs
+
+    # DB directory: owned by service, group-writable by ds01-admin so admins
+    # can run ds01-job-admin. Setgid ensures new files inherit the group.
     mkdir -p /opt/ds01-jobs/data
-    chown -R ds01:ds-admin /opt/ds01-jobs/data
-    chmod 770 /opt/ds01-jobs/data
+    chown -R ds01:ds01-admin /opt/ds01-jobs/data
+    chmod 2770 /opt/ds01-jobs/data
+
+    # Explicitly provision the DB file so whichever principal triggers first
+    # creation doesn't lock out others (root or manual admin runs).
+    if [[ ! -f "$DB_PATH" ]]; then
+        touch "$DB_PATH"
+        log "  Created empty DB at $DB_PATH"
+    fi
+    chown ds01:ds01-admin "$DB_PATH"
+    chmod 0660 "$DB_PATH"
 
     mkdir -p /var/lib/ds01-jobs/workspaces
-    chown ds01:ds-admin /var/lib/ds01-jobs
-    chown ds01:ds-admin /var/lib/ds01-jobs/workspaces
-    chmod 0750 /var/lib/ds01-jobs
-    chmod 0750 /var/lib/ds01-jobs/workspaces
+    chown ds01:ds01-admin /var/lib/ds01-jobs
+    chown ds01:ds01-admin /var/lib/ds01-jobs/workspaces
+    chmod 2750 /var/lib/ds01-jobs
+    chmod 2770 /var/lib/ds01-jobs/workspaces
 
     mkdir -p /var/log/ds01
     touch /var/log/ds01/events.jsonl
@@ -269,16 +298,20 @@ install_systemd_units() {
     cp "$SCRIPT_DIR/systemd/ds01-api.service" /etc/systemd/system/
     cp "$SCRIPT_DIR/systemd/ds01-runner.service" /etc/systemd/system/
     cp "$SCRIPT_DIR/systemd/ds01-cloudflared.service" /etc/systemd/system/
+    cp "$SCRIPT_DIR/systemd/ds01-revalidate.service" /etc/systemd/system/
+    cp "$SCRIPT_DIR/systemd/ds01-revalidate.timer" /etc/systemd/system/
     log "  Systemd unit files copied"
 
     systemctl daemon-reload
     log "  systemctl daemon-reload complete"
 
-    systemctl enable ds01-api ds01-runner ds01-cloudflared
+    systemctl enable ds01-api ds01-runner ds01-cloudflared ds01-revalidate.timer
     log "  Services enabled"
 
     systemctl restart ds01-api ds01-runner ds01-cloudflared
-    log "  Services restarted"
+    # Timers don't "restart" — start if not active, otherwise leave the schedule.
+    systemctl start ds01-revalidate.timer
+    log "  Services restarted; revalidation timer started"
 }
 
 verify_health() {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 [project.scripts]
 ds01-job-admin = "ds01_jobs.cli:app"
 ds01-job-runner = "ds01_jobs.runner:cli_main"
+ds01-job-revalidate = "ds01_jobs.revalidate:app"
 ds01-submit = "ds01_jobs.submit:app"
 
 [build-system]

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -225,6 +225,65 @@ def check_org_membership(username: str, org: str) -> bool:
     raise typer.Exit(code=1)
 
 
+def check_team_membership(username: str, org: str, team: str, token: str) -> bool:
+    """Check GitHub team membership via the team memberships endpoint.
+
+    Uses GET /orgs/{org}/teams/{team}/memberships/{username}. Returns True
+    only if the user's membership state is ``active`` (pending invitations
+    don't count).
+
+    Args:
+        username: GitHub username.
+        org: GitHub organisation name.
+        team: Team slug (not display name).
+        token: GitHub token with read:org scope.
+
+    Returns:
+        True if the user is an active team member, False otherwise.
+    """
+    headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+    url = f"https://api.github.com/orgs/{org}/teams/{team}/memberships/{username}"
+
+    try:
+        response = httpx.get(url, headers=headers, timeout=10.0)
+    except httpx.HTTPError as exc:
+        typer.echo(f"Error checking GitHub team membership: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if response.status_code == 404:
+        return False
+    if response.status_code == 200:
+        return bool(response.json().get("state") == "active")
+
+    typer.echo(
+        f"Unexpected response from GitHub API ({response.status_code}) "
+        "while checking team membership. Ensure your token has read:org scope.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def verify_github_access(username: str, settings: Settings) -> bool:
+    """Check whether a user has access via the configured GH gate.
+
+    When ``settings.github_team`` is set, gates on membership of that team
+    within ``settings.github_org``. Otherwise falls back to org-level
+    membership. Bot users (``[bot]`` suffix) always go through the org-level
+    App installation check — teams don't apply to bots.
+    """
+    if settings.github_team and not username.endswith("[bot]"):
+        token = _resolve_github_token()
+        if not token:
+            typer.echo(
+                "A GitHub token with read:org scope is required to verify team membership. "
+                "Run 'gh auth login' or set GITHUB_TOKEN.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        return check_team_membership(username, settings.github_org, settings.github_team, token)
+    return check_org_membership(username, settings.github_org)
+
+
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     """Ensure the api_keys table exists and apply any pending migrations."""
     conn.executescript(SCHEMA_SQL)
@@ -280,9 +339,14 @@ def key_create(
         typer.echo(f"Error: Unix user {unix_username!r} does not exist on this server", err=True)
         raise typer.Exit(code=1)
 
-    # Check GitHub org membership
-    if not check_org_membership(github_username, settings.github_org):
-        typer.echo(f"Error: {github_username} is not a member of {settings.github_org}", err=True)
+    # Check GitHub access (team-level if configured, else org-level)
+    if not verify_github_access(github_username, settings):
+        gate = (
+            f"team {settings.github_org}/{settings.github_team}"
+            if settings.github_team and not github_username.endswith("[bot]")
+            else f"org {settings.github_org}"
+        )
+        typer.echo(f"Error: {github_username} is not a member of {gate}", err=True)
         raise typer.Exit(code=1)
 
     days = parse_duration(expires)

--- a/src/ds01_jobs/cli.py
+++ b/src/ds01_jobs/cli.py
@@ -339,7 +339,6 @@ def key_create(
         typer.echo(f"Error: Unix user {unix_username!r} does not exist on this server", err=True)
         raise typer.Exit(code=1)
 
-    # Check GitHub access (team-level if configured, else org-level)
     if not verify_github_access(github_username, settings):
         gate = (
             f"team {settings.github_org}/{settings.github_team}"

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
 
     # Authentication
     github_org: str = "hertie-data-science-lab"
+    # When set, key-create and the nightly revalidation gate on membership
+    # of this team (under github_org) instead of org membership. Empty string
+    # means org-level gate.
+    github_team: str = ""
     key_expiry_days: int = 90
 
     # Dockerfile scanning

--- a/src/ds01_jobs/config.py
+++ b/src/ds01_jobs/config.py
@@ -26,9 +26,7 @@ class Settings(BaseSettings):
 
     # Authentication
     github_org: str = "hertie-data-science-lab"
-    # When set, key-create and the nightly revalidation gate on membership
-    # of this team (under github_org) instead of org membership. Empty string
-    # means org-level gate.
+    # Empty string means org-level gate; a team slug narrows to that team.
     github_team: str = ""
     key_expiry_days: int = 90
 

--- a/src/ds01_jobs/revalidate.py
+++ b/src/ds01_jobs/revalidate.py
@@ -1,0 +1,121 @@
+"""Nightly revalidation of GitHub access for active API keys.
+
+For each active key, queries GitHub for the user's current org/team
+membership and revokes the key if they've lost access. Runs daily via a
+systemd timer (``ds01-revalidate.timer``).
+
+Revocations are written to ``/var/log/ds01/events.jsonl`` alongside the
+API's existing event log.
+"""
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated
+
+import httpx
+import typer
+
+from ds01_jobs.cli import verify_github_access
+from ds01_jobs.config import Settings
+from ds01_jobs.database import _MIGRATIONS, SCHEMA_SQL, get_db_sync
+
+app = typer.Typer(
+    name="ds01-job-revalidate",
+    help="Revalidate active API keys against GitHub org/team membership.",
+)
+
+DEFAULT_EVENTS_LOG = Path("/var/log/ds01/events.jsonl")
+
+
+def _log_revocation(username: str, reason: str, events_log: Path) -> None:
+    event = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "event": "key_revoked",
+        "username": username,
+        "reason": reason,
+        "source": "revalidate",
+    }
+    events_log.parent.mkdir(parents=True, exist_ok=True)
+    with events_log.open("a") as fh:
+        fh.write(json.dumps(event) + "\n")
+
+
+def _active_usernames(conn: sqlite3.Connection) -> list[str]:
+    """Return distinct usernames with at least one active key."""
+    now = datetime.now(UTC).isoformat()
+    cursor = conn.execute(
+        "SELECT DISTINCT username FROM api_keys "
+        "WHERE revoked = 0 AND expires_at > ? ORDER BY username",
+        (now,),
+    )
+    return [row["username"] for row in cursor.fetchall()]
+
+
+def _safe_check_access(username: str, settings: Settings) -> bool | None:
+    """Return True/False if GitHub answered, None if the call failed."""
+    try:
+        return verify_github_access(username, settings)
+    except (typer.Exit, httpx.HTTPError):
+        return None
+
+
+@app.command()
+def main(
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Report actions without modifying the database."),
+    ] = False,
+    events_log: Annotated[
+        Path,
+        typer.Option("--events-log", help="Path to the JSONL event log."),
+    ] = DEFAULT_EVENTS_LOG,
+) -> None:
+    """Revalidate every active key; revoke keys for users who lost access."""
+    settings = Settings(_env_file=None)
+
+    checked = 0
+    revoked = 0
+    skipped = 0
+
+    with get_db_sync() as conn:
+        conn.executescript(SCHEMA_SQL)
+        for stmt in _MIGRATIONS:
+            try:
+                conn.execute(stmt)
+            except sqlite3.OperationalError:
+                pass
+        conn.commit()
+
+        for username in _active_usernames(conn):
+            checked += 1
+            has_access = _safe_check_access(username, settings)
+
+            if has_access is None:
+                typer.echo(f"skip {username}: github check failed")
+                skipped += 1
+                continue
+            if has_access:
+                continue
+
+            if dry_run:
+                typer.echo(f"[dry-run] would revoke {username}")
+            else:
+                conn.execute(
+                    "UPDATE api_keys SET revoked = 1 WHERE username = ? AND revoked = 0",
+                    (username,),
+                )
+                _log_revocation(username, "github_access_lost", events_log)
+                typer.echo(f"revoked {username}")
+            revoked += 1
+
+        conn.commit()
+
+    typer.echo(
+        f"revalidate: checked={checked} revoked={revoked} skipped={skipped} dry_run={dry_run}"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/src/ds01_jobs/revalidate.py
+++ b/src/ds01_jobs/revalidate.py
@@ -17,9 +17,9 @@ from typing import Annotated
 import httpx
 import typer
 
-from ds01_jobs.cli import verify_github_access
+from ds01_jobs.cli import _ensure_schema, verify_github_access
 from ds01_jobs.config import Settings
-from ds01_jobs.database import _MIGRATIONS, SCHEMA_SQL, get_db_sync
+from ds01_jobs.database import get_db_sync
 
 app = typer.Typer(
     name="ds01-job-revalidate",
@@ -53,14 +53,6 @@ def _active_usernames(conn: sqlite3.Connection) -> list[str]:
     return [row["username"] for row in cursor.fetchall()]
 
 
-def _safe_check_access(username: str, settings: Settings) -> bool | None:
-    """Return True/False if GitHub answered, None if the call failed."""
-    try:
-        return verify_github_access(username, settings)
-    except (typer.Exit, httpx.HTTPError):
-        return None
-
-
 @app.command()
 def main(
     dry_run: Annotated[
@@ -80,22 +72,17 @@ def main(
     skipped = 0
 
     with get_db_sync() as conn:
-        conn.executescript(SCHEMA_SQL)
-        for stmt in _MIGRATIONS:
-            try:
-                conn.execute(stmt)
-            except sqlite3.OperationalError:
-                pass
-        conn.commit()
+        _ensure_schema(conn)
 
         for username in _active_usernames(conn):
             checked += 1
-            has_access = _safe_check_access(username, settings)
-
-            if has_access is None:
+            try:
+                has_access = verify_github_access(username, settings)
+            except (typer.Exit, httpx.HTTPError):
                 typer.echo(f"skip {username}: github check failed")
                 skipped += 1
                 continue
+
             if has_access:
                 continue
 

--- a/systemd/ds01-api.service
+++ b/systemd/ds01-api.service
@@ -19,6 +19,7 @@ Environment=UV_PYTHON=/usr/local/share/uv-python/cpython-3.13-linux-x86_64-gnu/b
 Environment=UV_CACHE_DIR=/var/lib/ds01-jobs/uv-cache
 Restart=always
 RestartSec=5
+UMask=0002
 EnvironmentFile=/etc/ds01-jobs/env
 
 # Logging

--- a/systemd/ds01-revalidate.service
+++ b/systemd/ds01-revalidate.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=DS01 API key revalidation (GitHub org/team membership)
+Documentation=file:///opt/ds01-jobs/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ds01
+Group=ds01
+WorkingDirectory=/opt/ds01-jobs
+# Uses the same venv + env file as the API/runner services.
+ExecStart=/var/lib/ds01-jobs/venv/bin/ds01-job-revalidate
+Environment=UV_PROJECT_ENVIRONMENT=/var/lib/ds01-jobs/venv
+EnvironmentFile=/etc/ds01-jobs/env
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ds01-revalidate
+
+# Hardening
+ProtectSystem=full
+ReadWritePaths=/opt/ds01-jobs/data /var/log/ds01 /var/lib/ds01-jobs
+PrivateTmp=true
+NoNewPrivileges=true
+UMask=0002

--- a/systemd/ds01-revalidate.service
+++ b/systemd/ds01-revalidate.service
@@ -9,7 +9,6 @@ Type=oneshot
 User=ds01
 Group=ds01
 WorkingDirectory=/opt/ds01-jobs
-# Uses the same venv + env file as the API/runner services.
 ExecStart=/var/lib/ds01-jobs/venv/bin/ds01-job-revalidate
 Environment=UV_PROJECT_ENVIRONMENT=/var/lib/ds01-jobs/venv
 EnvironmentFile=/etc/ds01-jobs/env

--- a/systemd/ds01-revalidate.timer
+++ b/systemd/ds01-revalidate.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Daily DS01 API key revalidation
+Documentation=file:///opt/ds01-jobs/README.md
+
+[Timer]
+# Run daily at 03:17 local time. Persistent so missed runs (host offline)
+# fire at next boot. RandomizedDelaySec smooths load across hosts if we
+# ever run more than one.
+OnCalendar=*-*-* 03:17:00
+RandomizedDelaySec=600
+Persistent=true
+Unit=ds01-revalidate.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ds01-runner.service
+++ b/systemd/ds01-runner.service
@@ -20,6 +20,7 @@ Environment=UV_PYTHON=/usr/local/share/uv-python/cpython-3.13-linux-x86_64-gnu/b
 Environment=UV_CACHE_DIR=/var/lib/ds01-jobs/uv-cache
 Restart=always
 RestartSec=5
+UMask=0002
 KillMode=process
 EnvironmentFile=/etc/ds01-jobs/env
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,7 +9,14 @@ import bcrypt
 import pytest
 from typer.testing import CliRunner
 
-from ds01_jobs.cli import _resolve_github_token, app, generate_api_key, parse_duration
+from ds01_jobs.cli import (
+    _resolve_github_token,
+    app,
+    check_team_membership,
+    generate_api_key,
+    parse_duration,
+    verify_github_access,
+)
 from ds01_jobs.database import SCHEMA_SQL
 
 runner = CliRunner()
@@ -29,7 +36,12 @@ def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         lambda _env_file=None, **kw: type(
             "S",
             (),
-            {"db_path": db_path, "github_org": "hertie-data-science-lab", "key_expiry_days": 90},
+            {
+                "db_path": db_path,
+                "github_org": "hertie-data-science-lab",
+                "github_team": "",
+                "key_expiry_days": 90,
+            },
         )(),
     )
     # Also patch get_db_sync to use temp path
@@ -397,6 +409,87 @@ def test_key_rotate_json(tmp_db, mock_github_member, mock_unix_user_valid):
     data = json.loads(result.output)
     assert data["key"].startswith("ds01_")
     assert data["username"] == "researcher1"
+
+
+# --- team membership tests ---
+
+
+def _stub_httpx_get(status_code: int, json_body: dict | None = None):
+    class _Resp:
+        def __init__(self):
+            self.status_code = status_code
+
+        def json(self):
+            return json_body or {}
+
+    def _get(url, headers=None, timeout=None):  # noqa: ARG001
+        return _Resp()
+
+    return _get
+
+
+def test_check_team_membership_active(monkeypatch: pytest.MonkeyPatch):
+    """200 with state=active returns True."""
+    monkeypatch.setattr("ds01_jobs.cli.httpx.get", _stub_httpx_get(200, {"state": "active"}))
+    assert check_team_membership("alice", "org", "team", "tok") is True
+
+
+def test_check_team_membership_pending(monkeypatch: pytest.MonkeyPatch):
+    """200 with state=pending returns False (invite not accepted)."""
+    monkeypatch.setattr("ds01_jobs.cli.httpx.get", _stub_httpx_get(200, {"state": "pending"}))
+    assert check_team_membership("alice", "org", "team", "tok") is False
+
+
+def test_check_team_membership_not_found(monkeypatch: pytest.MonkeyPatch):
+    """404 returns False."""
+    monkeypatch.setattr("ds01_jobs.cli.httpx.get", _stub_httpx_get(404))
+    assert check_team_membership("alice", "org", "team", "tok") is False
+
+
+# --- verify_github_access dispatch tests ---
+
+
+def _settings(org: str = "myorg", team: str = "") -> object:
+    return type("S", (), {"github_org": org, "github_team": team})()
+
+
+def test_verify_github_access_org_gate(monkeypatch: pytest.MonkeyPatch):
+    """Empty team -> org membership check is used."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "ds01_jobs.cli.check_org_membership",
+        lambda u, o: calls.append((u, o)) or True,
+    )
+    assert verify_github_access("alice", _settings(team="")) is True
+    assert calls == [("alice", "myorg")]
+
+
+def test_verify_github_access_team_gate(monkeypatch: pytest.MonkeyPatch):
+    """Non-empty team -> team membership check is used."""
+    monkeypatch.setattr("ds01_jobs.cli._resolve_github_token", lambda: "tok")
+    calls: list[tuple[str, str, str, str]] = []
+    monkeypatch.setattr(
+        "ds01_jobs.cli.check_team_membership",
+        lambda u, o, t, tok: calls.append((u, o, t, tok)) or True,
+    )
+    assert verify_github_access("alice", _settings(team="ds01-access")) is True
+    assert calls == [("alice", "myorg", "ds01-access", "tok")]
+
+
+def test_verify_github_access_bot_bypasses_team(monkeypatch: pytest.MonkeyPatch):
+    """Bot users always go through org-level App check, even when team is set."""
+    org_calls: list[str] = []
+    monkeypatch.setattr(
+        "ds01_jobs.cli.check_org_membership",
+        lambda u, o: org_calls.append(u) or True,
+    )
+    # If team path were used we'd blow up without a team stub — ensure it's not.
+    monkeypatch.setattr(
+        "ds01_jobs.cli.check_team_membership",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+    assert verify_github_access("ds01-ci-bot[bot]", _settings(team="ds01-access")) is True
+    assert org_calls == ["ds01-ci-bot[bot]"]
 
 
 def test_key_rotate_old_hash_changes(tmp_db, mock_github_member, mock_unix_user_valid):

--- a/tests/unit/test_revalidate.py
+++ b/tests/unit/test_revalidate.py
@@ -1,0 +1,140 @@
+"""Tests for ds01_jobs.revalidate module."""
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ds01_jobs.database import SCHEMA_SQL
+from ds01_jobs.revalidate import app
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Temporary DB patched into revalidate's Settings + get_db_sync."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_SQL)
+    conn.close()
+
+    monkeypatch.setattr(
+        "ds01_jobs.revalidate.Settings",
+        lambda _env_file=None, **kw: type(
+            "S", (), {"db_path": db_path, "github_org": "org", "github_team": ""}
+        )(),
+    )
+
+    @contextmanager
+    def _get_db_sync(_path=None):
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    monkeypatch.setattr("ds01_jobs.revalidate.get_db_sync", _get_db_sync)
+    return db_path
+
+
+def _insert_key(db: Path, username: str, revoked: int = 0, expires_days: int = 30) -> None:
+    now = datetime.now(UTC)
+    expires = now + timedelta(days=expires_days)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO api_keys (username, unix_username, key_id, key_hash, "
+        "created_at, expires_at, revoked) VALUES (?, 'u', ?, 'h', ?, ?, ?)",
+        (username, username[:8].ljust(8, "x"), now.isoformat(), expires.isoformat(), revoked),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _active_count(db: Path) -> int:
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM api_keys WHERE revoked = 0").fetchone()[0]
+    conn.close()
+    return int(count)
+
+
+def test_revalidate_revokes_user_without_access(
+    db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Users who fail the access check get their keys revoked."""
+    _insert_key(db, "alice")
+    _insert_key(db, "bob")
+    monkeypatch.setattr(
+        "ds01_jobs.revalidate.verify_github_access",
+        lambda u, s: u != "bob",
+    )
+
+    events_log = tmp_path / "events.jsonl"
+    result = runner.invoke(app, ["--events-log", str(events_log)])
+    assert result.exit_code == 0
+    assert "revoked bob" in result.output
+    assert _active_count(db) == 1
+
+    entries = [json.loads(line) for line in events_log.read_text().splitlines()]
+    assert len(entries) == 1
+    assert entries[0]["username"] == "bob"
+    assert entries[0]["event"] == "key_revoked"
+    assert entries[0]["source"] == "revalidate"
+
+
+def test_revalidate_dry_run_reports_but_does_not_revoke(
+    db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--dry-run reports what would happen without touching the DB."""
+    _insert_key(db, "alice")
+    monkeypatch.setattr("ds01_jobs.revalidate.verify_github_access", lambda u, s: False)
+
+    events_log = tmp_path / "events.jsonl"
+    result = runner.invoke(app, ["--dry-run", "--events-log", str(events_log)])
+    assert result.exit_code == 0
+    assert "[dry-run] would revoke alice" in result.output
+    assert _active_count(db) == 1
+    assert not events_log.exists()
+
+
+def test_revalidate_skips_on_github_error(
+    db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When GitHub check raises, user is skipped (not revoked)."""
+    import httpx
+
+    _insert_key(db, "alice")
+
+    def _boom(u, s):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr("ds01_jobs.revalidate.verify_github_access", _boom)
+
+    result = runner.invoke(app, ["--events-log", str(tmp_path / "events.jsonl")])
+    assert result.exit_code == 0
+    assert "skip alice" in result.output
+    assert _active_count(db) == 1
+
+
+def test_revalidate_ignores_revoked_and_expired(
+    db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Already-revoked or expired keys don't get re-checked."""
+    _insert_key(db, "alice", revoked=1)
+    _insert_key(db, "bob", expires_days=-1)  # expired yesterday
+    _insert_key(db, "carol")
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        "ds01_jobs.revalidate.verify_github_access",
+        lambda u, s: seen.append(u) or True,
+    )
+
+    result = runner.invoke(app, ["--events-log", str(tmp_path / "events.jsonl")])
+    assert result.exit_code == 0
+    assert seen == ["carol"]


### PR DESCRIPTION
## Summary

Closes the permission/auth hygiene gaps surfaced during the 2026-04-13 Tier 2 CI unblock.

- **State-file ownership** — deploy.sh now provisions a dedicated \`ds01-admin\` group, explicitly chowns the DB, sets setgid on state dirs, moves \`ds01\`'s home to \`/var/lib/ds01-jobs\`, and adds \`UMask=0002\` to the API + runner services. Prevents the Mar 31 recurrence where the first admin to run \`ds01-job-admin\` locked everyone else out.
- **Nightly revalidation** — new \`ds01-job-revalidate\` CLI + daily systemd timer loops every active key and auto-revokes ones whose user is no longer in the GH org/team. Revocations logged to \`/var/log/ds01/events.jsonl\`. GH API errors skip the user (never revoke on uncertainty).
- **Optional team gate** — \`github_team\` config (default empty). When set, gates key issuance and revalidation on team membership instead of org membership. Bots still go through the org-level App installation check.
- **Housekeeping** — drops the orphan \`datasciencelab\` NOPASSWD sudoers entry (runner lives under its own user now).

## Behaviour change on land

None. \`github_team\` default is empty → org-level gate (unchanged). The DB chown and systemd UMask only take effect after \`deploy.sh\` runs.

## Post-merge host actions

1. \`sudo ./deploy.sh\` — creates the group, re-chowns the DB, installs the timer.
2. \`sudo usermod -aG ds01-admin <admin>\` for each admin who should manage keys.
3. Optional team-gate activation (requires creating \`ds01-access\` team in GH org and adding existing key holders):
   \`\`\`
   echo 'DS01_JOBS_GITHUB_TEAM=ds01-access' | sudo tee -a /etc/ds01-jobs/env
   sudo systemctl restart ds01-api ds01-runner
   \`\`\`
4. Verify the timer: \`systemctl list-timers ds01-revalidate.timer\`.

## Test plan

- [x] Unit tests pass (228 tests, including new \`check_team_membership\`, \`verify_github_access\` dispatch, and \`revalidate\` scenarios: revoke / dry-run / GH error skip / ignores already-revoked)
- [x] \`ruff format\` + \`ruff check\`
- [x] \`mypy --strict\`
- [ ] Tier 2 integration green after merge
- [ ] Post-deploy smoke: admin in \`ds01-admin\` can run \`ds01-job-admin key-list\`; service user still owns DB; \`systemctl list-timers\` shows \`ds01-revalidate.timer\` scheduled