### PR TITLE
test(integration): parametrise fixture scenarios in Tier 2

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,11 +3,16 @@
 Provides test key generation, HMAC signing, database seeding, and
 app/client fixtures that wire up a real FastAPI app against a temporary
 SQLite database. These are Tier 1 tests - no @pytest.mark.integration.
+
+Also exposes Tier 2 fixtures (``api_key``, ``api_base_url``) and a
+``subprocess_runner`` helper used by live-API scenarios.
 """
 
 import hashlib
 import hmac
+import os
 import secrets
+import subprocess
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -24,6 +29,8 @@ from ds01_jobs.app import create_app
 from ds01_jobs.config import Settings
 from ds01_jobs.database import _get_db_path, get_db, init_db
 from ds01_jobs.jobs import _get_settings
+
+LIVE_API_BASE_URL = "http://127.0.0.1:8765"
 
 # ---------------------------------------------------------------------------
 # Helper functions (module-level, not fixtures)
@@ -206,6 +213,37 @@ async def client(app):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
+
+
+@pytest.fixture()
+def api_key() -> str:
+    """Pre-provisioned Tier 2 CI API key; skips when unset (local runs)."""
+    key = os.environ.get("DS01_CI_API_KEY")
+    if not key:
+        pytest.skip(
+            "DS01_CI_API_KEY not set — provision via 'ds01-job-admin key-create' "
+            "and store as a GitHub Actions secret"
+        )
+    return key
+
+
+@pytest.fixture()
+def api_base_url() -> str:
+    """Base URL of the live API on the self-hosted runner."""
+    return LIVE_API_BASE_URL
+
+
+@pytest.fixture()
+def subprocess_runner():
+    """Return a helper that runs subprocesses with a merged environment."""
+
+    def _run(
+        args: list[str], env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        merged_env = {**os.environ, **(env or {})}
+        return subprocess.run(args, capture_output=True, text=True, env=merged_env)
+
+    return _run
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -18,8 +18,6 @@ runner via Tier 2 CI.
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 import time
 
 import pytest
@@ -29,52 +27,15 @@ pytestmark = pytest.mark.integration
 TEST_REPO_URL = "https://github.com/hertie-data-science-lab/ds01-jobs"
 TEST_REPO_BRANCH = "fixtures/smoke"
 
-API_BASE_URL = "http://127.0.0.1:8765"
-
-# Maximum time to wait for a job to reach a terminal state (seconds)
 POLL_TIMEOUT = 300
-
-# Backoff parameters for polling (seconds)
 INITIAL_BACKOFF = 2
 MAX_BACKOFF = 30
-
-
-def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    """Run a subprocess with merged environment and return the result."""
-    merged_env = {**os.environ, **(env or {})}
-    return subprocess.run(args, capture_output=True, text=True, env=merged_env)
-
-
-@pytest.fixture()
-def api_key() -> str:
-    """Return the pre-provisioned CI API key.
-
-    Reads ``DS01_CI_API_KEY`` from the environment (set via the ``DS01_CI_API_KEY``
-    GitHub Actions secret). The key is issued once by an admin via::
-
-        ds01-job-admin key-create ds01-ci-bot[bot] datasciencelab --expires 365d --json
-
-    and stored as a repository secret. Tests are skipped if the variable is unset
-    (e.g. local runs without the secret configured).
-    """
-    key = os.environ.get("DS01_CI_API_KEY")
-    if not key:
-        pytest.skip(
-            "DS01_CI_API_KEY not set — provision via 'ds01-job-admin key-create' "
-            "and store as a GitHub Actions secret"
-        )
-    return key
-
-
-@pytest.fixture()
-def api_base_url() -> str:
-    """Return the local API base URL."""
-    return API_BASE_URL
 
 
 def test_full_job_lifecycle(
     api_key: str,
     api_base_url: str,
+    subprocess_runner,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
     """Submit a job, wait for completion, verify success, download results."""
@@ -84,7 +45,7 @@ def test_full_job_lifecycle(
     }
 
     # 1. Submit a job via ds01-submit run
-    result = _run(
+    result = subprocess_runner(
         ["ds01-submit", "run", TEST_REPO_URL, "--branch", TEST_REPO_BRANCH, "--json"],
         env=env,
     )
@@ -100,7 +61,7 @@ def test_full_job_lifecycle(
     final_status = None
 
     while time.monotonic() < deadline:
-        result = _run(["ds01-submit", "status", job_id, "--json"], env=env)
+        result = subprocess_runner(["ds01-submit", "status", job_id, "--json"], env=env)
         assert result.returncode in (0, 2), f"Status check failed: {result.stderr}"
 
         status_data = json.loads(result.stdout)
@@ -123,7 +84,7 @@ def test_full_job_lifecycle(
 
     # 4. Download results
     output_dir = tmp_path / "results"
-    result = _run(
+    result = subprocess_runner(
         ["ds01-submit", "results", job_id, "-o", str(output_dir)],
         env=env,
     )

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -1,0 +1,212 @@
+"""Parametrised Tier 2 scenarios covering the fixture branches.
+
+One test per scenario from ``tests/integration/fixtures/scenarios/``: submit
+the job, poll to a terminal state, download results where relevant, and
+verify scenario-specific output shape.
+
+The scanner-rejection path is a separate test because it doesn't follow the
+submit-poll-download pattern — it asserts the inline dockerfile is blocked
+at submission time.
+
+Requires the live API on ``http://127.0.0.1:8765`` and the self-hosted GPU
+runner. Marked ``@pytest.mark.integration`` so only Tier 2 CI runs these.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+TEST_REPO_URL = "https://github.com/hertie-data-science-lab/ds01-jobs"
+
+POLL_TIMEOUT = 600  # gpu-compute + large-output need more headroom than lifecycle
+INITIAL_BACKOFF = 2
+MAX_BACKOFF = 30
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    branch: str
+    expected_status: str
+    submit_args: tuple[str, ...] = ()
+    verify: Callable[[Path], None] | None = None
+    poll_timeout: int = POLL_TIMEOUT
+
+
+def _verify_result_json(results: Path) -> None:
+    assert (results / "result.json").is_file(), list(results.iterdir())
+
+
+def _verify_training_results(results: Path) -> None:
+    payload = json.loads((results / "training_results.json").read_text())
+    assert "final_loss" in payload, payload
+
+
+def _verify_multi_file(results: Path) -> None:
+    for name in ("dataset.csv", "analysis.png", "summary.json"):
+        assert (results / name).is_file(), f"missing {name}: {list(results.iterdir())}"
+
+
+def _verify_large_output(results: Path) -> None:
+    bins = sorted(results.glob("*.bin"))
+    assert len(bins) == 50, f"expected 50 .bin files, got {len(bins)}"
+
+
+def _verify_benchmark(results: Path) -> None:
+    payload = json.loads((results / "benchmark.json").read_text())
+    assert payload, "benchmark.json is empty"
+
+
+SCENARIOS: tuple[Scenario, ...] = (
+    Scenario(
+        name="cpu-quick",
+        branch="fixtures/cpu-quick",
+        expected_status="succeeded",
+        verify=_verify_result_json,
+    ),
+    Scenario(
+        name="long-running",
+        branch="fixtures/long-running",
+        expected_status="succeeded",
+        verify=_verify_training_results,
+    ),
+    Scenario(
+        name="multi-file",
+        branch="fixtures/multi-file",
+        expected_status="succeeded",
+        verify=_verify_multi_file,
+    ),
+    Scenario(
+        name="large-output",
+        branch="fixtures/large-output",
+        expected_status="succeeded",
+        verify=_verify_large_output,
+    ),
+    Scenario(
+        name="gpu-compute",
+        branch="fixtures/gpu-compute",
+        expected_status="succeeded",
+        verify=_verify_benchmark,
+        # Cold pull of the PyTorch image can take several minutes on a fresh host.
+        poll_timeout=900,
+    ),
+    Scenario(
+        name="failing-runtime",
+        branch="fixtures/failing-runtime",
+        expected_status="failed",
+    ),
+    Scenario(
+        name="failing-build",
+        branch="fixtures/failing-build",
+        expected_status="failed",
+    ),
+    Scenario(
+        name="timeout",
+        branch="fixtures/timeout",
+        expected_status="failed",
+        submit_args=("--timeout", "60"),
+    ),
+)
+
+
+def _poll_for_terminal(job_id: str, env: dict[str, str], runner, timeout: int) -> tuple[str, dict]:
+    backoff = INITIAL_BACKOFF
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = runner(["ds01-submit", "status", job_id, "--json"], env=env)
+        assert result.returncode in (0, 2), f"Status check failed: {result.stderr}"
+        status_data = json.loads(result.stdout)
+        if status_data["status"] in ("succeeded", "failed"):
+            return status_data["status"], status_data
+        time.sleep(backoff)
+        backoff = min(backoff * 2, MAX_BACKOFF)
+    pytest.fail(f"Job {job_id} did not reach terminal state within {timeout}s")
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=lambda s: s.name)
+def test_scenario(
+    scenario: Scenario,
+    api_key: str,
+    api_base_url: str,
+    subprocess_runner,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    env = {"DS01_API_KEY": api_key, "DS01_API_URL": api_base_url}
+
+    submit_cmd = [
+        "ds01-submit",
+        "run",
+        TEST_REPO_URL,
+        "--branch",
+        scenario.branch,
+        "--gpus",
+        "1",
+        *scenario.submit_args,
+        "--json",
+    ]
+    result = subprocess_runner(submit_cmd, env=env)
+    assert result.returncode == 0, f"Submit failed ({scenario.name}): {result.stderr}"
+    job_id = json.loads(result.stdout)["job_id"]
+
+    final_status, status_data = _poll_for_terminal(
+        job_id, env, subprocess_runner, scenario.poll_timeout
+    )
+    assert final_status == scenario.expected_status, (
+        f"{scenario.name}: expected {scenario.expected_status}, got {final_status}. "
+        f"Status: {json.dumps(status_data, indent=2)}"
+    )
+
+    if scenario.verify is not None:
+        out_dir = tmp_path_factory.mktemp(scenario.name)
+        result = subprocess_runner(["ds01-submit", "results", job_id, "-o", str(out_dir)], env=env)
+        assert result.returncode == 0, f"Results download failed: {result.stderr}"
+        results_subdir = out_dir / "results"
+        assert results_subdir.is_dir(), f"no results/ subdir under {out_dir}"
+        scenario.verify(results_subdir)
+
+
+def test_scanner_rejects_disallowed_base_image(
+    api_key: str,
+    api_base_url: str,
+    subprocess_runner,
+    tmp_path: Path,
+) -> None:
+    """Inline Dockerfile with a non-allowlisted base image is rejected at submit.
+
+    The scanner only applies to ``--dockerfile`` overrides, not repo
+    Dockerfiles. We therefore pair the scanner-probe with an innocuous
+    fixture branch (``fixtures/cpu-quick``); the override is what drives the
+    rejection.
+    """
+    env = {"DS01_API_KEY": api_key, "DS01_API_URL": api_base_url}
+
+    bad_dockerfile = tmp_path / "Dockerfile.bad"
+    bad_dockerfile.write_text('FROM bitnami/python:latest\nCMD echo "never runs"\n')
+
+    result = subprocess_runner(
+        [
+            "ds01-submit",
+            "run",
+            TEST_REPO_URL,
+            "--branch",
+            "fixtures/cpu-quick",
+            "--gpus",
+            "1",
+            "--dockerfile",
+            str(bad_dockerfile),
+            "--json",
+        ],
+        env=env,
+    )
+    assert result.returncode != 0, (
+        f"Submission should have been rejected by the scanner. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Closes the P1 coverage gap from the 2026-04-13 handoff: 8 fixture scenarios were previously only exercised by \`scripts/run-test-suite.sh\` (manual, shell-based). This PR adds a parametrised pytest file so Tier 2 CI verifies every scenario on every main push.

- \`tests/integration/test_scenarios.py\` — 8 parametrised scenarios (\`cpu-quick\`, \`long-running\`, \`multi-file\`, \`large-output\`, \`gpu-compute\`, \`failing-runtime\`, \`failing-build\`, \`timeout\`) plus a standalone scanner-rejection test for the \`--dockerfile\` override path.
- Each scenario defines its own output-verification callable (result.json, benchmark.json, 50 .bin files, etc). Failure scenarios skip the download step.
- \`gpu-compute\` gets a wider poll timeout (15 min) to absorb cold image pulls.
- Shared subprocess + live-API plumbing lifted into \`tests/integration/conftest.py\` (\`api_key\`, \`api_base_url\`, \`subprocess_runner\`) so \`test_lifecycle.py\` and the new file reuse the same fixtures.

## Why not retire \`run-test-suite.sh\`?

Different use case — keep it. The bash script is the dev-on-runner smoke tool (one command, no pytest setup), while this PR is the automated CI coverage. Low maintenance overlap.

## Why not per-PR gating?

Single-GPU self-hosted runner already queues; per-PR runs would block unrelated PRs behind each other for 10–15 min per push. Post-merge non-blocking catches regressions within minutes of landing — the next PR sees red Tier 2 and the fix goes on top.

## Test plan

- [x] \`pytest --collect-only -m integration\` shows all 9 new tests
- [x] \`pytest -m 'not integration'\` passes (228 tests)
- [x] \`ruff format\` + \`ruff check\`
- [x] \`mypy src\`
- [ ] Post-merge Tier 2 runs all 9 scenarios green (observe \`gh run watch\` on the first main push)