### PR TITLE
fix(executor): pass gpu_count as --gpus N instead of --gpus all

### DIFF
--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -378,11 +378,14 @@ class JobExecutor:
             docker_prefix = [str(self.settings.docker_bin)]
 
         # When running via sudo -u, the Docker wrapper at /usr/local/bin/docker
-        # intercepts --gpus all and dynamically allocates GPUs via ds01-infra's
-        # gpu_allocator_v2.py (respects per-user quotas, MIG partitioning, etc.).
+        # parses --gpus <N> and dispatches to ds01-infra's gpu_allocator_v2.py:
+        # allocate-external for N=1, allocate-multi for N>1. It rewrites the arg
+        # to --gpus device=UUID1,UUID2,... so the container sees exactly the
+        # allocated GPUs. Passing "all" would under-honour gpu_count (wrapper
+        # always allocated one GPU regardless).
         # Without sudo -u (dev mode), fall back to NVIDIA_VISIBLE_DEVICES.
         if unix_username:
-            gpu_flag = ["--gpus", "all"]
+            gpu_flag = ["--gpus", str(gpu_count)]
         else:
             gpu_devices = ",".join(str(i) for i in range(gpu_count))
             gpu_flag = ["-e", f"NVIDIA_VISIBLE_DEVICES={gpu_devices}"]

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -668,6 +668,48 @@ async def test_run_uses_sudo_with_interface_label(
     assert "--label" in run_call
     label_idx = run_call.index("--label")
     assert run_call[label_idx + 1] == "ds01.interface=api"
+    # Verify --gpus carries the requested count (not "all") so the wrapper can
+    # dispatch to allocate-external or allocate-multi correctly.
+    assert "--gpus" in run_call
+    gpus_idx = run_call.index("--gpus")
+    assert run_call[gpus_idx + 1] == "1"
+
+
+@pytest.mark.asyncio
+@patch("ds01_jobs.executor.asyncio.create_subprocess_exec")
+async def test_run_passes_numeric_gpu_count(
+    mock_exec: AsyncMock,
+    executor_settings: Settings,
+    db_path: Path,
+) -> None:
+    """Multi-GPU requests forward the count to --gpus so the wrapper routes to allocate-multi."""
+    mock_exec.return_value = _mock_process(0)
+    executor = JobExecutor(executor_settings)
+
+    await executor.execute(
+        JOB_ID,
+        REPO_URL,
+        BRANCH,
+        gpu_count=3,
+        timeout_seconds=None,
+        db_path=db_path,
+        unix_username=UNIX_USER,
+    )
+
+    docker = str(executor_settings.docker_bin)
+    run_call = None
+    for c in mock_exec.call_args_list:
+        args = c[0] if c[0] else ()
+        if docker in args:
+            docker_idx = args.index(docker)
+            if len(args) > docker_idx + 1 and args[docker_idx + 1] == "run":
+                run_call = args
+                break
+
+    assert run_call is not None
+    gpus_idx = run_call.index("--gpus")
+    assert run_call[gpus_idx + 1] == "3"
+    assert "all" not in run_call
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Honours the user's \`gpu_count\` in the \`docker run\` command so the ds01-infra wrapper can route to \`allocate-multi\` when N>1. Paired with [ds01-infra#38](https://github.com/hertie-data-science-lab/ds01-infra/pull/38).

### Context

Before today, the executor passed \`--gpus all\`. The wrapper only ever called \`allocate-external\` (single-GPU), so any job requesting N>1 got exactly one GPU regardless. For the Tier 2 scenarios this wasn't immediately visible because every scenario requests \`--gpus 1\`, but it's still a correctness bug: user-facing \`gpu_count\` was effectively ignored.

### Change

\`src/ds01_jobs/executor.py:384-388\`:

\`\`\`python
-    gpu_flag = ["--gpus", "all"]
+    gpu_flag = ["--gpus", str(gpu_count)]
\`\`\`

The dev-mode \`NVIDIA_VISIBLE_DEVICES\` branch is unchanged — it bypasses the wrapper and is only used for single-developer local testing, where the existing \`range(gpu_count)\` pattern is adequate.

### Why this only works alongside ds01-infra#38

With plain \`--gpus N\` and the current wrapper on main, the wrapper parses the value as \"not-all-not-device\", falls through to \`allocate-external\` (N=1 only), and either under-allocates or — now that PR #37 is merged — allocates correctly for N=1 but still under-allocates for N>1. ds01-infra#38 teaches the wrapper to dispatch to \`allocate-multi\` when N>1 so multi-GPU jobs actually work.

## Test plan
- [x] \`uv run pytest tests/unit/test_executor.py\` — 20 pass (updated \`test_run_uses_sudo_with_interface_label\` to assert \`--gpus 1\`; new \`test_run_passes_numeric_gpu_count\` covers N=3)
- [ ] Tier 2 on this branch verifies the 9 scenarios + lifecycle still pass end-to-end (all request gpu_count=1, exercising the N=1 branch of the wrapper)
- [ ] Follow-up: ship a multi-GPU fixture scenario once ds01-infra#38 lands to actually exercise the N>1 path in CI

## Risk
Narrow. Single-GPU jobs (every current fixture scenario) go through \`allocate-external\` exactly as before PR #37. The only behaviour change is that \`gpu_count\` is now honoured end-to-end instead of being silently clamped to 1.