### PR TITLE
fix(executor): surface cleanup failures and verify container removal

### DIFF
--- a/src/ds01_jobs/executor.py
+++ b/src/ds01_jobs/executor.py
@@ -438,58 +438,67 @@ class JobExecutor:
         if proc.returncode != 0:
             logger.warning("Failed to collect results for %s: %s", job_id, stderr.decode().strip())
 
+    async def _run_docker(
+        self, docker_prefix: list[str], args: list[str], what: str, job_id: str
+    ) -> tuple[int, str]:
+        """Run a docker subcommand, capture stderr, log failures at WARNING.
+
+        Returns (returncode, stderr). Non-zero exits are logged but don't raise —
+        cleanup is best-effort.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *docker_prefix,
+                *args,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr_bytes = await proc.communicate()
+            stderr = stderr_bytes.decode(errors="replace").strip()
+            if proc.returncode != 0:
+                logger.warning(
+                    "%s failed for job %s (exit=%d): %s", what, job_id, proc.returncode, stderr
+                )
+            return proc.returncode or 0, stderr
+        except Exception as exc:
+            logger.warning("%s raised for job %s: %s", what, job_id, exc)
+            return -1, str(exc)
+
     async def _cleanup(self, job_id: str) -> None:
-        """Remove container, image, and prune build cache."""
+        """Remove container, image, and prune build cache. Best-effort; logs failures."""
         unix_username = self._unix_username
         if unix_username:
             docker_prefix = self._sudo_docker(unix_username)
         else:
             docker_prefix = [str(self.settings.docker_bin)]
 
-        # Remove container
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *docker_prefix,
-                "rm",
-                "-f",
-                f"ds01-job-{job_id}",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await proc.wait()
-        except Exception:
-            logger.debug("Failed to remove container for job %s", job_id, exc_info=True)
+        container = f"ds01-job-{job_id}"
 
-        # Remove image
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *docker_prefix,
-                "image",
-                "rm",
-                "-f",
-                f"ds01-job-{job_id}",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await proc.wait()
-        except Exception:
-            logger.debug("Failed to remove image for job %s", job_id, exc_info=True)
+        rc, _ = await self._run_docker(
+            docker_prefix, ["rm", "-f", container], "container rm", job_id
+        )
 
-        # Prune build cache
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *docker_prefix,
-                "builder",
-                "prune",
-                "--force",
-                "--filter",
-                "until=1h",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
+        # Verify the container is actually gone. If `docker rm -f` reported success
+        # but inspect still finds it, something upstream is blocking removal — log
+        # loudly so the allocator's self-heal isn't masking a systemic issue.
+        if rc == 0:
+            inspect_rc, _ = await self._run_docker(
+                docker_prefix, ["inspect", container], "post-rm verify", job_id
             )
-            await proc.wait()
-        except Exception:
-            logger.debug("Failed to prune build cache for job %s", job_id, exc_info=True)
+            if inspect_rc == 0:
+                logger.error(
+                    "Container %s still present after rm -f reported success — "
+                    "allocator quota will remain held until release-stale runs",
+                    container,
+                )
+
+        await self._run_docker(docker_prefix, ["image", "rm", "-f", container], "image rm", job_id)
+        await self._run_docker(
+            docker_prefix,
+            ["builder", "prune", "--force", "--filter", "until=1h"],
+            "builder prune",
+            job_id,
+        )
 
     async def kill_current_process(self, job_id: str) -> None:
         """Kill the currently running subprocess and its Docker container.


### PR DESCRIPTION
## Problem

\`_cleanup\` used \`stdout=stderr=DEVNULL\` and caught all exceptions at \`logger.debug\`. Silent failures in \`docker rm -f\` went undetected, which bit us in CI today: a long-running fixture's container was never actually removed despite cleanup executing. No log, no warning. The stale container held a GPU slot against ds01-ci-bot's quota until the ds01-infra allocator's release-stale cron fired, breaking 4 subsequent scenarios with \`QUOTA_EXCEEDED:1/1\`.

Paired with [ds01-infra#44](https://github.com/hertie-data-science-lab/ds01-infra/pull/44), which adds self-healing on the allocator side so the failure doesn't cascade. This PR is the other half of belt-and-suspenders: the dispatcher shouldn't silently fail to clean up in the first place.

## Changes

\`src/ds01_jobs/executor.py\`:

- Extract \`_run_docker\` helper — captures stderr, logs non-zero exits at \`WARNING\`, failures to launch at \`WARNING\`. Replaces three near-duplicate try/except blocks.
- After \`docker rm -f\` reports success, verify with \`docker inspect\`. If the container is still there, log at \`ERROR\` — this is the invariant that was silently violated today.
- \`_cleanup\` now uses the helper for container rm + image rm + builder prune.

## Test plan

- [x] \`uv run pytest tests/unit/test_executor.py\` — 20 pass
- [x] \`uv run ruff format\` + \`ruff check\` — clean
- [ ] Reviewer: next CI run exercises the new logging path; any residual cleanup issues will now surface at WARNING/ERROR in the runner journal

## Risk

Narrow. No behaviour change on the happy path — cleanup still best-effort, still non-blocking for the dispatcher. The only new effect is louder logs when something goes wrong.

## Follow-up (not in this PR)

Diagnose why the long-running container specifically wasn't removed. Once this PR lands and the next CI run exposes the real failure cause in logs, file a dedicated issue.